### PR TITLE
feat(common): add utility class Strings with replaceAll

### DIFF
--- a/packages/cactus-common/src/main/typescript/public-api.ts
+++ b/packages/cactus-common/src/main/typescript/public-api.ts
@@ -2,3 +2,4 @@ export { LoggerProvider } from "./logging/logger-provider";
 export { Logger, ILoggerOptions } from "./logging/logger";
 export { LogLevelDesc } from "loglevel";
 export { Objects } from "./objects";
+export { Strings } from "./strings";

--- a/packages/cactus-common/src/main/typescript/strings.ts
+++ b/packages/cactus-common/src/main/typescript/strings.ts
@@ -1,0 +1,9 @@
+export class Strings {
+  public static replaceAll(
+    source: string,
+    searchValue: string,
+    replaceValue: string
+  ): string {
+    return source.replace(new RegExp(searchValue, "gm"), replaceValue);
+  }
+}


### PR DESCRIPTION
This is a method that is used pretty often but not included
in the Javascript language itself.
What the method does is what you would expect, it finds
all occurrences of a substring and replaces all of them with
another one. The deafult Javascript String.replace function
only does this with the first occurrence by default so it is not
a good solution.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>