### PR TITLE
Add video link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ As blockchain technology proliferates, blockchain integration will become an inc
 
 * [Hyperledger Cactus Home](https://wiki.hyperledger.org/display/cactus)
 * [Whitepaper](./whitepaper/whitepaper.md)
+* [Hyperledger Forum Introduction To Cactus](https://www.youtube.com/watch?v=fgYrUIc_-sU)
 
 ## How It Works
 


### PR DESCRIPTION
The video from Hyperledger Forum that introduces Cactus is a great technical overview of the project that I think would be helpful to have in the documentation.