### PR TITLE
test(test-tooling): parametrize besu-all-in-one container

### DIFF
--- a/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/besu-test-ledger-parameters.test.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/besu-test-ledger-parameters.test.ts
@@ -1,0 +1,85 @@
+// tslint:disable-next-line: no-var-requires
+const tap = require("tap");
+import { BesuTestLedger } from "@hyperledger/cactus-test-tooling";
+tap.test("deploys a Besu node with the default configurations", async (assert: any) => {
+    assert.plan(1);
+
+    // No options
+    const besuTestLedger = new BesuTestLedger();
+
+    assert.ok(besuTestLedger);
+    assert.end();
+});
+
+
+tap.test("checks if simple Besu's environment variables are correctly passed", async (assert: any) => {
+    assert.plan(2);
+    const simpleEnvVars = ["BESU_MINER_ENABLED","BESU_NETWORK=dev","BESU_MIN_GAS_PRICE=0"]
+
+    const besuOptions = {
+        envVars: simpleEnvVars
+    }
+    const besuTestLedger = new BesuTestLedger(besuOptions);
+
+    assert.equal(besuTestLedger.envVars,simpleEnvVars);
+    assert.ok(besuTestLedger);
+    assert.end();
+});
+
+tap.test("deploys a Besu Node on the Rinkeby network", async (assert: any) => {
+    assert.plan(2);
+    const rinkebyNetworkEnvVars = ["BESU_MOUNT_TYPE=bind","BESU_MINER_ENABLED","BESU_MINER_COINBASE=fe3b557e8fb62b89f4916b721be55ceb828dbd73","BESU_SOURCE=/<myvolume/besu/testnode>","BESU_NETWORK=rinkeby", "BESU_MIN_GAS_PRICE=0", "BESU_TARGET=/var/lib/besu hyperledger/besu:latest"];
+    const besuOptions = {
+        envVars: rinkebyNetworkEnvVars
+    }
+
+    const besuTestLedger = new BesuTestLedger(besuOptions);
+
+    assert.equal(besuTestLedger.envVars,rinkebyNetworkEnvVars);
+    assert.ok(besuTestLedger);
+    assert.end();
+});
+
+tap.test("deploys a Besu Node on the Ropsten network", async (assert: any) => {
+    assert.plan(2);
+    // const rinkebyNetworkParameters = "--mount type=bind,source=/<myvolume/besu/testnode>,target=/var/lib/besu hyperledger/besu:latest --miner-enabled --miner-coinbase fe3b557e8fb62b89f4916b721be55ceb828dbd73--network=dev --min-gas-price=0";
+    const rinkebyNetworkEnvVars = ["BESU_MOUNT_TYPE=bind","BESU_MINER_ENABLED","BESU_MINER_COINBASE=fe3b557e8fb62b89f4916b721be55ceb828dbd73","BESU_SOURCE=/<myvolume/besu/testnode>","BESU_NETWORK=ropsten", "BESU_MIN_GAS_PRICE=0", "BESU_TARGET=/var/lib/besu hyperledger/besu:latest"];
+    const besuOptions = {
+        envVars: rinkebyNetworkEnvVars
+    }
+
+    const besuTestLedger = new BesuTestLedger(besuOptions);
+
+    assert.equal(besuTestLedger.envVars,rinkebyNetworkEnvVars);
+    assert.ok(besuTestLedger);
+    assert.end();
+});
+
+tap.test("deploys a Besu Node on the Goerli network", async (assert: any) => {
+    assert.plan(2);
+    // const rinkebyNetworkParameters = "--mount type=bind,source=/<myvolume/besu/testnode>,target=/var/lib/besu hyperledger/besu:latest --miner-enabled --miner-coinbase fe3b557e8fb62b89f4916b721be55ceb828dbd73--network=dev --min-gas-price=0";
+    const rinkebyNetworkEnvVars = ["BESU_MOUNT_TYPE=bind","BESU_MINER_ENABLED","BESU_MINER_COINBASE=fe3b557e8fb62b89f4916b721be55ceb828dbd73","BESU_SOURCE=/<myvolume/besu/testnode>","BESU_NETWORK=goerli", "BESU_MIN_GAS_PRICE=0", "BESU_TARGET=/var/lib/besu hyperledger/besu:latest"];
+    const besuOptions = {
+        envVars: rinkebyNetworkEnvVars
+    }
+
+    const besuTestLedger = new BesuTestLedger(besuOptions);
+
+    assert.equal(besuTestLedger.envVars,rinkebyNetworkEnvVars);
+    assert.ok(besuTestLedger);
+    assert.end();
+});
+
+
+tap.test("deploys a Besu Node on the Ethereum main network", async (assert: any) => {
+    assert.plan(2);
+    const ethereumEnvVars = ["BESU_TARGET=/var/lib/besu", "BESU_PORT=30303:30303", "BESU_RCP_HTTP_ENABLED"];
+    const besuOptions = {
+        envVars: ethereumEnvVars
+    }
+    const besuTestLedger = new BesuTestLedger(besuOptions);
+
+    assert.equal(besuTestLedger.envVars,ethereumEnvVars);
+    assert.ok(besuTestLedger);
+    assert.end();
+});

--- a/packages/cactus-test-tooling/src/main/typescript/besu/besu-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/besu/besu-test-ledger.ts
@@ -11,12 +11,14 @@ export interface IBesuTestLedgerConstructorOptions {
   containerImageVersion?: string;
   containerImageName?: string;
   rpcApiHttpPort?: number;
+  envVars?: string[]
 }
 
 export const BESU_TEST_LEDGER_DEFAULT_OPTIONS = Object.freeze({
   containerImageVersion: "latest",
   containerImageName: "hyperledger/cactus-besu-all-in-one",
   rpcApiHttpPort: 8545,
+  envVars: ["BESU_NETWORK=dev"]
 });
 
 export const BESU_TEST_LEDGER_OPTIONS_JOI_SCHEMA: Joi.Schema = Joi.object().keys(
@@ -29,6 +31,7 @@ export const BESU_TEST_LEDGER_OPTIONS_JOI_SCHEMA: Joi.Schema = Joi.object().keys
       .min(1024)
       .max(65535)
       .required(),
+    envVars: Joi.array().allow(null).required(),
   }
 );
 
@@ -36,6 +39,7 @@ export class BesuTestLedger implements ITestLedger {
   public readonly containerImageVersion: string;
   public readonly containerImageName: string;
   public readonly rpcApiHttpPort: number;
+  public readonly envVars: string[];
 
   private container: Container | undefined;
 
@@ -51,6 +55,8 @@ export class BesuTestLedger implements ITestLedger {
       BESU_TEST_LEDGER_DEFAULT_OPTIONS.containerImageName;
     this.rpcApiHttpPort =
       options.rpcApiHttpPort || BESU_TEST_LEDGER_DEFAULT_OPTIONS.rpcApiHttpPort;
+    this.envVars =
+        options.envVars || BESU_TEST_LEDGER_DEFAULT_OPTIONS.envVars;
 
     this.validateConstructorOptions();
   }
@@ -141,6 +147,7 @@ export class BesuTestLedger implements ITestLedger {
           // to docker container's IP addresses directly...
           // https://stackoverflow.com/a/39217691
           PublishAllPorts: true,
+          Env: this.envVars,
         },
         {},
         (err: any) => {
@@ -293,6 +300,7 @@ export class BesuTestLedger implements ITestLedger {
         containerImageVersion: this.containerImageVersion,
         containerImageName: this.containerImageName,
         rpcApiHttpPort: this.rpcApiHttpPort,
+        envVars: this.envVars,
       },
       BESU_TEST_LEDGER_OPTIONS_JOI_SCHEMA
     );


### PR DESCRIPTION
Allows passing input arguments to the docker container running the Besu test ledger. This is useful, for example, to run Besu in different ledgers than the default one.

I've included tests that check if the ledger was successfully initialized, based on the configurations.