### PR TITLE
style(tslint): ban PascalCase variables from the code

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -4,7 +4,15 @@
         "tslint:recommended"
     ],
     "jsRules": {},
-    "rules": {},
+    "rules": {
+        "variable-name": {
+            "options": [
+                "allow-leading-underscore",
+                "ban-keywords",
+                "check-format"
+            ]
+        }
+    },
     "rulesDirectory": [],
     "linterOptions": {
         "exclude": [


### PR DESCRIPTION
It is very easy to confuse PascalCase variables in JS/TS with classes.
We would much rather keep
lowerCamelCase for variables and PascalCase for classes
to make it easier to read the code.

fix #197

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>