### PR TITLE
test-incorrect-pr-title validate PR title and ALL commits

### DIFF
--- a/.github/.semantic.yml
+++ b/.github/.semantic.yml
@@ -1,0 +1,10 @@
+# Always validate the PR title AND all the commits
+titleAndCommits: true
+
+# Prohibit use of Merge commits (eg on github: "Merge branch 'master' into feature/ride-unicorns")
+# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
+allowMergeCommits: false
+
+# Prohibit use of Revert commits (eg on github: "Revert "feat: ride unicorns"")
+# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
+allowRevertCommits: false

--- a/.github/.semantic.yml
+++ b/.github/.semantic.yml
@@ -1,3 +1,9 @@
+titleOnly: false
+commitsOnly: false
+anyCommit: false
+scopes: null
+types: null
+
 # Always validate the PR title AND all the commits
 titleAndCommits: true
 
@@ -8,3 +14,4 @@ allowMergeCommits: false
 # Prohibit use of Revert commits (eg on github: "Revert "feat: ride unicorns"")
 # this is only relevant when using commitsOnly: true (or titleAndCommits: true)
 allowRevertCommits: false
+

--- a/.github/.semantic.yml
+++ b/.github/.semantic.yml
@@ -1,8 +1,6 @@
 titleOnly: false
 commitsOnly: false
 anyCommit: false
-scopes: null
-types: null
 
 # Always validate the PR title AND all the commits
 titleAndCommits: true


### PR DESCRIPTION
If this actually works as advertised, then we can
enable squash commits from the repo settings
once again because it will no longer be possible
to make the mistake of squash-merging a PR and
ending up with the PR title as the commit
message while the PR title is not a valid commit
message (yes, this has happened in the past).

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>