### PR TITLE
build(plugin-consortium-manual): ignore the git_push script

### DIFF
--- a/packages/cactus-plugin-consortium-manual/src/main/typescript/generated/openapi/typescript-axios/.openapi-generator-ignore
+++ b/packages/cactus-plugin-consortium-manual/src/main/typescript/generated/openapi/typescript-axios/.openapi-generator-ignore
@@ -21,3 +21,5 @@
 #docs/*.md
 # Then explicitly reverse the ignore rule for a single file:
 #!docs/README.md
+
+git_push.sh


### PR DESCRIPTION
This ensures that the git_push.sh script is not flickering in the
git index when doing a build/re-build of the project/package

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>