### PR TITLE
chore: fix package scope  typo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hyperledger-labs/cactus",
+  "name": "@hyperledger/cactus",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hyperledger-labs/cactus",
+  "name": "@hyperledger/cactus",
   "private": true,
   "scripts": {
     "run-ci": "./tools/ci.sh",


### PR DESCRIPTION
Instead of Hyperledger Labs, the package scope should
be just Hyperledger since we've graduated from  being
a lab into a top level project.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>