### PR TITLE
build(tools): pkg info and bundle validation scripts

### DIFF
--- a/tools/get-package-info-list.js
+++ b/tools/get-package-info-list.js
@@ -1,0 +1,83 @@
+const { execSync } = require("child_process");
+const { readJsonSync } = require("fs-extra");
+
+/**
+ * Example:
+ * {
+ *   name: '@hyperledger/cactus-core-api',
+ *   version: '0.2.0',
+ *   private: false,
+ *   location: '/home/peter/a/blockchain/blockchain-integration-framework/packages/cactus-core-api'
+ *   packageObject: {
+ *    ...
+ *   }
+ * };
+ *
+ * @typedef {Object} PackageInfo
+ * @property {string} name Name of the package as listed on npm/other registry.
+ * @property {string} version Package version as listed on npm/other registry.
+ * @property {boolean} private Indicates if the package is meant to be published or not.
+ * @property {string} location Absolute file-system path to the package root directory.
+ * @property {string[]} localDependencies The packages in this mono-repo that the current package is dependent on.
+ * @property {object} packageObject The contents of the package.json file as a JS object
+ * @property {string} packageObject.main The main field is a module ID that is the primary entry point to your program.
+ * @property {string} packageObject.mainMinified Same as main but minified for production.
+ * @property {string} packageObject.browser Primary entry point for the browser compatible build of the code.
+ * @property {string} packageObject.browserMinified Same as browser but the production ready, minified version.
+ * @property {string} packageObject.module An ECMAScript module ID that is the primary entry point to your program.
+ * @property {string} packageObject.types Set the types property to point to your bundled declaration file.
+ * @property {string[]} packageObject.files The 'files' field is an array of files to include in your project.
+ * If you name a folder in the array, then it will also include the files inside that folder.
+ */
+
+/** @typedef {Object<string, string[]} PackageDependencyGraph */
+
+/**
+ * @returns {PackageDependencyGraph}
+ */
+const getDependencyGraph = () => {
+  const cliCommand = `./node_modules/.bin/lerna list --all --graph --toposort`;
+  const processOutputBuffer = execSync(cliCommand);
+  const processOutput = processOutputBuffer.toString("utf-8");
+
+  /** @type {PackageDependencyGraph} */
+  const dependencyGraph = JSON.parse(processOutput);
+
+  return dependencyGraph;
+};
+
+/**
+ * Returns an array of objects that represent the packages of the project.
+ * Useful when developing build related scripts that need a surefire way of
+ * obtaining the project folders/package names, etc without having to do
+ * cross-platform shell magic.
+ *
+ * @param {RegExp[]} ignorePatterns Patterns that will be checked for exclusion
+ *
+ * @returns {PackageInfo[]}
+ */
+module.exports.getPackageInfoList = (ignorePatterns = []) => {
+  const cliCommand = `./node_modules/.bin/lerna list --all --json --toposort`;
+  const processOutputBuffer = execSync(cliCommand);
+  const processOutput = processOutputBuffer.toString("utf-8");
+
+  /** @type {PackageInfo[]} */
+  const pkgInfoList = JSON.parse(processOutput).filter(
+    (pkgInfo) => !ignorePatterns.some((ip) => ip.test(pkgInfo.name))
+  );
+
+  pkgInfoList.forEach((pkgInfo) => {
+    pkgInfo.packageObject = readJsonSync(`${pkgInfo.location}/package.json`);
+  });
+
+  /** @type {PackageDependencyGraph} */
+  const dependencyGraph = getDependencyGraph();
+
+  pkgInfoList.forEach((pkgInfo) => {
+    pkgInfo.localDependencies = dependencyGraph[pkgInfo.name]
+      .filter((pkgName) => !ignorePatterns.some((ip) => ip.test(pkgName)))
+      .filter((pkgName) => pkgName.startsWith("@hyperledger/cactus"));
+  });
+
+  return pkgInfoList;
+};

--- a/tools/validate-bundle-names.js
+++ b/tools/validate-bundle-names.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+const { getPackageInfoList } = require("./get-package-info-list");
+
+const main = async () => {
+  const packageInfoList = await getPackageInfoList([/cactus-cockpit/]);
+
+  const errors = [];
+
+  packageInfoList.forEach((pi) => {
+    const nameNoScope = pi.name.replace("@hyperledger/", "");
+
+    const targetMain = `dist/${nameNoScope}.node.umd.js`;
+    const targetMainMinified = `dist/${nameNoScope}.node.umd.min.js`;
+    const targetBrowser = `dist/${nameNoScope}.web.umd.js`;
+    const targetBrowserMinified = `dist/${nameNoScope}.web.umd.min.js`;
+
+    const { main, mainMinified, browser, browserMinified } = pi.packageObject;
+
+    const pkgJsonPath = `${pi.location}/package.json`;
+
+    if (targetMain !== main) {
+      errors.push(`${pkgJsonPath}: \n\t${targetMain}\n\t${main}\n`);
+    }
+    if (targetMainMinified !== mainMinified) {
+      errors.push(
+        `${pkgJsonPath}: \n\t${targetMainMinified}\n\t${mainMinified}\n`
+      );
+    }
+    if (targetBrowser !== browser) {
+      errors.push(`${pkgJsonPath}: \n\t${targetBrowser}\n\t${browser}\n`);
+    }
+    if (targetBrowserMinified !== browserMinified) {
+      const diff = `\n\t${targetBrowserMinified}\n\t${browserMinified}\n`;
+      const errorMessage = `${pkgJsonPath}: ${diff}`;
+      errors.push(errorMessage);
+    }
+  });
+
+  if (errors.length === 0) {
+    console.log(`No errors found. All OK.`);
+    process.exit(0);
+  } else {
+    errors.forEach((e) => console.error(e));
+    process.exit(-1);
+  }
+};
+
+main();


### PR DESCRIPTION
Adds two utility scripts that come handy when
1. Authoring build tools for the project where
the package dependency graph has to be accessed
and processed programmatically for example.

2. Wanting to validate that there are no typos in
the bundle names of packages as declared in
their package.json files (which has been a
recurring theme hence this script to automate
the checks for it).

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>