### PR TITLE
feat(plugin registry): get keychain by keychain id

### DIFF
--- a/packages/cactus-core-api/src/main/typescript/plugin/plugin-registry.ts
+++ b/packages/cactus-core-api/src/main/typescript/plugin/plugin-registry.ts
@@ -1,6 +1,7 @@
 import { Optional } from "typescript-optional";
 import { ICactusPlugin, isICactusPlugin } from "../plugin/i-cactus-plugin";
 import { PluginAspect } from "../plugin/plugin-aspect";
+import { IPluginKeychain } from "./keychain/i-plugin-keychain";
 
 /**
  * This interface describes the constructor options object that can be used to provide configuration parameters to
@@ -78,6 +79,21 @@ export class PluginRegistry {
   ): Optional<T> {
     const plugin = this.getPlugins().find((p) => p.getAspect() === aspect);
     return Optional.ofNullable(plugin as T);
+  }
+
+  public findOneByKeychainId<T extends IPluginKeychain>(keychainId: string): T {
+    const fnTag = "PluginRegistry#findOneByKeychainId()";
+    if (typeof keychainId !== "string" || keychainId.trim().length < 1) {
+      throw new Error(`${fnTag} need keychainId arg as non-blank string.`);
+    }
+
+    const plugin = this.findManyByAspect<IPluginKeychain>(
+      PluginAspect.KEYCHAIN
+    ).find((keychainPlugin) => keychainPlugin.getKeychainId() === keychainId);
+
+    return Optional.ofNullable(plugin as T).orElseThrow(
+      () => new Error(`${fnTag} No keychain found for ID ${keychainId}`)
+    );
   }
 
   public findManyByAspect<T extends ICactusPlugin>(aspect: PluginAspect): T[] {

--- a/packages/cactus-core-api/src/test/typescript/unit/plugin-registry.test.ts
+++ b/packages/cactus-core-api/src/test/typescript/unit/plugin-registry.test.ts
@@ -1,0 +1,54 @@
+import test, { Test } from "tape";
+import { v4 as uuidv4 } from "uuid";
+
+import {
+  ICactusPlugin,
+  IPluginKeychain,
+  PluginAspect,
+  PluginRegistry,
+} from "../../../main/typescript/public-api";
+
+test("PluginRegistry", (tMain: Test) => {
+  test("findOneByKeychainId() finds plugin by keychain ID", (t: Test) => {
+    const keychainId = uuidv4();
+
+    const mockKeychainPlugin = {
+      getKeychainId: () => keychainId,
+      getAspect: () => PluginAspect.KEYCHAIN,
+    } as IPluginKeychain;
+
+    const pluginRegistry = new PluginRegistry({
+      plugins: [
+        mockKeychainPlugin,
+        {
+          getAspect: () => PluginAspect.CONSORTIUM,
+        } as ICactusPlugin,
+        {
+          getAspect: () => PluginAspect.KV_STORAGE,
+        } as ICactusPlugin,
+        {
+          getAspect: () => PluginAspect.LEDGER_CONNECTOR,
+        } as ICactusPlugin,
+      ],
+    });
+
+    t.doesNotThrow(() => pluginRegistry.findOneByKeychainId(keychainId));
+    const keychainPlugin = pluginRegistry.findOneByKeychainId(keychainId);
+    t.equal(keychainPlugin, mockKeychainPlugin, "Finds same object OK");
+
+    t.throws(
+      () => pluginRegistry.findOneByKeychainId(""),
+      /need keychainId arg as non-blank string/,
+      "Check for keychain ID blankness OK"
+    );
+    t.throws(
+      () => pluginRegistry.findOneByKeychainId("x"),
+      /No keychain found for ID/,
+      "Throws for keychain not found OK"
+    );
+
+    t.end();
+  });
+
+  tMain.end();
+});


### PR DESCRIPTION
## Commit to be reviewed:

```
feat(plugin-registry): get keychain by keychainId …
be42952
Adds a utility method where I can just pass in the
keychain ID and get back a plugin instance or an
exception thrown if it was not found.

Fixes #381

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>
```

Resolves #381