### PR TITLE
fix(common): Servers#listen() port number validation

### DIFF
--- a/packages/cactus-common/src/main/typescript/servers.ts
+++ b/packages/cactus-common/src/main/typescript/servers.ts
@@ -43,7 +43,10 @@ export class Servers {
 
     Checks.truthy(options, `${fnTag} arg options`);
     Checks.truthy(options.server, `${fnTag} arg options.server`);
-    Checks.truthy(options.port, `${fnTag} arg options.port`);
+    Checks.truthy(
+      options.port || options.port === 0,
+      `${fnTag} arg options.port`
+    );
     Checks.truthy(options.hostname, `${fnTag} arg options.hostname`);
     const { server, port, hostname } = options;
 

--- a/packages/cactus-common/src/test/typescript/unit/servers.test.ts
+++ b/packages/cactus-common/src/test/typescript/unit/servers.test.ts
@@ -1,0 +1,41 @@
+import { createServer } from "http";
+
+import test, { Test } from "tape-promise/tape";
+
+import { Servers } from "../../../main/typescript/index";
+
+test("Servers", async (tParent: Test) => {
+  test("Servers#listen()", async (t: Test) => {
+    {
+      const server = createServer();
+      await t.rejects(
+        Servers.listen({ hostname: "x", port: "" as any, server }),
+        /options\.port/,
+        "Rejects when port specified as empty string OK"
+      );
+    }
+
+    {
+      const server = createServer();
+      await t.rejects(
+        Servers.listen({ hostname: "localhost", port: false as any, server }),
+        /options\.port/,
+        "Rejects when port specified as literal false boolean OK"
+      );
+      // await Servers.shutdown(server);
+    }
+
+    {
+      const server = createServer();
+      await t.doesNotReject(
+        Servers.listen({ hostname: "localhost", port: 0, server }),
+        "Does not rejects when port specified as zero OK"
+      );
+      await Servers.shutdown(server);
+    }
+
+    t.end();
+  });
+
+  tParent.end();
+});

--- a/packages/cactus-core-api/src/main/typescript/plugin/plugin-registry.ts
+++ b/packages/cactus-core-api/src/main/typescript/plugin/plugin-registry.ts
@@ -1,6 +1,7 @@
 import { Optional } from "typescript-optional";
 import { ICactusPlugin, isICactusPlugin } from "../plugin/i-cactus-plugin";
 import { PluginAspect } from "../plugin/plugin-aspect";
+import { IPluginKeychain } from "./keychain/i-plugin-keychain";
 
 /**
  * This interface describes the constructor options object that can be used to provide configuration parameters to
@@ -78,6 +79,21 @@ export class PluginRegistry {
   ): Optional<T> {
     const plugin = this.getPlugins().find((p) => p.getAspect() === aspect);
     return Optional.ofNullable(plugin as T);
+  }
+
+  public findOneByKeychainId<T extends IPluginKeychain>(keychainId: string): T {
+    const fnTag = "PluginRegistry#findOneByKeychainId()";
+    if (typeof keychainId !== "string" || keychainId.trim().length < 1) {
+      throw new Error(`${fnTag} need keychainId arg as non-blank string.`);
+    }
+
+    const plugin = this.findManyByAspect<IPluginKeychain>(
+      PluginAspect.KEYCHAIN
+    ).find((keychainPlugin) => keychainPlugin.getKeychainId() === keychainId);
+
+    return Optional.ofNullable(plugin as T).orElseThrow(
+      () => new Error(`${fnTag} No keychain found for ID ${keychainId}`)
+    );
   }
 
   public findManyByAspect<T extends ICactusPlugin>(aspect: PluginAspect): T[] {

--- a/packages/cactus-core-api/src/test/typescript/unit/plugin-registry.test.ts
+++ b/packages/cactus-core-api/src/test/typescript/unit/plugin-registry.test.ts
@@ -1,0 +1,54 @@
+import test, { Test } from "tape";
+import { v4 as uuidv4 } from "uuid";
+
+import {
+  ICactusPlugin,
+  IPluginKeychain,
+  PluginAspect,
+  PluginRegistry,
+} from "../../../main/typescript/public-api";
+
+test("PluginRegistry", (tMain: Test) => {
+  test("findOneByKeychainId() finds plugin by keychain ID", (t: Test) => {
+    const keychainId = uuidv4();
+
+    const mockKeychainPlugin = {
+      getKeychainId: () => keychainId,
+      getAspect: () => PluginAspect.KEYCHAIN,
+    } as IPluginKeychain;
+
+    const pluginRegistry = new PluginRegistry({
+      plugins: [
+        mockKeychainPlugin,
+        {
+          getAspect: () => PluginAspect.CONSORTIUM,
+        } as ICactusPlugin,
+        {
+          getAspect: () => PluginAspect.KV_STORAGE,
+        } as ICactusPlugin,
+        {
+          getAspect: () => PluginAspect.LEDGER_CONNECTOR,
+        } as ICactusPlugin,
+      ],
+    });
+
+    t.doesNotThrow(() => pluginRegistry.findOneByKeychainId(keychainId));
+    const keychainPlugin = pluginRegistry.findOneByKeychainId(keychainId);
+    t.equal(keychainPlugin, mockKeychainPlugin, "Finds same object OK");
+
+    t.throws(
+      () => pluginRegistry.findOneByKeychainId(""),
+      /need keychainId arg as non-blank string/,
+      "Check for keychain ID blankness OK"
+    );
+    t.throws(
+      () => pluginRegistry.findOneByKeychainId("x"),
+      /No keychain found for ID/,
+      "Throws for keychain not found OK"
+    );
+
+    t.end();
+  });
+
+  tMain.end();
+});


### PR DESCRIPTION
**Depends on #381**

# How to review

Because this PR is a dependent of PR #381, by default the diff will show the full set of changes including everything from #381 and its parents changes as well. Therefore, to review this pull request please only look at the last commit (hash may change after rebasing later on)

---

Commit: 1ce14fa3fee1a723f96e5ae284bbf91a0ecb7959
Parents: be429528c14c9230bceff31db070424cea702fe2
Author: Peter Somogyvari <peter.somogyvari@accenture.com>
Committer: Peter Somogyvari <peter.somogyvari@accenture.com>
Date: Tue Nov 10 2020 11:20:52 GMT-0800 (Pacific Standard Time) 

fix(common): servers#listen() port number validation

Fixes #383

Ensures that the when specifying port 0 the liste()
method does not throw an exception since it is
perfectly valid to bind to port zero in general.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

---
