### PR TITLE
build(github): use dependent-issues action

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -2,7 +2,16 @@ name: Dependent Issues
 
 on:
   issues:
-  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
   schedule:
     - cron: '0 0 * * *' # schedule daily check
 

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -1,0 +1,27 @@
+name: Dependent Issues
+
+on:
+  issues:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *' # schedule daily check
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: z0al/dependent-issues@v1
+        env:
+          # (Required) The token to use to make API calls to GitHub.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # (Optional) The label to use to mark dependent issues
+          label: dependent
+
+          # (Optional) Enable checking for dependencies in issues. Enable by
+          # setting the value to "on". Default "off"
+          check_issues: off
+
+          # (Optional) A comma-separated list of keywords. Default
+          # "depends on, blocked by"
+          keywords: depends on, blocked by


### PR DESCRIPTION
Hey there :wave:,

This is an ***automated PR*** to migrate recent [DEP](https://github.com/apps/dep) App users to a new [GitHub action](https://github.com/features/actions) called [Dependent Issues]( https://github.com/marketplace/actions/dependent-issues). 

If you received this PR it means you have DEP installed on the organization level (not necessarily enabled on this repository). If you think this is a mistake, I'm sorry. Please close this PR.

### :newspaper: TLDR

* The current DEP app has _been deprecated in favor of the new [Dependent Issues](https://github.com/marketplace/actions/dependent-issues)_ Github Action and it will be removed soon.
* The new Action works the same way the bot did but with additional features/changes:
  - Works with both _PRs and issues_ (disabled by default).
  - Works with _cross-repository_ dependencies e.g. `microsoft/vscode#999`.
  - It _notifies users by writing a comment_ with the list of dependencies and keep their states updated. This is especially useful when having the action enabled for non-PR issues.
  - Keywords and the label _can now be customized._
  - It sets the state of the head commit on a PR _to `pending` instead of `failure`_ (shows as :orange_circle: instead of a :x: ) when some dependencies are not yet ready (i.e. closed).

Breaking changes? Nothing. You can use the action the same way as before. eg. Writing `Depends on #number` or `Depends on owner/repo#number` clause(s) on the PR/issue description.

For more info please visit :point_right:  https://github.com/marketplace/actions/dependent-issues

### :bulb: Usage

![example](https://raw.githubusercontent.com/z0al/dependent-issues/main/demo.png)
