### PR TITLE
refactor(core-api): move PluginRegistry to core package

### DIFF
--- a/examples/cactus-example-supply-chain-backend/src/main/typescript/infrastructure/supply-chain-app-dummy-infrastructure.ts
+++ b/examples/cactus-example-supply-chain-backend/src/main/typescript/infrastructure/supply-chain-app-dummy-infrastructure.ts
@@ -6,7 +6,7 @@ import {
   LogLevelDesc,
   LoggerProvider,
 } from "@hyperledger/cactus-common";
-import { PluginRegistry } from "@hyperledger/cactus-core-api";
+import { PluginRegistry } from "@hyperledger/cactus-core";
 import { PluginLedgerConnectorBesu } from "@hyperledger/cactus-plugin-ledger-connector-besu";
 import {
   PluginLedgerConnectorQuorum,

--- a/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
+++ b/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
@@ -10,8 +10,9 @@ import {
   Consortium,
   ConsortiumMember,
   LedgerType,
-  PluginRegistry,
 } from "@hyperledger/cactus-core-api";
+
+import { PluginRegistry } from "@hyperledger/cactus-core";
 
 import {
   LogLevelDesc,

--- a/packages/cactus-cmd-api-server/package.json
+++ b/packages/cactus-cmd-api-server/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "@hyperledger/cactus-cockpit": "^0.2.0",
     "@hyperledger/cactus-common": "^0.2.0",
+    "@hyperledger/cactus-core": "^0.2.0",
     "@hyperledger/cactus-core-api": "^0.2.0",
     "@hyperledger/cactus-plugin-consortium-manual": "^0.2.0",
     "@hyperledger/cactus-plugin-keychain-memory": "^0.2.0",

--- a/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
@@ -22,8 +22,8 @@ import {
   ICactusPlugin,
   isIPluginWebService,
   IPluginWebService,
-  PluginRegistry,
 } from "@hyperledger/cactus-core-api";
+import { PluginRegistry } from "@hyperledger/cactus-core";
 import { ICactusApiServerOptions } from "./config/config-service";
 import { CACTUS_OPEN_API_JSON } from "./openapi-spec";
 import { Logger, LoggerProvider, Servers } from "@hyperledger/cactus-common";

--- a/packages/cactus-cmd-api-server/src/test/typescript/integration/runtime-plugin-imports.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/integration/runtime-plugin-imports.test.ts
@@ -2,7 +2,7 @@ import test, { Test } from "tape-promise/tape";
 import { v4 as uuidv4 } from "uuid";
 
 import { LogLevelDesc } from "@hyperledger/cactus-common";
-import { PluginRegistry } from "@hyperledger/cactus-core-api";
+import { PluginRegistry } from "@hyperledger/cactus-core";
 
 import { ApiServer, ConfigService } from "../../../main/typescript/public-api";
 import { IPluginKeychainMemoryOptions } from "../../../../../cactus-plugin-keychain-memory/dist/types/main/typescript";

--- a/packages/cactus-core-api/src/main/typescript/public-api.ts
+++ b/packages/cactus-core-api/src/main/typescript/public-api.ts
@@ -15,4 +15,3 @@ export {
   isICactusPlugin,
 } from "./plugin/i-cactus-plugin";
 export { PluginAspect } from "./plugin/plugin-aspect";
-export { PluginRegistry } from "./plugin/plugin-registry";

--- a/packages/cactus-core/src/main/typescript/plugin-registry.ts
+++ b/packages/cactus-core/src/main/typescript/plugin-registry.ts
@@ -1,7 +1,10 @@
 import { Optional } from "typescript-optional";
-import { ICactusPlugin, isICactusPlugin } from "../plugin/i-cactus-plugin";
-import { PluginAspect } from "../plugin/plugin-aspect";
-import { IPluginKeychain } from "./keychain/i-plugin-keychain";
+import {
+  ICactusPlugin,
+  IPluginKeychain,
+  isICactusPlugin,
+  PluginAspect,
+} from "@hyperledger/cactus-core-api";
 
 /**
  * This interface describes the constructor options object that can be used to provide configuration parameters to

--- a/packages/cactus-core/src/main/typescript/public-api.ts
+++ b/packages/cactus-core/src/main/typescript/public-api.ts
@@ -1,1 +1,2 @@
 export { registerWebServiceEndpoint } from "./web-services/register-web-service-endpoint";
+export { IPluginRegistryOptions, PluginRegistry } from "./plugin-registry";

--- a/packages/cactus-core/src/test/typescript/unit/plugin-registry.test.ts
+++ b/packages/cactus-core/src/test/typescript/unit/plugin-registry.test.ts
@@ -1,12 +1,13 @@
 import test, { Test } from "tape";
 import { v4 as uuidv4 } from "uuid";
 
+import { PluginRegistry } from "../../../main/typescript/public-api";
+
 import {
   ICactusPlugin,
   IPluginKeychain,
   PluginAspect,
-  PluginRegistry,
-} from "../../../main/typescript/public-api";
+} from "@hyperledger/cactus-core-api";
 
 test("PluginRegistry", (tMain: Test) => {
   test("findOneByKeychainId() finds plugin by keychain ID", (t: Test) => {

--- a/packages/cactus-plugin-consortium-manual/src/main/typescript/plugin-consortium-manual.ts
+++ b/packages/cactus-plugin-consortium-manual/src/main/typescript/plugin-consortium-manual.ts
@@ -9,11 +9,13 @@ import {
   Consortium,
   IPluginWebService,
   PluginAspect,
-  PluginRegistry,
   IWebServiceEndpoint,
   ICactusPlugin,
   ICactusPluginOptions,
 } from "@hyperledger/cactus-core-api";
+
+import { PluginRegistry } from "@hyperledger/cactus-core";
+
 import {
   Checks,
   Logger,

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/plugin-ledger-connector-besu.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/plugin-ledger-connector-besu.ts
@@ -16,9 +16,10 @@ import {
   PluginAspect,
   ICactusPlugin,
   ICactusPluginOptions,
-  PluginRegistry,
   IPluginKeychain,
 } from "@hyperledger/cactus-core-api";
+
+import { PluginRegistry } from "@hyperledger/cactus-core";
 
 import {
   Checks,

--- a/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/deploy-contract-from-json.test.ts
@@ -1,6 +1,6 @@
 import test, { Test } from "tape";
 import { v4 as uuidv4 } from "uuid";
-import { PluginRegistry } from "@hyperledger/cactus-core-api";
+import { PluginRegistry } from "@hyperledger/cactus-core";
 import {
   EthContractInvocationType,
   Web3SigningCredentialType,

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/plugin-ledger-connector-fabric.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/plugin-ledger-connector-fabric.ts
@@ -22,8 +22,9 @@ import {
   IWebServiceEndpoint,
   ICactusPlugin,
   ICactusPluginOptions,
-  PluginRegistry,
 } from "@hyperledger/cactus-core-api";
+
+import { PluginRegistry } from "@hyperledger/cactus-core";
 
 import {
   Logger,

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/deploy-contract-go-bin-endpoint-v1/deploy-contract/deploy-cc-from-golang-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/deploy-contract-go-bin-endpoint-v1/deploy-contract/deploy-cc-from-golang-source.test.ts
@@ -18,7 +18,7 @@ import {
   LogLevelDesc,
   Servers,
 } from "@hyperledger/cactus-common";
-import { PluginRegistry } from "@hyperledger/cactus-core-api";
+import { PluginRegistry } from "@hyperledger/cactus-core";
 
 import {
   PluginLedgerConnectorFabric,

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/run-transaction-endpoint-v1.test.ts
@@ -8,7 +8,7 @@ import bodyParser from "body-parser";
 import express from "express";
 
 import { FabricTestLedgerV1 } from "@hyperledger/cactus-test-tooling";
-import { PluginRegistry } from "@hyperledger/cactus-core-api";
+import { PluginRegistry } from "@hyperledger/cactus-core";
 
 import {
   IListenOptions,

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/plugin-ledger-connector-quorum.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/plugin-ledger-connector-quorum.ts
@@ -16,9 +16,10 @@ import {
   PluginAspect,
   ICactusPlugin,
   ICactusPluginOptions,
-  PluginRegistry,
   IPluginKeychain,
 } from "@hyperledger/cactus-core-api";
+
+import { PluginRegistry } from "@hyperledger/cactus-core";
 
 import {
   Checks,

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/deploy-contract-from-json.test.ts
@@ -24,7 +24,7 @@ import {
   IQuorumGenesisOptions,
   IAccount,
 } from "@hyperledger/cactus-test-tooling";
-import { PluginRegistry } from "@hyperledger/cactus-core-api";
+import { PluginRegistry } from "@hyperledger/cactus-core";
 
 const logLevel: LogLevelDesc = "INFO";
 const log: Logger = LoggerProvider.getOrCreate({

--- a/packages/cactus-test-api-client/package.json
+++ b/packages/cactus-test-api-client/package.json
@@ -65,6 +65,7 @@
     "@hyperledger/cactus-api-client": "^0.2.0",
     "@hyperledger/cactus-cmd-api-server": "^0.2.0",
     "@hyperledger/cactus-common": "^0.2.0",
+    "@hyperledger/cactus-core": "^0.2.0",
     "@hyperledger/cactus-core-api": "^0.2.0",
     "@hyperledger/cactus-plugin-consortium-manual": "^0.2.0",
     "@hyperledger/cactus-plugin-ledger-connector-besu": "^0.2.0",

--- a/packages/cactus-test-api-client/src/test/typescript/integration/api-client-routing-node-to-node.test.ts
+++ b/packages/cactus-test-api-client/src/test/typescript/integration/api-client-routing-node-to-node.test.ts
@@ -7,12 +7,8 @@ import Web3 from "web3";
 
 import { ApiClient } from "@hyperledger/cactus-api-client";
 import { ApiServer, ConfigService } from "@hyperledger/cactus-cmd-api-server";
-import {
-  PluginRegistry,
-  Consortium,
-  Ledger,
-  LedgerType,
-} from "@hyperledger/cactus-core-api";
+import { Consortium, Ledger, LedgerType } from "@hyperledger/cactus-core-api";
+import { PluginRegistry } from "@hyperledger/cactus-core";
 import {
   DefaultApi as QuorumApi,
   PluginLedgerConnectorQuorum,

--- a/packages/cactus-test-cmd-api-server/src/test/typescript/integration/runtime-plugin-imports.test.ts
+++ b/packages/cactus-test-cmd-api-server/src/test/typescript/integration/runtime-plugin-imports.test.ts
@@ -2,7 +2,6 @@ import test, { Test } from "tape-promise/tape";
 import { v4 as uuidv4 } from "uuid";
 
 import { LogLevelDesc } from "@hyperledger/cactus-common";
-import { PluginRegistry } from "@hyperledger/cactus-core-api";
 
 import { ApiServer, ConfigService } from "@hyperledger/cactus-cmd-api-server";
 import { IPluginKeychainMemoryOptions } from "@hyperledger/cactus-plugin-keychain-memory";

--- a/packages/cactus-test-plugin-consortium-manual/package.json
+++ b/packages/cactus-test-plugin-consortium-manual/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "@hyperledger/cactus-cmd-api-server": "^0.2.0",
     "@hyperledger/cactus-common": "^0.2.0",
+    "@hyperledger/cactus-core": "^0.2.0",
     "@hyperledger/cactus-core-api": "^0.2.0",
     "@hyperledger/cactus-plugin-consortium-manual": "^0.2.0",
     "@hyperledger/cactus-plugin-kv-storage-memory": "^0.2.0",

--- a/packages/cactus-test-plugin-consortium-manual/src/test/typescript/integration/plugin-consortium-manual/get-consortium-jws-endpoint.test.ts
+++ b/packages/cactus-test-plugin-consortium-manual/src/test/typescript/integration/plugin-consortium-manual/get-consortium-jws-endpoint.test.ts
@@ -12,7 +12,8 @@ import {
   DefaultApi,
   Configuration,
 } from "@hyperledger/cactus-plugin-consortium-manual";
-import { Consortium, PluginRegistry } from "@hyperledger/cactus-core-api";
+import { Consortium } from "@hyperledger/cactus-core-api";
+import { PluginRegistry } from "@hyperledger/cactus-core";
 
 test("member node public keys and hosts are pre-shared", async (t: Test) => {
   const consortiumId = uuidV4();

--- a/packages/cactus-test-plugin-consortium-manual/src/test/typescript/integration/plugin-consortium-manual/security-isolation-via-api-server-ports.ts
+++ b/packages/cactus-test-plugin-consortium-manual/src/test/typescript/integration/plugin-consortium-manual/security-isolation-via-api-server-ports.ts
@@ -10,8 +10,9 @@ import {
   CactusNode,
   ConsortiumMember,
   Consortium,
-  PluginRegistry,
 } from "@hyperledger/cactus-core-api";
+import { PluginRegistry } from "@hyperledger/cactus-core";
+
 import { PluginKVStorageMemory } from "@hyperledger/cactus-plugin-kv-storage-memory";
 import {
   DefaultApi as DefaultApiPlugin,

--- a/packages/cactus-test-plugin-ledger-connector-besu/package.json
+++ b/packages/cactus-test-plugin-ledger-connector-besu/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "@hyperledger/cactus-cmd-api-server": "^0.2.0",
     "@hyperledger/cactus-common": "^0.2.0",
+    "@hyperledger/cactus-core": "^0.2.0",
     "@hyperledger/cactus-core-api": "^0.2.0",
     "@hyperledger/cactus-plugin-keychain-memory": "^0.2.0",
     "@hyperledger/cactus-plugin-ledger-connector-besu": "^0.2.0",

--- a/packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/sign-transaction-endpoint.test.ts
+++ b/packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/sign-transaction-endpoint.test.ts
@@ -26,7 +26,7 @@ import {
   SignTransactionRequest,
 } from "@hyperledger/cactus-plugin-ledger-connector-besu";
 
-import { PluginRegistry } from "@hyperledger/cactus-core-api";
+import { PluginRegistry } from "@hyperledger/cactus-core";
 
 import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory";
 

--- a/packages/cactus-test-plugin-ledger-connector-quorum/package.json
+++ b/packages/cactus-test-plugin-ledger-connector-quorum/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "@hyperledger/cactus-cmd-api-server": "^0.2.0",
     "@hyperledger/cactus-common": "^0.2.0",
+    "@hyperledger/cactus-core": "^0.2.0",
     "@hyperledger/cactus-core-api": "^0.2.0",
     "@hyperledger/cactus-plugin-consortium-manual": "^0.2.0",
     "@hyperledger/cactus-plugin-kv-storage-memory": "^0.2.0",

--- a/packages/cactus-test-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/deploy-contract-via-web-service.test.ts
+++ b/packages/cactus-test-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/deploy-contract-via-web-service.test.ts
@@ -24,7 +24,8 @@ import {
   ICactusApiServerOptions,
 } from "@hyperledger/cactus-cmd-api-server";
 
-import { ICactusPlugin, PluginRegistry } from "@hyperledger/cactus-core-api";
+import { PluginRegistry } from "@hyperledger/cactus-core";
+import { ICactusPlugin } from "@hyperledger/cactus-core-api";
 import { PluginKVStorageMemory } from "@hyperledger/cactus-plugin-kv-storage-memory";
 
 const log: Logger = LoggerProvider.getOrCreate({


### PR DESCRIPTION
## Commit to be reviewed:

```
commit 6c88f647baf6f5f70e47d2634697d47498e8bed4 (refactor/core-api/move-pluginregistry-to-core-package-380)
Author: Peter Somogyvari <peter.somogyvari@accenture.com>
Date:   Tue Dec 1 17:04:16 2020 -0800

    refactor(core-api): move PluginRegistry to core package
    
    Fixes #380
    
    Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

```