### PR TITLE
feat(core-api): add consensus algorithms OpenAPI enum

### DIFF
--- a/packages/cactus-core-api/src/main/json/generated/openapi-spec.json
+++ b/packages/cactus-core-api/src/main/json/generated/openapi-spec.json
@@ -27,6 +27,15 @@
     ],
     "components": {
         "schemas": {
+            "ConsensusAlgorithmFamily": {
+                "type": "string",
+                "description": "Enumerates a list of consensus algorithm families in existence. Does not intend to be an exhaustive list, just a practical one, meaning that we only include items here that are relevant to Hyperledger Cactus in fulfilling its own duties. This can be extended later as more sophisticated features of Cactus get implemented. This enum is meant to be first and foremest a useful abstraction for achieving practical tasks, not an encyclopedia and therefore we ask of everyone that this to be extended only in ways that serve a practical purpose for the runtime behavior of Cactus or Cactus plugins in general. The bottom line is that we can accept this enum being not 100% accurate as long as it 100% satisfies what it was designed to do.",
+                "enum": [
+                    "org.hyperledger.cactus.consensusalgorithm.PROOF_OF_AUTHORITY",
+                    "org.hyperledger.cactus.consensusalgorithm.PROOF_OF_STAKE",
+                    "org.hyperledger.cactus.consensusalgorithm.PROOF_OF_WORK"
+                ]
+            },
             "PrimaryKey": {
                 "type": "string",
                 "minLength": 1,

--- a/packages/cactus-core-api/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-core-api/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -125,6 +125,17 @@ export interface CactusNodeMeta {
     publicKeyPem: string;
 }
 /**
+ * Enumerates a list of consensus algorithm families in existence. Does not intend to be an exhaustive list, just a practical one, meaning that we only include items here that are relevant to Hyperledger Cactus in fulfilling its own duties. This can be extended later as more sophisticated features of Cactus get implemented. This enum is meant to be first and foremest a useful abstraction for achieving practical tasks, not an encyclopedia and therefore we ask of everyone that this to be extended only in ways that serve a practical purpose for the runtime behavior of Cactus or Cactus plugins in general. The bottom line is that we can accept this enum being not 100% accurate as long as it 100% satisfies what it was designed to do.
+ * @export
+ * @enum {string}
+ */
+export enum ConsensusAlgorithmFamily {
+    AUTHORITY = 'org.hyperledger.cactus.consensusalgorithm.PROOF_OF_AUTHORITY',
+    STAKE = 'org.hyperledger.cactus.consensusalgorithm.PROOF_OF_STAKE',
+    WORK = 'org.hyperledger.cactus.consensusalgorithm.PROOF_OF_WORK'
+}
+
+/**
  * 
  * @export
  * @interface Consortium

--- a/packages/cactus-core-api/src/main/typescript/openapi-spec.ts
+++ b/packages/cactus-core-api/src/main/typescript/openapi-spec.ts
@@ -35,6 +35,28 @@ export const CACTUS_OPEN_API_JSON: OpenAPIV3.Document = {
   ],
   components: {
     schemas: {
+      ConsensusAlgorithmFamily: {
+        type: "string",
+        description:
+          "Enumerates a list of consensus algorithm families in " +
+          "existence. Does not intend to be an exhaustive list, just a " +
+          "practical one, meaning that we only include items here that are " +
+          "relevant to Hyperledger Cactus in fulfilling its own duties. " +
+          "This can be extended later as more sophisticated features " +
+          "of Cactus get implemented. " +
+          "This enum is meant to be first and foremest a useful abstraction " +
+          "for achieving practical tasks, not an encyclopedia and therefore " +
+          "we ask of everyone that this to be extended only in ways that " +
+          "serve a practical purpose for the runtime behavior of Cactus or " +
+          "Cactus plugins in general. The bottom line is that we can accept " +
+          "this enum being not 100% accurate as long as it 100% satisfies " +
+          "what it was designed to do.",
+        enum: [
+          "org.hyperledger.cactus.consensusalgorithm.PROOF_OF_AUTHORITY",
+          "org.hyperledger.cactus.consensusalgorithm.PROOF_OF_STAKE",
+          "org.hyperledger.cactus.consensusalgorithm.PROOF_OF_WORK",
+        ],
+      },
       PrimaryKey: {
         type: "string",
         minLength: 1,


### PR DESCRIPTION
## How to Review

**<ins>This PR depends on another [PR](https://github.com/hyperledger/cactus/pull/409) to ensure that the authors are not blocked in performing their work while waiting for the pull request to get reviewed. Please read the each point of the description below carefully!</ins>**

- It is strongly recommended that you review the parent PR first before reviewing this one because once that one (parent PR) is merged, this can be rebased onto the main branch which will literally disappear the additional commits that are shown in this PR but actually belong to the parent PR
- Before this one can be merged, #409 has to be approved and merged first.
- Reviewing this one can be done as of right now by looking at the changes made specifically by the single commit that this branch commits on top of the branch of the parent branch (parent PR)
- Feel free to ask @petermetz via any of your preferred communication channels for help if you get stuck using the GitHub UI or any git features during the review.
- You can use the 'commits' tab of the PR page of GitHub to filter down the diff to a specific commit which allows you to not be bothered by the other commits at all (which belong to the parent PR). To see which commit to filter the diffs down onto, see the section below titled as "commit to be reviewed".
- Important: The CI will not pass on this PR until the parent PR is merged due to a dependency on the docker image that will only get updated once the parent PR has been merged in. Because of this, please disregard the fact that the CI is failing and review the pull request with the assumption (requesting benefit of the doubt) that the CI is (will be) passing once the parent PR has been merged.

## Commit to be reviewed:

```
feat(core-api): add consensus algorithms OpenAPI enum

Enumerates a list of consensus algorithm families in
existence. Does not intend to be an exhaustive list, just a
practical one, meaning that we only include items here
that are relevant to Hyperledger Cactus in fulfilling its
own duties. This can be extended later as more
sophisticated features of Cactus get implemented. This
enum is meant to be first and foremest a useful
abstraction for achieving practical tasks, not an
encyclopedia and therefore we ask of everyone that this
to be extended only in ways that serve a practical
purpose for the runtime behavior of Cactus or Cactus
plugins in general. The bottom line is that we can accept
this enum being not 100% accurate as long as it 100%
satisfies what it was designed to do.

Fixes hyperledger#359

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>
```

Fixes #359 