### PR TITLE
feat(core-api): getConsensusAlgorithmFamily() on connector API

### DIFF
--- a/packages/cactus-core-api/src/main/json/generated/openapi-spec.json
+++ b/packages/cactus-core-api/src/main/json/generated/openapi-spec.json
@@ -27,6 +27,15 @@
     ],
     "components": {
         "schemas": {
+            "ConsensusAlgorithmFamily": {
+                "type": "string",
+                "description": "Enumerates a list of consensus algorithm families in existence. Does not intend to be an exhaustive list, just a practical one, meaning that we only include items here that are relevant to Hyperledger Cactus in fulfilling its own duties. This can be extended later as more sophisticated features of Cactus get implemented. This enum is meant to be first and foremest a useful abstraction for achieving practical tasks, not an encyclopedia and therefore we ask of everyone that this to be extended only in ways that serve a practical purpose for the runtime behavior of Cactus or Cactus plugins in general. The bottom line is that we can accept this enum being not 100% accurate as long as it 100% satisfies what it was designed to do.",
+                "enum": [
+                    "org.hyperledger.cactus.consensusalgorithm.PROOF_OF_AUTHORITY",
+                    "org.hyperledger.cactus.consensusalgorithm.PROOF_OF_STAKE",
+                    "org.hyperledger.cactus.consensusalgorithm.PROOF_OF_WORK"
+                ]
+            },
             "PrimaryKey": {
                 "type": "string",
                 "minLength": 1,

--- a/packages/cactus-core-api/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-core-api/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -125,6 +125,17 @@ export interface CactusNodeMeta {
     publicKeyPem: string;
 }
 /**
+ * Enumerates a list of consensus algorithm families in existence. Does not intend to be an exhaustive list, just a practical one, meaning that we only include items here that are relevant to Hyperledger Cactus in fulfilling its own duties. This can be extended later as more sophisticated features of Cactus get implemented. This enum is meant to be first and foremest a useful abstraction for achieving practical tasks, not an encyclopedia and therefore we ask of everyone that this to be extended only in ways that serve a practical purpose for the runtime behavior of Cactus or Cactus plugins in general. The bottom line is that we can accept this enum being not 100% accurate as long as it 100% satisfies what it was designed to do.
+ * @export
+ * @enum {string}
+ */
+export enum ConsensusAlgorithmFamily {
+    AUTHORITY = 'org.hyperledger.cactus.consensusalgorithm.PROOF_OF_AUTHORITY',
+    STAKE = 'org.hyperledger.cactus.consensusalgorithm.PROOF_OF_STAKE',
+    WORK = 'org.hyperledger.cactus.consensusalgorithm.PROOF_OF_WORK'
+}
+
+/**
  * 
  * @export
  * @interface Consortium

--- a/packages/cactus-core-api/src/main/typescript/openapi-spec.ts
+++ b/packages/cactus-core-api/src/main/typescript/openapi-spec.ts
@@ -35,6 +35,28 @@ export const CACTUS_OPEN_API_JSON: OpenAPIV3.Document = {
   ],
   components: {
     schemas: {
+      ConsensusAlgorithmFamily: {
+        type: "string",
+        description:
+          "Enumerates a list of consensus algorithm families in " +
+          "existence. Does not intend to be an exhaustive list, just a " +
+          "practical one, meaning that we only include items here that are " +
+          "relevant to Hyperledger Cactus in fulfilling its own duties. " +
+          "This can be extended later as more sophisticated features " +
+          "of Cactus get implemented. " +
+          "This enum is meant to be first and foremest a useful abstraction " +
+          "for achieving practical tasks, not an encyclopedia and therefore " +
+          "we ask of everyone that this to be extended only in ways that " +
+          "serve a practical purpose for the runtime behavior of Cactus or " +
+          "Cactus plugins in general. The bottom line is that we can accept " +
+          "this enum being not 100% accurate as long as it 100% satisfies " +
+          "what it was designed to do.",
+        enum: [
+          "org.hyperledger.cactus.consensusalgorithm.PROOF_OF_AUTHORITY",
+          "org.hyperledger.cactus.consensusalgorithm.PROOF_OF_STAKE",
+          "org.hyperledger.cactus.consensusalgorithm.PROOF_OF_WORK",
+        ],
+      },
       PrimaryKey: {
         type: "string",
         minLength: 1,

--- a/packages/cactus-core-api/src/main/typescript/plugin/ledger-connector/i-plugin-ledger-connector.ts
+++ b/packages/cactus-core-api/src/main/typescript/plugin/ledger-connector/i-plugin-ledger-connector.ts
@@ -1,4 +1,5 @@
 import { ICactusPlugin } from "../i-cactus-plugin";
+import { ConsensusAlgorithmFamily } from "../../generated/openapi/typescript-axios/api";
 
 /**
  * Common interface to be implemented by plugins which are implementing the connection to ledgers.
@@ -21,4 +22,12 @@ export interface IPluginLedgerConnector<
    * type of ledger this connectir is targeted at.
    */
   transact(options?: TransactIn): Promise<TransactOut>;
+
+  /**
+   * Returns the family of algorithms in which the consensus algorithm used
+   * by the ledger (this connector is associated with) belongs in.
+   *
+   * @see {ConsensusAlgorithmFamily}
+   */
+  getConsensusAlgorithmFamily(): Promise<ConsensusAlgorithmFamily>;
 }

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/plugin-ledger-connector-besu.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/plugin-ledger-connector-besu.ts
@@ -10,6 +10,7 @@ import { ContractSendMethod } from "web3-eth-contract";
 import { TransactionReceipt } from "web3-eth";
 
 import {
+  ConsensusAlgorithmFamily,
   IPluginLedgerConnector,
   IWebServiceEndpoint,
   IPluginWebService,
@@ -166,6 +167,12 @@ export class PluginLedgerConnectorBesu
 
   public getAspect(): PluginAspect {
     return PluginAspect.LEDGER_CONNECTOR;
+  }
+
+  public async getConsensusAlgorithmFamily(): Promise<
+    ConsensusAlgorithmFamily
+  > {
+    return ConsensusAlgorithmFamily.AUTHORITY;
   }
 
   public async invokeContract(

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/plugin-ledger-connector-fabric.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/plugin-ledger-connector-fabric.ts
@@ -16,6 +16,7 @@ import {
 import { Optional } from "typescript-optional";
 
 import {
+  ConsensusAlgorithmFamily,
   IPluginLedgerConnector,
   PluginAspect,
   IPluginWebService,
@@ -114,6 +115,12 @@ export class PluginLedgerConnectorFabric
 
   public getHttpServer(): Optional<Server | SecureServer> {
     return Optional.empty();
+  }
+
+  public async getConsensusAlgorithmFamily(): Promise<
+    ConsensusAlgorithmFamily
+  > {
+    return ConsensusAlgorithmFamily.AUTHORITY;
   }
 
   /**

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/plugin-ledger-connector-quorum.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/plugin-ledger-connector-quorum.ts
@@ -10,6 +10,7 @@ import { ContractSendMethod } from "web3-eth-contract";
 import { TransactionReceipt } from "web3-eth";
 
 import {
+  ConsensusAlgorithmFamily,
   IPluginLedgerConnector,
   IWebServiceEndpoint,
   IPluginWebService,
@@ -150,6 +151,12 @@ export class PluginLedgerConnectorQuorum
 
   public getAspect(): PluginAspect {
     return PluginAspect.LEDGER_CONNECTOR;
+  }
+
+  public async getConsensusAlgorithmFamily(): Promise<
+    ConsensusAlgorithmFamily
+  > {
+    return ConsensusAlgorithmFamily.AUTHORITY;
   }
 
   public async invokeContract(


### PR DESCRIPTION
## How to Review

**<ins>This PR depends on another [PR](https://github.com/hyperledger/cactus/pull/414) to ensure that the authors are not blocked in performing their work while waiting for the pull request to get reviewed. Please read the each point of the description below carefully!</ins>**

- It is strongly recommended that you review the parent PR first before reviewing this one because once that one (parent PR) is merged, this can be rebased onto the main branch which will literally disappear the additional commits that are shown in this PR but actually belong to the parent PR
- Before this one can be merged, #414 has to be approved and merged first.
- Reviewing this one can be done as of right now by looking at the changes made specifically by the single commit that this branch commits on top of the branch of the parent branch (parent PR)
- Feel free to ask @petermetz via any of your preferred communication channels for help if you get stuck using the GitHub UI or any git features during the review.
- You can use the 'commits' tab of the PR page of GitHub to filter down the diff to a specific commit which allows you to not be bothered by the other commits at all (which belong to the parent PR). To see which commit to filter the diffs down onto, see the section below titled as "commit to be reviewed".
- Important: The CI will not pass on this PR until the parent PR is merged due to a dependency on the docker image that will only get updated once the parent PR has been merged in. Because of this, please disregard the fact that the CI is failing and review the pull request with the assumption (requesting benefit of the doubt) that the CI is (will be) passing once the parent PR has been merged.

## Commit to be reviewed:

```
feat(core-api): getConsensusAlgorithmFamily() on connector API

The method is called getConsensusAlgorithmFamily()
because we don't need (for now) the level of granularity
that is provided by having a method that points to the exact
algorithm used by the ledger (can be added later).
Why? Because for now we are mostly interested in whether an
algorithm family guarantees transaction finality or not and this
can be determined just from the family since for example it
does not make much of a difference if you are talking about
Bitcon's or Ethereum 1's proof of work, they both just do not
guarantee transaction finality the same way for all our intents
and purposes at present.

The added benefit of only dealing in families instead of specific
algorithms is that we can hardcode the answers instead of
having to query the ledger or rely on operators to provide
this information via configuration (again, we'll probably end
up needing this in the future anyway, but for the upcoming
work the families should be enough).

Fixes #355

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>
```

Fixes #355