### PR TITLE
ci(github-workflows): launch CI on PR & push for all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Cactus CI Github Workflow
 
-# Triggers the workflow on pull request events
-on: [pull_request]
+# Triggers the workflow on push or pull request events
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Before this change the only time the CI would get executed was when
a pull request was submitted against the $DEFAULT branch. After this
the CI will run for every commit and pull request that is issued against
the any branches.
The specific reason for this change is that we introduced a new branch
called dev which can be used to provide early access to pending changes
that may or may not be stuck in the review queue for longer periods of
time. Of course there's an additional overhead in maintaining this
dev branch by way of cherry picking and rebasing, but this is minor
compared to the positive effects it can bring to the community.

Fixes #434

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>