### PR TITLE
fix: Open API generator config - protected keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:example-supply-chain": "node ./examples/supply-chain-app/node_modules/.bin/cactus-example-supply-chain-backend",
     "export-open-api-spec": "ts-node -e 'import(\"./packages/cactus-cmd-api-server/src/main/typescript/openapi-spec\").then((x) => x.exportToFileSystemAsJson());'",
     "pregenerate-sdk": "npm-run-all export-open-api-spec",
-    "generate-sdk": "openapi-generator generate --input-spec cactus-openapi-spec.json -g typescript-axios -o packages/cactus-api-client/src/main/typescript/generated/openapi/typescript-axios/",
+    "generate-sdk": "openapi-generator generate --input-spec cactus-openapi-spec.json -g typescript-axios -o packages/cactus-api-client/src/main/typescript/generated/openapi/typescript-axios/ --reserved-words-mappings protected=protected",
     "clean": "lerna exec --stream --ignore '*/*cockpit' -- del-cli dist/** && del-cli packages/cactus-api-client/src/main/typescript/generated/openapi/typescript-axios/*",
     "lint": "lerna exec --stream --ignore '*/*cockpit' -- cross-env DEBUG= tslint --project tsconfig.json",
     "tsc": "lerna run tsc",

--- a/packages/cactus-core-api/package.json
+++ b/packages/cactus-core-api/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "export-open-api-spec": "ts-node src/main/typescript/openapi-spec.ts",
     "pregenerate-sdk": "npm-run-all export-open-api-spec",
-    "generate-sdk": "openapi-generator generate --input-spec src/main/json/generated/openapi-spec.json -g typescript-axios -o ./src/main/typescript/generated/openapi/typescript-axios/",
+    "generate-sdk": "openapi-generator generate --input-spec src/main/json/generated/openapi-spec.json -g typescript-axios -o ./src/main/typescript/generated/openapi/typescript-axios/ --reserved-words-mappings protected=protected",
     "pretsc": "npm run generate-sdk",
     "tsc": "tsc --project ./tsconfig.json",
     "webpack": "npm-run-all webpack:dev webpack:prod",

--- a/packages/cactus-core-api/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-core-api/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -235,7 +235,7 @@ export interface JWSRecipient {
      * @type {string}
      * @memberof JWSRecipient
      */
-    _protected?: string;
+    protected?: string;
     /**
      * 
      * @type {{ [key: string]: object; }}

--- a/packages/cactus-core-api/src/main/typescript/openapi-spec.ts
+++ b/packages/cactus-core-api/src/main/typescript/openapi-spec.ts
@@ -278,9 +278,6 @@ export const CACTUS_OPEN_API_JSON: OpenAPIV3.Document = {
           signature: {
             type: "string",
           },
-          // In the generated models this shows up as _protected because it is
-          // a reserved keyword in Typescript. Opened an issue here about  this:
-          // https://github.com/OpenAPITools/openapi-generator/issues/7100
           protected: {
             type: "string",
           },

--- a/packages/cactus-plugin-consortium-manual/package.json
+++ b/packages/cactus-plugin-consortium-manual/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "export-open-api-spec": "ts-node src/main/typescript/openapi-spec.ts",
     "pregenerate-sdk": "npm-run-all export-open-api-spec",
-    "generate-sdk": "openapi-generator generate --input-spec src/main/json/generated/openapi-spec.json -g typescript-axios -o ./src/main/typescript/generated/openapi/typescript-axios/",
+    "generate-sdk": "openapi-generator generate --input-spec src/main/json/generated/openapi-spec.json -g typescript-axios -o ./src/main/typescript/generated/openapi/typescript-axios/ --reserved-words-mappings protected=protected",
     "tsc": "tsc --project ./tsconfig.json",
     "pretsc": "npm run generate-sdk",
     "webpack": "npm-run-all webpack:dev webpack:prod",

--- a/packages/cactus-plugin-consortium-manual/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-consortium-manual/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -81,7 +81,7 @@ export interface JWSRecipient {
      * @type {string}
      * @memberof JWSRecipient
      */
-    _protected?: string;
+    protected?: string;
     /**
      * 
      * @type {{ [key: string]: object; }}

--- a/packages/cactus-plugin-ledger-connector-besu/package.json
+++ b/packages/cactus-plugin-ledger-connector-besu/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "export-open-api-spec": "ts-node src/main/typescript/openapi-spec.ts",
     "pregenerate-sdk": "npm-run-all export-open-api-spec",
-    "generate-sdk": "openapi-generator generate --input-spec src/main/json/generated/openapi-spec.json -g typescript-axios -o ./src/main/typescript/generated/openapi/typescript-axios/",
+    "generate-sdk": "openapi-generator generate --input-spec src/main/json/generated/openapi-spec.json -g typescript-axios -o ./src/main/typescript/generated/openapi/typescript-axios/ --reserved-words-mappings protected=protected",
     "pretsc": "npm run generate-sdk",
     "tsc": "tsc --project ./tsconfig.json",
     "webpack": "npm-run-all webpack:dev webpack:prod",

--- a/packages/cactus-plugin-ledger-connector-fabric/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "export-open-api-spec": "ts-node -e 'import(\"./src/main/typescript/openapi-spec\").then((x) => x.exportToFileSystemAsJson());'",
     "pregenerate-sdk": "npm-run-all export-open-api-spec",
-    "generate-sdk": "openapi-generator generate --input-spec src/main/json/generated/openapi-spec.json -g typescript-axios -o ./src/main/typescript/generated/openapi/typescript-axios/",
+    "generate-sdk": "openapi-generator generate --input-spec src/main/json/generated/openapi-spec.json -g typescript-axios -o ./src/main/typescript/generated/openapi/typescript-axios/ --reserved-words-mappings protected=protected",
     "pretsc": "npm run generate-sdk",
     "tsc": "tsc --project ./tsconfig.json",
     "webpack": "npm-run-all webpack:dev webpack:prod",

--- a/packages/cactus-plugin-ledger-connector-quorum/package.json
+++ b/packages/cactus-plugin-ledger-connector-quorum/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "export-open-api-spec": "ts-node ./src/main/typescript/openapi-spec.ts",
     "pregenerate-sdk": "npm-run-all export-open-api-spec",
-    "generate-sdk": "openapi-generator generate --input-spec cactus-openapi-spec-plugin-ledger-connector-quorum.json -g typescript-axios -o ./src/main/typescript/generated/openapi/typescript-axios/",
+    "generate-sdk": "openapi-generator generate --input-spec cactus-openapi-spec-plugin-ledger-connector-quorum.json -g typescript-axios -o ./src/main/typescript/generated/openapi/typescript-axios/ --reserved-words-mappings protected=protected",
     "pretsc": "npm run generate-sdk",
     "tsc": "tsc --project ./tsconfig.json",
     "webpack": "npm-run-all webpack:dev webpack:prod",


### PR DESCRIPTION
This changes makes it so that model properties named `protected` will
no longer get mangled by the OpenAPI generator into `_protected`.
This is needed so that our generated models can be compliant with the
JWS RFC [1]

Since `protected` is only a softly reserved keyword, this means that
you can still declare classes/interfaces with fields that are called
`protected` which is what we need since the RFC mentioned above
declares exactly that for JWS recipients.

[1]: https://tools.ietf.org/html/rfc7515

Fixes #436

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>