### PR TITLE
fix(common): servers.listen() port validation

### DIFF
--- a/packages/cactus-common/src/main/typescript/servers.ts
+++ b/packages/cactus-common/src/main/typescript/servers.ts
@@ -38,7 +38,7 @@ export class Servers {
     });
   }
 
-  public static async listen(options: IListenOptions): Promise<any> {
+  public static async listen(options: IListenOptions): Promise<AddressInfo> {
     const fnTag = "Servers#listen()";
 
     Checks.truthy(options, `${fnTag} arg options`);
@@ -47,6 +47,12 @@ export class Servers {
       options.port || options.port === 0,
       `${fnTag} arg options.port`
     );
+    Checks.truthy(
+      typeof options.port === "number",
+      `${fnTag} arg options.port is number`
+    );
+    Checks.truthy(isFinite(options.port), `${fnTag} arg finite options.port`);
+    Checks.truthy(options.port > -1, `${fnTag} arg positive options.port`);
     Checks.truthy(options.hostname, `${fnTag} arg options.hostname`);
     const { server, port, hostname } = options;
 


### PR DESCRIPTION
Adds more type assertions to check if the
provided port number is indeed a finite,
positive integer.

Fixes #491 

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>
(cherry picked from commit 3b16aeb4ba0932c52766fcd365fe14b7319bbed2)
Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>