### PR TITLE
chore(deps): fabric connector upgrade bl

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/package-lock.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/package-lock.json
@@ -383,9 +383,9 @@
 			}
 		},
 		"bl": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+			"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
 			"requires": {
 				"readable-stream": "^2.3.5",
 				"safe-buffer": "^5.1.1"

--- a/packages/cactus-plugin-ledger-connector-fabric/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/package.json
@@ -83,6 +83,7 @@
     "@hyperledger/cactus-common": "0.3.0",
     "@hyperledger/cactus-core": "0.3.0",
     "@hyperledger/cactus-core-api": "0.3.0",
+    "bl": "1.2.3",
     "express": "4.17.1",
     "express-openapi-validator": "3.16.11",
     "fabric-client": "1.4.13",


### PR DESCRIPTION
Fixes #498 

```sh
commit 5431c4708e842fb4c8384882bd4d5e02f7bef045
Author: Peter Somogyvari <peter.somogyvari@accenture.com>
Date:   Fri Jan 15 11:44:33 2021 -0800

    chore(deps): specify explicit bl version 1.2.3 in fabric plugin
    
    This is necessary so that we can resolve the issue of us
    being susceptible to this CVE:
    
    https://github.com/advisories/GHSA-pp7h-53gx-mx7r
    
    Fixes #498
    
    Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

```

Depends on #506 