### PR TITLE
build(deps): upgrade axios to 0.21.1 due to high severity CVE #449

### DIFF
--- a/packages/cactus-plugin-ledger-connector-besu/package-lock.json
+++ b/packages/cactus-plugin-ledger-connector-besu/package-lock.json
@@ -230,9 +230,9 @@
 			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
 		},
 		"axios": {
-			"version": "0.20.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-			"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+			"version": "0.21.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+			"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
 			"requires": {
 				"follow-redirects": "^1.10.0"
 			}
@@ -1228,9 +1228,9 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-			"integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+			"integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
 		},
 		"forever-agent": {
 			"version": "0.6.1",

--- a/packages/cactus-plugin-ledger-connector-besu/package.json
+++ b/packages/cactus-plugin-ledger-connector-besu/package.json
@@ -83,7 +83,7 @@
     "@hyperledger/cactus-common": "0.3.0",
     "@hyperledger/cactus-core": "0.3.0",
     "@hyperledger/cactus-core-api": "0.3.0",
-    "axios": "0.20.0",
+    "axios": "0.21.1",
     "express": "4.17.1",
     "joi": "14.3.1",
     "openapi-types": "7.0.1",

--- a/packages/cactus-plugin-ledger-connector-fabric/package-lock.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/package-lock.json
@@ -327,9 +327,9 @@
 			"integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
 		},
 		"axios": {
-			"version": "0.20.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-			"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+			"version": "0.21.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+			"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
 			"dev": true,
 			"requires": {
 				"follow-redirects": "^1.10.0"
@@ -1829,9 +1829,9 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-			"integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+			"integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
 		},
 		"forever-agent": {
 			"version": "0.6.1",

--- a/packages/cactus-plugin-ledger-connector-fabric/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/package.json
@@ -109,7 +109,7 @@
     "@types/ssh2": "0.5.44",
     "@types/temp": "0.8.34",
     "@types/uuid": "8.3.0",
-    "axios": "0.20.0",
+    "axios": "0.21.1",
     "form-data": "3.0.0"
   }
 }

--- a/packages/cactus-plugin-ledger-connector-quorum/package-lock.json
+++ b/packages/cactus-plugin-ledger-connector-quorum/package-lock.json
@@ -322,9 +322,9 @@
 			"integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
 		},
 		"axios": {
-			"version": "0.20.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-			"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+			"version": "0.21.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+			"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
 			"requires": {
 				"follow-redirects": "^1.10.0"
 			}
@@ -1102,9 +1102,9 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-			"integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+			"integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
 		},
 		"forever-agent": {
 			"version": "0.6.1",

--- a/packages/cactus-plugin-ledger-connector-quorum/package.json
+++ b/packages/cactus-plugin-ledger-connector-quorum/package.json
@@ -83,7 +83,7 @@
     "@hyperledger/cactus-common": "0.3.0",
     "@hyperledger/cactus-core": "0.3.0",
     "@hyperledger/cactus-core-api": "0.3.0",
-    "axios": "0.20.0",
+    "axios": "0.21.1",
     "express": "4.17.1",
     "joi": "14.3.1",
     "openapi-types": "7.0.1",


### PR DESCRIPTION
The previous commit attempting to do the same thing
somehow did not achieve the expected outcome meaning
that there were still leftovers of other versions of axios.

For reference: CVE-2020-28168

Fixes #449

Depends on #506 #507

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>