### PR TITLE
chore(linter): enable no-unused-vars error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,13 +15,10 @@ module.exports = {
     "no-prototype-builtins": "error",
     "@typescript-eslint/no-var-requires": "warn",
     "no-dupe-class-members": "off",
-    "no-unused-vars": [
-      "warn",
-      {
-        vars: "all",
-        args: "after-used",
-        ignoreRestSiblings: false,
-      },
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { ignoreRestSiblings: true },
     ],
     indent: ["off"],
     semi: ["error", "always"],

--- a/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
+++ b/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
@@ -32,7 +32,6 @@ import {
   PluginLedgerConnectorQuorum,
   Web3SigningCredentialType,
   DefaultApi as QuorumApi,
-  EthContractInvocationType,
 } from "@hyperledger/cactus-plugin-ledger-connector-quorum";
 
 import {
@@ -41,10 +40,7 @@ import {
 } from "@hyperledger/cactus-plugin-ledger-connector-besu";
 
 import { SupplyChainAppDummyInfrastructure } from "./infrastructure/supply-chain-app-dummy-infrastructure";
-import {
-  BambooHarvest,
-  SupplyChainCactusPlugin,
-} from "@hyperledger/cactus-example-supply-chain-business-logic-plugin";
+import { SupplyChainCactusPlugin } from "@hyperledger/cactus-example-supply-chain-business-logic-plugin";
 
 export interface ISupplyChainAppOptions {
   logLevel?: LogLevelDesc;

--- a/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/insert-bamboo-harvest-endpoint.ts
+++ b/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/insert-bamboo-harvest-endpoint.ts
@@ -1,4 +1,4 @@
-import { Express, Request, Response, NextFunction } from "express";
+import { Express, Request, Response } from "express";
 
 import {
   Logger,
@@ -39,7 +39,7 @@ export class InsertBambooHarvestEndpoint implements IWebServiceEndpoint {
 
   private readonly log: Logger;
 
-  public get className() {
+  public get className(): string {
     return InsertBambooHarvestEndpoint.CLASS_NAME;
   }
 
@@ -76,11 +76,7 @@ export class InsertBambooHarvestEndpoint implements IWebServiceEndpoint {
     return this.handleRequest.bind(this);
   }
 
-  async handleRequest(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> {
+  async handleRequest(req: Request, res: Response): Promise<void> {
     const tag = `${this.getVerbLowerCase().toUpperCase()} ${this.getPath()}`;
     try {
       const { bambooHarvest } = req.body as InsertBambooHarvestRequest;

--- a/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/insert-bookshelf-endpoint.ts
+++ b/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/insert-bookshelf-endpoint.ts
@@ -1,4 +1,4 @@
-import { Express, Request, Response, NextFunction } from "express";
+import { Express, Request, Response } from "express";
 
 import {
   Logger,
@@ -39,7 +39,7 @@ export class InsertBookshelfEndpoint implements IWebServiceEndpoint {
 
   private readonly log: Logger;
 
-  public get className() {
+  public get className(): string {
     return InsertBookshelfEndpoint.CLASS_NAME;
   }
 
@@ -76,11 +76,7 @@ export class InsertBookshelfEndpoint implements IWebServiceEndpoint {
     return this.handleRequest.bind(this);
   }
 
-  async handleRequest(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> {
+  async handleRequest(req: Request, res: Response): Promise<void> {
     const tag = `${this.getVerbLowerCase().toUpperCase()} ${this.getPath()}`;
     try {
       const { bookshelf } = req.body as InsertBookshelfRequest;

--- a/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/list-bamboo-harvest-endpoint.ts
+++ b/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/list-bamboo-harvest-endpoint.ts
@@ -1,4 +1,4 @@
-import { Express, Request, Response, NextFunction } from "express";
+import { Express, Request, Response } from "express";
 
 import {
   Logger,
@@ -75,11 +75,7 @@ export class ListBambooHarvestEndpoint implements IWebServiceEndpoint {
     return this.handleRequest.bind(this);
   }
 
-  async handleRequest(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> {
+  async handleRequest(req: Request, res: Response): Promise<void> {
     const tag = `${this.getVerbLowerCase().toUpperCase()} ${this.getPath()}`;
     try {
       this.log.debug(`${tag}`);

--- a/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/list-bookshelf-endpoint.ts
+++ b/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/list-bookshelf-endpoint.ts
@@ -1,4 +1,4 @@
-import { Express, Request, Response, NextFunction } from "express";
+import { Express, Request, Response } from "express";
 
 import {
   Logger,
@@ -38,7 +38,7 @@ export class ListBookshelfEndpoint implements IWebServiceEndpoint {
 
   private readonly log: Logger;
 
-  public get className() {
+  public get className(): string {
     return ListBookshelfEndpoint.CLASS_NAME;
   }
 
@@ -75,11 +75,7 @@ export class ListBookshelfEndpoint implements IWebServiceEndpoint {
     return this.handleRequest.bind(this);
   }
 
-  async handleRequest(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> {
+  async handleRequest(req: Request, res: Response): Promise<void> {
     const tag = `${this.getVerbLowerCase().toUpperCase()} ${this.getPath()}`;
     try {
       this.log.debug(`${tag}`);

--- a/examples/cactus-example-supply-chain-frontend/src/app/app.component.ts
+++ b/examples/cactus-example-supply-chain-frontend/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from "@angular/core";
+import { Component } from "@angular/core";
 
 import { Platform } from "@ionic/angular";
 import { SplashScreen } from "@ionic-native/splash-screen/ngx";

--- a/examples/cactus-example-supply-chain-frontend/src/app/bamboo-harvest/bamboo-harvest-detail/bamboo-harvest-detail.page.ts
+++ b/examples/cactus-example-supply-chain-frontend/src/app/bamboo-harvest/bamboo-harvest-detail/bamboo-harvest-detail.page.ts
@@ -5,10 +5,7 @@ import { FormGroup, FormBuilder, Validators } from "@angular/forms";
 import { ModalController } from "@ionic/angular";
 
 import { ApiClient } from "@hyperledger/cactus-api-client";
-import {
-  BambooHarvest,
-  DefaultApi as SupplyChainApi,
-} from "@hyperledger/cactus-example-supply-chain-business-logic-plugin";
+import { BambooHarvest } from "@hyperledger/cactus-example-supply-chain-business-logic-plugin";
 
 import { QUORUM_DEMO_LEDGER_ID } from "../../../constants";
 import { Logger, LoggerProvider } from "@hyperledger/cactus-common";
@@ -55,13 +52,13 @@ export class BambooHarvestDetailPage implements OnInit {
     });
   }
 
-  onClickFormSubmit(value: any) {
+  public onClickFormSubmit(value: any): void {
     this.log.debug("form submitted", value);
     this.bambooHarvest = value;
     this.modalController.dismiss(this.bambooHarvest);
   }
 
-  onClickBtnCancel() {
+  public onClickBtnCancel(): void {
     this.log.debug("form submission cancelled by user");
     this.modalController.dismiss();
   }

--- a/examples/cactus-example-supply-chain-frontend/src/app/bamboo-harvest/bamboo-harvest-list/bamboo-harvest-list.page.ts
+++ b/examples/cactus-example-supply-chain-frontend/src/app/bamboo-harvest/bamboo-harvest-list/bamboo-harvest-list.page.ts
@@ -1,7 +1,5 @@
 import { Component, Inject, OnInit } from "@angular/core";
 
-import { v4 as uuidv4 } from "uuid";
-
 import { Logger, LoggerProvider } from "@hyperledger/cactus-common";
 import { ApiClient } from "@hyperledger/cactus-api-client";
 import {

--- a/packages/cactus-cmd-api-server/src/main/typescript/cmd/cactus-api.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/cmd/cactus-api.ts
@@ -27,7 +27,7 @@ const main = async () => {
   }
 };
 
-export async function launchApp(cliOpts?: any): Promise<void> {
+export async function launchApp(): Promise<void> {
   try {
     await main();
     log.info(`Cactus API server launched OK `);

--- a/packages/cactus-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
@@ -1,8 +1,6 @@
 import test, { Test } from "tape-promise/tape";
 import { v4 as uuidv4 } from "uuid";
 
-import { LogLevelDesc } from "@hyperledger/cactus-common";
-
 import { ApiServer, ConfigService } from "../../../main/typescript/public-api";
 
 import {

--- a/packages/cactus-cmd-api-server/src/test/typescript/unit/config/self-signed-certificate-generator/certificates-work-for-mutual-tls-test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/unit/config/self-signed-certificate-generator/certificates-work-for-mutual-tls-test.ts
@@ -79,6 +79,7 @@ tap.test("works with HTTPS NodeJS module", async (assert: any) => {
       ),
     );
 
+    aServer.once("tlsClientError", (err: Error) => reject(err));
     aServer.once("listening", () => resolve(aServer));
     aServer.listen(0, "localhost");
     assert.tearDown(() => aServer.close());

--- a/packages/cactus-cockpit/src/app/app.component.ts
+++ b/packages/cactus-cockpit/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Inject } from "@angular/core";
+import { Component, Inject } from "@angular/core";
 
 import { Platform } from "@ionic/angular";
 import { SplashScreen } from "@ionic-native/splash-screen/ngx";

--- a/packages/cactus-cockpit/src/app/app.module.ts
+++ b/packages/cactus-cockpit/src/app/app.module.ts
@@ -1,7 +1,6 @@
 import "@angular/compiler";
-import { NgModule, APP_INITIALIZER, InjectionToken } from "@angular/core";
+import { NgModule } from "@angular/core";
 
-import { HttpClientModule } from "@angular/common/http";
 import { BrowserModule } from "@angular/platform-browser";
 import { RouteReuseStrategy } from "@angular/router";
 

--- a/packages/cactus-common/src/main/typescript/logging/logger.ts
+++ b/packages/cactus-common/src/main/typescript/logging/logger.ts
@@ -1,8 +1,4 @@
-import libLogLevel, {
-  Logger as LogLevelLogger,
-  levels,
-  LogLevelDesc,
-} from "loglevel";
+import libLogLevel, { Logger as LogLevelLogger, LogLevelDesc } from "loglevel";
 import prefix from "loglevel-plugin-prefix";
 
 prefix.reg(libLogLevel);
@@ -46,7 +42,7 @@ export class Logger {
     this.backend.setLevel(logLevel);
   }
 
-  public async shutdown(gracePeriodMillis = 60000): Promise<void> {
+  public async shutdown(): Promise<void> {
     this.backend.info("Shut down logger OK.");
   }
 

--- a/packages/cactus-common/src/test/typescript/unit/js-object-signer.test.ts
+++ b/packages/cactus-common/src/test/typescript/unit/js-object-signer.test.ts
@@ -117,8 +117,6 @@ test("Circular JSON Test", async (assert: Test) => {
   };
   const jsObjectSigner = new JsObjectSigner(jsObjectSignerOptions);
 
-  const date: Date = new Date();
-
   const obj: any = { a: "foo" };
   obj.b = obj;
 
@@ -209,8 +207,7 @@ test("Test missing required constructor field", async (assert: Test) => {
     const jsObjectSignerOptions: IJsObjectSignerOptions = {
       privateKey: undefined,
     };
-
-    const jsObjectSigner = new JsObjectSigner(jsObjectSignerOptions);
+    new JsObjectSigner(jsObjectSignerOptions);
   } catch (e) {
     assert.equal(e.message, "JsObjectSigner#ctor options.privateKey falsy.");
   }

--- a/packages/cactus-core-api/src/main/typescript/plugin/keychain/i-plugin-keychain.ts
+++ b/packages/cactus-core-api/src/main/typescript/plugin/keychain/i-plugin-keychain.ts
@@ -19,5 +19,5 @@ export interface IPluginKeychain extends ICactusPlugin {
   has(key: string): Promise<boolean>;
   get<T>(key: string): Promise<T>;
   set<T>(key: string, value: T): Promise<void>;
-  delete<T>(key: string): Promise<void>;
+  delete(key: string): Promise<void>;
 }

--- a/packages/cactus-plugin-consortium-manual/src/main/typescript/consortium/get-consortium-jws-endpoint-v1.ts
+++ b/packages/cactus-plugin-consortium-manual/src/main/typescript/consortium/get-consortium-jws-endpoint-v1.ts
@@ -1,5 +1,4 @@
-import { Express, Request, Response, NextFunction } from "express";
-import { AxiosResponse } from "axios";
+import { Express, Request, Response } from "express";
 
 import {
   IWebServiceEndpoint,
@@ -11,7 +10,6 @@ import {
 import {
   Configuration,
   DefaultApi,
-  GetNodeJwsResponse,
 } from "../generated/openapi/typescript-axios";
 
 import {
@@ -80,11 +78,7 @@ export class GetConsortiumEndpointV1 implements IWebServiceEndpoint {
     return this;
   }
 
-  async handleRequest(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> {
+  async handleRequest(req: Request, res: Response): Promise<void> {
     const fnTag = "GetConsortiumJwsEndpointV1#handleRequest()";
     this.log.debug(`GET ${this.getPath()}`);
 

--- a/packages/cactus-plugin-consortium-manual/src/main/typescript/consortium/get-node-jws-endpoint-v1.ts
+++ b/packages/cactus-plugin-consortium-manual/src/main/typescript/consortium/get-node-jws-endpoint-v1.ts
@@ -1,5 +1,5 @@
 import uuid from "uuid";
-import { Express, Request, Response, NextFunction } from "express";
+import { Express, Request, Response } from "express";
 import { JWS, JWK } from "jose";
 import jsonStableStringify from "json-stable-stringify";
 
@@ -77,11 +77,7 @@ export class GetNodeJwsEndpoint implements IWebServiceEndpoint {
     return this;
   }
 
-  async handleRequest(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> {
+  async handleRequest(req: Request, res: Response): Promise<void> {
     try {
       this.log.debug(`GET ${this.getPath()}`);
 

--- a/packages/cactus-plugin-consortium-manual/src/main/typescript/plugin-consortium-manual.ts
+++ b/packages/cactus-plugin-consortium-manual/src/main/typescript/plugin-consortium-manual.ts
@@ -14,11 +14,7 @@ import {
   ICactusPluginOptions,
 } from "@hyperledger/cactus-core-api";
 
-import {
-  PluginRegistry,
-  IConsortiumRepositoryOptions,
-  ConsortiumRepository,
-} from "@hyperledger/cactus-core";
+import { PluginRegistry, ConsortiumRepository } from "@hyperledger/cactus-core";
 
 import {
   Checks,
@@ -82,7 +78,7 @@ export class PluginConsortiumManual
   }
 
   public async installWebServices(
-    expressApp: any,
+    expressApp: Express,
   ): Promise<IWebServiceEndpoint[]> {
     const { log } = this;
 
@@ -113,7 +109,6 @@ export class PluginConsortiumManual
     }
 
     const { consortiumDatabase, keyPairPem } = this.options;
-    const packageName = this.getPackageName();
     const consortiumRepo = new ConsortiumRepository({
       db: consortiumDatabase,
     });

--- a/packages/cactus-plugin-consortium-manual/src/test/typescript/unit/consortium/get-node-jws-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-consortium-manual/src/test/typescript/unit/consortium/get-node-jws-endpoint-v1.test.ts
@@ -1,13 +1,7 @@
 import test, { Test } from "tape";
 import { JWS, JWK } from "jose";
-import { v4 as uuidV4 } from "uuid";
 
-import {
-  CactusNode,
-  Consortium,
-  ConsortiumDatabase,
-  ConsortiumMember,
-} from "@hyperledger/cactus-core-api";
+import { ConsortiumDatabase } from "@hyperledger/cactus-core-api";
 
 import { ConsortiumRepository } from "@hyperledger/cactus-core";
 
@@ -21,34 +15,6 @@ test("Can provide JWS", async (t: Test) => {
 
   const keyPair = await JWK.generate("EC", "secp256k1", { use: "sig" }, true);
   const keyPairPem = keyPair.toPEM(true);
-
-  const consortiumName = "Example Corp. & Friends Crypto Consortium";
-  const consortiumId = uuidV4();
-  const memberId = uuidV4();
-  const nodeId = uuidV4();
-
-  const cactusNode: CactusNode = {
-    nodeApiHost: "http://127.0.0.1:80",
-    memberId,
-    publicKeyPem: keyPair.toPEM(false),
-    consortiumId,
-    id: nodeId,
-    pluginInstanceIds: [],
-    ledgerIds: [],
-  };
-
-  const member: ConsortiumMember = {
-    id: memberId,
-    nodeIds: [cactusNode.id],
-    name: "Example Corp",
-  };
-
-  const consortium: Consortium = {
-    id: consortiumId,
-    name: consortiumName,
-    mainApiHost: "http://127.0.0.1:80",
-    memberIds: [member.id],
-  };
 
   const db: ConsortiumDatabase = {
     cactusNode: [],
@@ -74,7 +40,9 @@ test("Can provide JWS", async (t: Test) => {
   t.doesNotThrow(() => JWS.verify(jws, pubKeyPem), "JWS verified OK");
   t.doesNotThrow(() => JWS.verify(jws, keyPair), "JWS verified OK");
 
-  const payload = JWS.verify(jws, pubKeyPem) as any;
+  const payload = JWS.verify(jws, pubKeyPem) as {
+    consortiumDatabase: ConsortiumDatabase;
+  };
   t.ok(payload, "JWS verified payload truthy");
   if (typeof payload === "string") {
     t.fail(`JWS Verification result: ${payload}`);

--- a/packages/cactus-plugin-keychain-memory/src/main/typescript/plugin-keychain-memory.ts
+++ b/packages/cactus-plugin-keychain-memory/src/main/typescript/plugin-keychain-memory.ts
@@ -22,7 +22,7 @@ export class PluginKeychainMemory {
   private readonly log: Logger;
   private readonly instanceId: string;
 
-  public get className() {
+  public get className(): string {
     return PluginKeychainMemory.CLASS_NAME;
   }
 
@@ -77,7 +77,7 @@ export class PluginKeychainMemory {
     this.backend.set(key, value);
   }
 
-  async delete<T>(key: string): Promise<void> {
+  async delete(key: string): Promise<void> {
     this.backend.delete(key);
   }
 }

--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/plugin-keychain-vault-remote-adapter.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/plugin-keychain-vault-remote-adapter.ts
@@ -1,7 +1,6 @@
 import { Server } from "http";
 import { Server as SecureServer } from "https";
 
-import { Express } from "express";
 import { Optional } from "typescript-optional";
 
 import {
@@ -45,7 +44,7 @@ export class PluginKeychainVaultRemoteAdapter
   private readonly log: Logger;
   private readonly backend: DefaultApi;
 
-  public get className() {
+  public get className(): string {
     return PluginKeychainVaultRemoteAdapter.CLASS_NAME;
   }
 
@@ -80,9 +79,7 @@ export class PluginKeychainVaultRemoteAdapter
    *
    * @param _expressApp
    */
-  public async installWebServices(
-    _expressApp: Express,
-  ): Promise<IWebServiceEndpoint[]> {
+  public async installWebServices(): Promise<IWebServiceEndpoint[]> {
     return [];
   }
 
@@ -130,7 +127,7 @@ export class PluginKeychainVaultRemoteAdapter
     await this.backend.setKeychainEntry({ key, value: value as any });
   }
 
-  public async delete<T>(key: string): Promise<void> {
+  public async delete(key: string): Promise<void> {
     // FIXME Pretty sure vault can do delete so we don't have to hack it like this
     // but it cannot be done in this code until the rust code has been updated
     // to have that endpoint as well...

--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/plugin-keychain-vault.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/plugin-keychain-vault.ts
@@ -153,7 +153,7 @@ export class PluginKeychainVault implements ICactusPlugin, IPluginWebService {
     await this.backend.write(key, value);
   }
 
-  async delete<T>(key: string): Promise<void> {
+  async delete(key: string): Promise<void> {
     await this.backend.delete(key);
   }
 }

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/web-services/deploy-contract-solidity-bytecode-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/web-services/deploy-contract-solidity-bytecode-endpoint.ts
@@ -1,4 +1,4 @@
-import { Express, Request, Response, NextFunction } from "express";
+import { Express, Request, Response } from "express";
 
 import {
   IWebServiceEndpoint,
@@ -60,11 +60,7 @@ export class DeployContractSolidityBytecodeEndpoint
     return this.handleRequest.bind(this);
   }
 
-  public async handleRequest(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> {
+  public async handleRequest(req: Request, res: Response): Promise<void> {
     const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
     this.log.debug(reqTag);
     const reqBody: DeployContractSolidityBytecodeV1Request = req.body;

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/web-services/invoke-contract-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/web-services/invoke-contract-endpoint.ts
@@ -1,4 +1,4 @@
-import { Express, Request, Response, NextFunction } from "express";
+import { Express, Request, Response } from "express";
 
 import {
   Logger,
@@ -26,7 +26,7 @@ export class InvokeContractEndpoint implements IWebServiceEndpoint {
 
   private readonly log: Logger;
 
-  public get className() {
+  public get className(): string {
     return InvokeContractEndpoint.CLASS_NAME;
   }
 
@@ -57,11 +57,7 @@ export class InvokeContractEndpoint implements IWebServiceEndpoint {
     return this.handleRequest.bind(this);
   }
 
-  public async handleRequest(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> {
+  public async handleRequest(req: Request, res: Response): Promise<void> {
     const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
     this.log.debug(reqTag);
     const reqBody = req.body;

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/web-services/run-transaction-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/web-services/run-transaction-endpoint.ts
@@ -1,4 +1,4 @@
-import { Express, Request, Response, NextFunction } from "express";
+import { Express, Request, Response } from "express";
 
 import {
   Logger,
@@ -26,7 +26,7 @@ export class RunTransactionEndpoint implements IWebServiceEndpoint {
 
   private readonly log: Logger;
 
-  public get className() {
+  public get className(): string {
     return RunTransactionEndpoint.CLASS_NAME;
   }
 
@@ -57,11 +57,7 @@ export class RunTransactionEndpoint implements IWebServiceEndpoint {
     return this.handleRequest.bind(this);
   }
 
-  public async handleRequest(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> {
+  public async handleRequest(req: Request, res: Response): Promise<void> {
     const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
     this.log.debug(reqTag);
     const reqBody = req.body;

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/web-services/sign-transaction-endpoint-v1.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/web-services/sign-transaction-endpoint-v1.ts
@@ -1,6 +1,4 @@
 import { Express, Request, Response } from "express";
-import { Optional } from "typescript-optional";
-import Web3 from "web3";
 
 import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";
 
@@ -13,17 +11,10 @@ import {
   LogLevelDesc,
   Logger,
   LoggerProvider,
-  JsObjectSigner,
-  IJsObjectSignerOptions,
-  KeyConverter,
-  KeyFormat,
   Checks,
 } from "@hyperledger/cactus-common";
 
-import {
-  SignTransactionRequest,
-  SignTransactionResponse,
-} from "../generated/openapi/typescript-axios/api";
+import { SignTransactionRequest } from "../generated/openapi/typescript-axios/api";
 
 import { BesuSignTransactionEndpointV1 as Constants } from "./sign-transaction-endpoint-constants";
 import { PluginLedgerConnectorBesu } from "../plugin-ledger-connector-besu";

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/chain-code-compiler.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/chain-code-compiler.ts
@@ -140,17 +140,19 @@ export class ChainCodeCompiler {
         Checks.truthy(proc.exitCode === 0, `0 exit code of go mod tidy`);
       }
 
-      {
-        const cmdArgs = ["mod", "vendor"];
-        const proc = await ngo(cmdArgs, { cwd: dirPath });
-        Checks.truthy(proc.exitCode === 0, `0 exit code of go mod vendor`);
-      }
+      if (!modTidyOnly) {
+        {
+          const cmdArgs = ["mod", "vendor"];
+          const proc = await ngo(cmdArgs, { cwd: dirPath });
+          Checks.truthy(proc.exitCode === 0, `0 exit code of go mod vendor`);
+        }
 
-      {
-        this.log.debug(`Running go process...`);
-        const proc = await ngo(["build"], { cwd: dirPath });
-        Checks.truthy(proc.exitCode === 0, `0 exit code of go build`);
-        this.log.debug(`Ran go process OK %o`, proc);
+        {
+          this.log.debug(`Running go process...`);
+          const proc = await ngo(["build"], { cwd: dirPath });
+          Checks.truthy(proc.exitCode === 0, `0 exit code of go build`);
+          this.log.debug(`Ran go process OK %o`, proc);
+        }
       }
 
       const binaryPath = path.join(dirPath, options.moduleName);

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/plugin-ledger-connector-fabric.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/plugin-ledger-connector-fabric.ts
@@ -1,12 +1,12 @@
 import { Server } from "http";
 import { Server as SecureServer } from "https";
+import { Express } from "express";
 
 import "multer";
 import { Config as SshConfig } from "node-ssh";
 import {
   DefaultEventHandlerOptions,
   DefaultEventHandlerStrategies,
-  DiscoveryOptions,
   Gateway,
   GatewayOptions,
   InMemoryWallet,
@@ -79,7 +79,7 @@ export class PluginLedgerConnectorFabric
   private readonly instanceId: string;
   private readonly log: Logger;
 
-  public get className() {
+  public get className(): string {
     return PluginLedgerConnectorFabric.CLASS_NAME;
   }
 
@@ -133,11 +133,11 @@ export class PluginLedgerConnectorFabric
     req: DeployContractGoSourceV1Request,
   ): Promise<DeployContractGoSourceV1Response> {
     const fnTag = "PluginLedgerConnectorFabric#deployContract()";
-    throw new Error(`${fnTag} Not yet implemented!`);
+    throw new Error(`${fnTag} Not yet implemented! ${req}`);
   }
 
   public async installWebServices(
-    expressApp: any,
+    expressApp: Express,
   ): Promise<IWebServiceEndpoint[]> {
     const { log } = this;
 

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/run-transaction/run-transaction-endpoint-v1.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/run-transaction/run-transaction-endpoint-v1.ts
@@ -10,7 +10,6 @@ import {
 import {
   IWebServiceEndpoint,
   IExpressRequestHandler,
-  IPluginKeychain,
 } from "@hyperledger/cactus-core-api";
 
 import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/deploy-contract-go-bin-endpoint-v1/deploy-contract/deploy-cc-from-golang-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/deploy-contract-go-bin-endpoint-v1/deploy-contract/deploy-cc-from-golang-source.test.ts
@@ -66,7 +66,7 @@ test.skip("deploys contract from go source", async (t: Test) => {
     server,
   };
   const addressInfo = (await Servers.listen(listenOptions)) as AddressInfo;
-  const { address, port } = addressInfo;
+  const { port } = addressInfo;
   test.onFinish(async () => await Servers.shutdown(server));
 
   const [endpoint] = await plugin.installWebServices(expressApp);

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts
@@ -58,7 +58,8 @@ test("runs tx on a Fabric v1.4.8 ledger", async (t: Test) => {
   };
   test.onFinish(tearDownLedger);
 
-  const [_, adminWallet] = await ledger.enrollAdmin();
+  const enrollAdminOut = await ledger.enrollAdmin();
+  const adminWallet = enrollAdminOut[1];
   const [userIdentity] = await ledger.enrollUser(adminWallet);
 
   const connectionProfile = await ledger.getConnectionProfileOrg1();
@@ -132,7 +133,7 @@ test("runs tx on a Fabric v1.4.8 ledger", async (t: Test) => {
     t.ok(res);
     t.ok(res.data);
     t.equal(res.status, 200);
-    const cars = JSON.parse(res.data.functionOutput);
+    t.doesNotThrow(() => JSON.parse(res.data.functionOutput));
   }
 
   {

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
@@ -58,7 +58,8 @@ test("runs tx on a Fabric v2.2.0 ledger", async (t: Test) => {
   };
   test.onFinish(tearDownLedger);
 
-  const [_, adminWallet] = await ledger.enrollAdmin();
+  const enrollAdminOut = await ledger.enrollAdmin();
+  const adminWallet = enrollAdminOut[1];
   const [userIdentity] = await ledger.enrollUser(adminWallet);
 
   const connectionProfile = await ledger.getConnectionProfileOrg1();
@@ -132,7 +133,7 @@ test("runs tx on a Fabric v2.2.0 ledger", async (t: Test) => {
     t.ok(res);
     t.ok(res.data);
     t.equal(res.status, 200);
-    const cars = JSON.parse(res.data.functionOutput);
+    t.doesNotThrow(() => JSON.parse(res.data.functionOutput));
   }
 
   {

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/plugin-ledger-connector-quorum.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/plugin-ledger-connector-quorum.ts
@@ -39,7 +39,6 @@ import {
   InvokeContractV1Response,
   RunTransactionRequest,
   RunTransactionResponse,
-  Web3SigningCredential,
   Web3SigningCredentialGethKeychainPassword,
   Web3SigningCredentialCactusKeychainRef,
   Web3SigningCredentialPrivateKeyHex,

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/deploy-contract-solidity-bytecode-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/deploy-contract-solidity-bytecode-endpoint.ts
@@ -1,4 +1,4 @@
-import { Express, Request, Response, NextFunction } from "express";
+import { Express, Request, Response } from "express";
 
 import {
   IWebServiceEndpoint,
@@ -60,11 +60,7 @@ export class DeployContractSolidityBytecodeEndpoint
     return this.handleRequest.bind(this);
   }
 
-  public async handleRequest(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> {
+  public async handleRequest(req: Request, res: Response): Promise<void> {
     const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
     this.log.debug(reqTag);
     const reqBody: DeployContractSolidityBytecodeV1Request = req.body;

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/invoke-contract-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/invoke-contract-endpoint.ts
@@ -1,4 +1,4 @@
-import { Express, Request, Response, NextFunction } from "express";
+import { Express, Request, Response } from "express";
 
 import {
   Logger,
@@ -57,11 +57,7 @@ export class InvokeContractEndpoint implements IWebServiceEndpoint {
     return this.handleRequest.bind(this);
   }
 
-  public async handleRequest(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> {
+  public async handleRequest(req: Request, res: Response): Promise<void> {
     const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
     this.log.debug(reqTag);
     const reqBody = req.body;

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/run-transaction-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/run-transaction-endpoint.ts
@@ -1,4 +1,4 @@
-import { Express, Request, Response, NextFunction } from "express";
+import { Express, Request, Response } from "express";
 
 import {
   Logger,
@@ -57,11 +57,7 @@ export class RunTransactionEndpoint implements IWebServiceEndpoint {
     return this.handleRequest.bind(this);
   }
 
-  public async handleRequest(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> {
+  public async handleRequest(req: Request, res: Response): Promise<void> {
     const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
     this.log.debug(reqTag);
     const reqBody = req.body;

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/deploy-contract-from-json.test.ts
@@ -2,11 +2,7 @@ import test, { Test } from "tape";
 import Web3 from "web3";
 import { v4 as uuidV4 } from "uuid";
 
-import {
-  Logger,
-  LoggerProvider,
-  LogLevelDesc,
-} from "@hyperledger/cactus-common";
+import { LogLevelDesc } from "@hyperledger/cactus-common";
 
 import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory";
 
@@ -27,10 +23,6 @@ import {
 import { PluginRegistry } from "@hyperledger/cactus-core";
 
 const logLevel: LogLevelDesc = "INFO";
-const log: Logger = LoggerProvider.getOrCreate({
-  label: "test-deploy-contract-from-json",
-  level: logLevel,
-});
 
 test("Quorum Ledger Connector Plugin", async (t: Test) => {
   const ledger = new QuorumTestLedger();

--- a/packages/cactus-test-tooling/src/main/typescript/besu/besu-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/besu/besu-test-ledger.ts
@@ -348,7 +348,6 @@ export class BesuTestLedger implements ITestLedger {
                 resolve(output);
               }
             },
-            (event: any) => null, // ignore the spammy docker download log, we get it in the output variable anyway
           );
         }
       });

--- a/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
@@ -245,9 +245,6 @@ export class Containers {
                   resolve(output);
                 }
               },
-              // ignore the spammy docker download log, we get
-              // it in the output variable anyway if needed
-              (event: any) => null,
             );
           }
         },

--- a/packages/cactus-test-tooling/src/main/typescript/fabric/fabric-test-ledger-v1.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/fabric/fabric-test-ledger-v1.ts
@@ -1,7 +1,6 @@
-import path from "path";
 import { EventEmitter } from "events";
 
-import compareVersions, { compare } from "compare-versions";
+import compareVersions from "compare-versions";
 
 import Docker, {
   Container,
@@ -16,7 +15,7 @@ import {
   Gateway,
 } from "fabric-network";
 import FabricCAServices from "fabric-ca-client";
-import Joi, { array } from "joi";
+import Joi from "joi";
 import { ITestLedger } from "../i-test-ledger";
 import { Containers } from "../common/containers";
 import {
@@ -215,7 +214,6 @@ export class FabricTestLedgerV1 implements ITestLedger {
   }
 
   public async getConnectionProfileOrg1(): Promise<any> {
-    const fnTag = `${this.className}#getConnectionProfileOrg1()`;
     const cInfo = await this.getContainerInfo();
     const container = this.getContainer();
     const CCP_JSON_PATH_FABRIC_V1 =

--- a/packages/cactus-test-tooling/src/main/typescript/http-echo/http-echo-container.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/http-echo/http-echo-container.ts
@@ -223,7 +223,6 @@ export class HttpEchoContainer implements ITestLedger {
                 resolve(output);
               }
             },
-            (event: any) => null, // ignore the spammy docker download log, we get it in the output variable anyway
           );
         }
       });

--- a/packages/cactus-test-tooling/src/main/typescript/quorum/quorum-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/quorum/quorum-test-ledger.ts
@@ -134,8 +134,6 @@ export class QuorumTestLedger implements ITestLedger {
    * @param [seedMoney=10e8] The amount of money to seed the new test account with.
    */
   public async createEthTestAccount(seedMoney = 10e8): Promise<Account> {
-    const fnTag = `QuorumTestLedger#getEthTestAccount()`;
-
     const rpcApiHttpHost = await this.getRpcApiHttpHost();
     const web3 = new Web3(rpcApiHttpHost);
     const ethTestAccount = web3.eth.accounts.create(uuidv4());
@@ -355,7 +353,6 @@ export class QuorumTestLedger implements ITestLedger {
                 resolve(output);
               }
             },
-            (event: any) => null, // ignore the spammy docker download log, we get it in the output variable anyway
           );
         }
       });


### PR DESCRIPTION
Depends on #520

```sh
This makes it so that the linter will error
out when there are unused variables.
This is more important than it looks because unused imports can contribute
a lot of overhead to the build artifact sizes.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>
```

