### PR TITLE
fix(cmd-api-server): config generator emits correct type

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/config/config-service.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/config/config-service.ts
@@ -411,7 +411,7 @@ export class ConfigService {
     const keyPairPem = keyPair.toPEM(true);
     const memberId1 = "Cactus_Example_Consortium_Member_1";
     const nodeId1 = "Cactus_Example_Consortium_Node_1";
-    const consortium: ConsortiumDatabase = {
+    const consortiumDatabase: ConsortiumDatabase = {
       cactusNode: [
         {
           consortiumId: "Cactus_Example_Consortium",
@@ -453,14 +453,18 @@ export class ConfigService {
       {
         packageName: "@hyperledger/cactus-plugin-keychain-memory",
         type: PluginImportType.LOCAL,
-        options: {},
+        options: {
+          instanceId: uuidV4(),
+          keychainId: uuidV4(),
+        },
       },
       {
         packageName: "@hyperledger/cactus-plugin-consortium-manual",
         type: PluginImportType.LOCAL,
         options: {
+          instanceId: uuidV4(),
           keyPairPem,
-          consortium,
+          consortiumDatabase,
         },
       },
     ];


### PR DESCRIPTION
1. the "consortium" property has been renamed to "consortiumDatabase"
when we normalized the data structure of the in-memory
storage of the manual consortium plugin.
2. instanceId and keychainId properties were missing
These are also properties that were recently added to
all constructors and the generator was not updated.

TODO: leverage the compiler to make it impossible to
make these user errors when updating the plugin
constructor interface and forgetting to update the
generator at the same time. The build should fail in
cases like that instead of letting the CI pass.

Fixes #598

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>