### PR TITLE
feat(quorum): add prometheus exporter

### DIFF
--- a/packages/cactus-plugin-ledger-connector-quorum/README.md
+++ b/packages/cactus-plugin-ledger-connector-quorum/README.md
@@ -9,6 +9,7 @@ This plugin provides `Cactus` a way to interact with Quorum networks. Using this
 
   - [Getting Started](#getting-started)
   - [Usage](#usage)
+  - [Prometheus Exporter](#prometheus-exporter)
   - [Runing the tests](#running-the-tests)
   - [Contributing](#contributing)
   - [License](#license)
@@ -76,6 +77,53 @@ enum Web3SigningCredentialType {
 }
 ```
 > Extensive documentation and examples in the [readthedocs](https://readthedocs.org/projects/hyperledger-cactus/) (WIP)
+
+## Running the tests
+
+To check that all has been installed correctly and that the pugin has no errors, there are two options to run the tests:
+
+* Run this command at the project's root:
+```sh
+npm run test:plugin-ledger-connector-quorum
+```
+## Prometheus Exporter
+
+This class creates a prometheus exporter, which scrapes the transactions (total transaction count) for the use cases incorporating the use of Quorum connector plugin.
+
+### Prometheus Exporter Usage
+The prometheus exporter object is initialized in the `PluginLedgerConnectorQuorum` class constructor itself, so instantiating the object of the `PluginLedgerConnectorQuorum` class, gives access to the exporter object.
+You can also initialize the prometheus exporter object seperately and then pass it to the `IPluginLedgerConnectorQuorumOptions` interface for `PluginLedgerConnectoQuorum` constructor.
+
+`getPrometheusExporterMetricsV1` function returns the prometheus exporter metrics, currently displaying the total transaction count, which currently increments everytime the `transact()` method of the `PluginLedgerConnectorQuorum` class is called.
+
+### Prometheus Integration
+To use Prometheus with this exporter make sure to install [Prometheus main component](https://prometheus.io/download/).
+Once Prometheus is setup, the corresponding scrape_config needs to be added to the prometheus.yml
+
+```(yaml)
+- job_name: 'quorum_ledger_connector_exporter'
+  metrics_path: api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/get-prometheus-exporter-metrics
+  scrape_interval: 5s
+  static_configs:
+    - targets: ['{host}:{port}']
+```
+
+Here the `host:port` is where the prometheus exporter metrics are exposed. The test cases (For example, packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/deploy-contract-from-json.test.ts) exposes it over `0.0.0.0` and a random port(). The random port can be found in the running logs of the test case and looks like (42379 in the below mentioned URL)
+`Metrics URL: http://0.0.0.0:42379/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/get-prometheus-exporter-metrics`
+
+Once edited, you can start the prometheus service by referencing the above edited prometheus.yml file.
+On the prometheus graphical interface (defaulted to http://localhost:9090), choose **Graph** from the menu bar, then select the **Console** tab. From the **Insert metric at cursor** drop down, select **cactus_quorum_total_tx_count** and click **execute**
+
+### Helper code
+
+###### response.type.ts
+This file contains the various responses of the metrics.
+
+###### data-fetcher.ts
+This file contains functions encasing the logic to process the data points
+
+###### metrics.ts
+This file lists all the prometheus metrics and what they are used for.
 
 ## Running the tests
 

--- a/packages/cactus-plugin-ledger-connector-quorum/package-lock.json
+++ b/packages/cactus-plugin-ledger-connector-quorum/package-lock.json
@@ -355,6 +355,11 @@
 			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
 			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
 		},
+		"bintrees": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+			"integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+		},
 		"blakejs": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
@@ -1764,6 +1769,14 @@
 			"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
 			"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
 		},
+		"prom-client": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.1.0.tgz",
+			"integrity": "sha512-jT9VccZCWrJWXdyEtQddCDszYsiuWj5T0ekrPszi/WEegj3IZy6Mm09iOOVM86A4IKMWq8hZkT2dD9MaSe+sng==",
+			"requires": {
+				"tdigest": "^0.1.1"
+			}
+		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -2183,6 +2196,14 @@
 						"minimist": "^1.2.5"
 					}
 				}
+			}
+		},
+		"tdigest": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+			"integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+			"requires": {
+				"bintrees": "1.0.1"
 			}
 		},
 		"timed-out": {

--- a/packages/cactus-plugin-ledger-connector-quorum/package.json
+++ b/packages/cactus-plugin-ledger-connector-quorum/package.json
@@ -33,7 +33,10 @@
       "ignore": [
         "src/**/generated/*"
       ],
-      "extensions": ["ts", "json"],
+      "extensions": [
+        "ts",
+        "json"
+      ],
       "quiet": true,
       "verbose": false,
       "runOnChangeOnly": true
@@ -87,6 +90,7 @@
     "express": "4.17.1",
     "joi": "14.3.1",
     "openapi-types": "7.0.1",
+    "prom-client": "13.1.0",
     "typescript-optional": "2.0.1",
     "web3": "1.2.7",
     "web3-core-method": "1.3.0",

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/json/openapi.json
@@ -637,6 +637,10 @@
                         "nullable": false
                     }
                 }
+            },
+            "PrometheusExporterMetricsResponse": {
+                "type": "string",
+                "nullable": false
             }
         }
     },
@@ -770,6 +774,31 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/InvokeContractV2Response"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/get-prometheus-exporter-metrics": {
+            "get": {
+                "x-hyperledger-cactus": {
+                    "http": {
+                        "verbLowerCase": "get",
+                        "path": "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/get-prometheus-exporter-metrics"
+                    }
+                },
+                "operationId": "getPrometheusExporterMetricsV1",
+                "summary": "Get the Prometheus Metrics",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PrometheusExporterMetricsResponse"
                                 }
                             }
                         }

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -771,6 +771,42 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * 
+         * @summary Get the Prometheus Metrics
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getPrometheusExporterMetricsV1: async (options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/get-prometheus-exporter-metrics`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
+                options: localVarRequestOptions,
+            };
+        },
     }
 };
 
@@ -836,6 +872,19 @@ export const DefaultApiFp = function(configuration?: Configuration) {
                 return axios.request(axiosRequestArgs);
             };
         },
+        /**
+         * 
+         * @summary Get the Prometheus Metrics
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getPrometheusExporterMetricsV1(options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await DefaultApiAxiosParamCreator(configuration).getPrometheusExporterMetricsV1(options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {...localVarAxiosArgs.options, url: basePath + localVarAxiosArgs.url};
+                return axios.request(axiosRequestArgs);
+            };
+        },
     }
 };
 
@@ -884,6 +933,15 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          */
         apiV2QuorumInvokeContract(invokeContractV2Request?: InvokeContractV2Request, options?: any): AxiosPromise<InvokeContractV2Response> {
             return DefaultApiFp(configuration).apiV2QuorumInvokeContract(invokeContractV2Request, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Get the Prometheus Metrics
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getPrometheusExporterMetricsV1(options?: any): AxiosPromise<string> {
+            return DefaultApiFp(configuration).getPrometheusExporterMetricsV1(options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -941,6 +999,17 @@ export class DefaultApi extends BaseAPI {
      */
     public apiV2QuorumInvokeContract(invokeContractV2Request?: InvokeContractV2Request, options?: any) {
         return DefaultApiFp(this.configuration).apiV2QuorumInvokeContract(invokeContractV2Request, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Get the Prometheus Metrics
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public getPrometheusExporterMetricsV1(options?: any) {
+        return DefaultApiFp(this.configuration).getPrometheusExporterMetricsV1(options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/prometheus-exporter/data.fetcher.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/prometheus-exporter/data.fetcher.ts
@@ -1,0 +1,8 @@
+import { Transactions } from "./response.type";
+
+import { totalTxCount, K_CACTUS_QUORUM_TOTAL_TX_COUNT } from "./metrics";
+
+export async function collectMetrics(transactions: Transactions) {
+  transactions.counter++;
+  totalTxCount.labels(K_CACTUS_QUORUM_TOTAL_TX_COUNT).set(transactions.counter);
+}

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/prometheus-exporter/metrics.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/prometheus-exporter/metrics.ts
@@ -1,0 +1,9 @@
+import { Gauge } from "prom-client";
+
+export const K_CACTUS_QUORUM_TOTAL_TX_COUNT = "cactus_quorum_total_tx_count";
+
+export const totalTxCount = new Gauge({
+  name: K_CACTUS_QUORUM_TOTAL_TX_COUNT,
+  help: "Total transactions executed",
+  labelNames: ["type"],
+});

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/prometheus-exporter/prometheus-exporter.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/prometheus-exporter/prometheus-exporter.ts
@@ -1,0 +1,37 @@
+import promClient from "prom-client";
+import { Transactions } from "./response.type";
+import { collectMetrics } from "./data.fetcher";
+import { K_CACTUS_QUORUM_TOTAL_TX_COUNT } from "./metrics";
+
+export interface IPrometheusExporterOptions {
+  pollingIntervalInMin?: number;
+}
+
+export class PrometheusExporter {
+  public readonly metricsPollingIntervalInMin: number;
+  public readonly transactions: Transactions = { counter: 0 };
+
+  constructor(
+    public readonly prometheusExporterOptions: IPrometheusExporterOptions,
+  ) {
+    this.metricsPollingIntervalInMin =
+      prometheusExporterOptions.pollingIntervalInMin || 1;
+  }
+
+  public addCurrentTransaction(): void {
+    collectMetrics(this.transactions);
+  }
+
+  public async getPrometheusMetrics(): Promise<string> {
+    const result = await promClient.register.getSingleMetricAsString(
+      K_CACTUS_QUORUM_TOTAL_TX_COUNT,
+    );
+    return result;
+  }
+
+  public startMetricsCollection(): void {
+    const Registry = promClient.Registry;
+    const register = new Registry();
+    promClient.collectDefaultMetrics({ register });
+  }
+}

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/prometheus-exporter/response.type.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/prometheus-exporter/response.type.ts
@@ -1,0 +1,3 @@
+export type Transactions = {
+  counter: number;
+};

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/get-prometheus-exporter-metrics-endpoint-v1.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/get-prometheus-exporter-metrics-endpoint-v1.ts
@@ -1,0 +1,80 @@
+import { Express, Request, Response } from "express";
+
+import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";
+
+import OAS from "../../json/openapi.json";
+
+import {
+  IWebServiceEndpoint,
+  IExpressRequestHandler,
+} from "@hyperledger/cactus-core-api";
+
+import {
+  LogLevelDesc,
+  Logger,
+  LoggerProvider,
+  Checks,
+} from "@hyperledger/cactus-common";
+
+import { PluginLedgerConnectorQuorum } from "../plugin-ledger-connector-quorum";
+
+export interface IGetPrometheusExporterMetricsEndpointV1Options {
+  connector: PluginLedgerConnectorQuorum;
+  logLevel?: LogLevelDesc;
+}
+
+export class GetPrometheusExporterMetricsEndpointV1
+  implements IWebServiceEndpoint {
+  private readonly log: Logger;
+
+  constructor(
+    public readonly options: IGetPrometheusExporterMetricsEndpointV1Options,
+  ) {
+    const fnTag = "GetPrometheusExporterMetricsEndpointV1#constructor()";
+
+    Checks.truthy(options, `${fnTag} options`);
+    Checks.truthy(options.connector, `${fnTag} options.connector`);
+
+    const label = "get-prometheus-exporter-metrics-endpoint";
+    const level = options.logLevel || "INFO";
+    this.log = LoggerProvider.getOrCreate({ label, level });
+  }
+
+  public getExpressRequestHandler(): IExpressRequestHandler {
+    return this.handleRequest.bind(this);
+  }
+
+  getPath(): string {
+    return OAS.paths[
+      "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/get-prometheus-exporter-metrics"
+    ].get["x-hyperledger-cactus"].http.path;
+  }
+
+  getVerbLowerCase(): string {
+    return OAS.paths[
+      "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/get-prometheus-exporter-metrics"
+    ].get["x-hyperledger-cactus"].http.verbLowerCase;
+  }
+
+  registerExpress(app: Express): IWebServiceEndpoint {
+    registerWebServiceEndpoint(app, this);
+    return this;
+  }
+
+  async handleRequest(req: Request, res: Response): Promise<void> {
+    const fnTag = "GetPrometheusExporterMetrics#handleRequest()";
+    const verbUpper = this.getVerbLowerCase().toUpperCase();
+    this.log.debug(`${verbUpper} ${this.getPath()}`);
+
+    try {
+      const resBody = await this.options.connector.getPrometheusExporterMetrics();
+      res.status(200);
+      res.send(resBody);
+    } catch (ex) {
+      this.log.error(`${fnTag} failed to serve request`, ex);
+      res.status(500);
+      res.statusMessage = ex.message;
+      res.json({ error: ex.stack });
+    }
+  }
+}

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/deploy-contract-from-json.test.ts
@@ -2,17 +2,24 @@ import test, { Test } from "tape-promise/tape";
 import Web3 from "web3";
 import { v4 as uuidV4 } from "uuid";
 
-import { LogLevelDesc } from "@hyperledger/cactus-common";
+import {
+  LogLevelDesc,
+  IListenOptions,
+  Servers,
+} from "@hyperledger/cactus-common";
 
 import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory";
 
 import HelloWorldContractJson from "../../../../solidity/hello-world-contract/HelloWorld.json";
+
+import { K_CACTUS_QUORUM_TOTAL_TX_COUNT } from "../../../../../main/typescript/prometheus-exporter/metrics";
 
 import {
   EthContractInvocationType,
   PluginLedgerConnectorQuorum,
   Web3SigningCredentialCactusKeychainRef,
   Web3SigningCredentialType,
+  DefaultApi as QuorumApi,
 } from "../../../../../main/typescript/public-api";
 
 import {
@@ -24,6 +31,11 @@ import {
 import { PluginRegistry } from "@hyperledger/cactus-core";
 
 const testCase = "Quorum Ledger Connector Plugin";
+import express from "express";
+import bodyParser from "body-parser";
+import http from "http";
+import { AddressInfo } from "net";
+
 const logLevel: LogLevelDesc = "INFO";
 
 test("BEFORE " + testCase, async (t: Test) => {
@@ -80,6 +92,25 @@ test(testCase, async (t: Test) => {
       pluginRegistry: new PluginRegistry({ plugins: [keychainPlugin] }),
     },
   );
+
+  const expressApp = express();
+  expressApp.use(bodyParser.json({ limit: "250mb" }));
+  const server = http.createServer(expressApp);
+  const listenOptions: IListenOptions = {
+    hostname: "0.0.0.0",
+    port: 0,
+    server,
+  };
+  const addressInfo = (await Servers.listen(listenOptions)) as AddressInfo;
+  test.onFinish(async () => await Servers.shutdown(server));
+  const { address, port } = addressInfo;
+  const apiHost = `http://${address}:${port}`;
+  t.comment(
+    `Metrics URL: ${apiHost}/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/get-prometheus-exporter-metrics`,
+  );
+  const apiClient = new QuorumApi({ basePath: apiHost });
+
+  await connector.installWebServices(expressApp);
 
   await connector.transact({
     web3SigningCredential: {
@@ -392,6 +423,29 @@ test(testCase, async (t: Test) => {
     });
     t2.ok(getNameOut2, "getName() invocation #2 output is truthy OK");
 
+    t2.end();
+  });
+
+  test("get prometheus exporter metrics", async (t2: Test) => {
+    const res = await apiClient.getPrometheusExporterMetricsV1();
+    const promMetricsOutput =
+      "# HELP " +
+      K_CACTUS_QUORUM_TOTAL_TX_COUNT +
+      " Total transactions executed\n" +
+      "# TYPE " +
+      K_CACTUS_QUORUM_TOTAL_TX_COUNT +
+      " gauge\n" +
+      K_CACTUS_QUORUM_TOTAL_TX_COUNT +
+      '{type="' +
+      K_CACTUS_QUORUM_TOTAL_TX_COUNT +
+      '"} 5';
+    t2.ok(res);
+    t2.ok(res.data);
+    t2.equal(res.status, 200);
+    t2.true(
+      res.data.includes(promMetricsOutput),
+      "Total Transaction Count of 5 recorded as expected. RESULT OK.",
+    );
     t2.end();
   });
 


### PR DESCRIPTION
# Commit to be reviewed
---------------------------------

feat(quorum): prometheus exporter metrics integration
	
	Primary Change
	--------------

	1. The quorum ledger connector plugin now includes the prometheus metrics exporter integration
	2. OpenAPI spec now has api endpoint for the getting the prometheus metrics

	Refactorings that were also necessary to accomodate 1) and 2)
	------------------------------------------------------------

	3. GetPrometheusMetricsV1 class is created to handle the corresponding api endpoint
	4. IPluginLedgerConnectorQuorumOptions interface in PluginLedgerConnectorQuorum class now has a prometheusExporter optional field
	5. The PluginLedgerConnectorQuorum class has relevant functions and codes to incorporate prometheus exporter
	6. Added Readme.md on the prometheus exporter usage

	Fixes #534

Signed-off-by: Jagpreet Singh Sasan <jagpreet.singh.sasan@accenture.com>