### PR TITLE
feat(fabric-connector): contract deployment endpoint #616

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/package-lock.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/package-lock.json
@@ -330,7 +330,6 @@
 			"version": "0.21.1",
 			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
 			"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-			"dev": true,
 			"requires": {
 				"follow-redirects": "^1.10.0"
 			}
@@ -910,16 +909,6 @@
 				"sha.js": "^2.4.8"
 			}
 		},
-		"cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-			"requires": {
-				"path-key": "^3.1.0",
-				"shebang-command": "^2.0.0",
-				"which": "^2.0.1"
-			}
-		},
 		"crypto-browserify": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -1458,37 +1447,6 @@
 				"safe-buffer": "^5.1.1"
 			}
 		},
-		"execa": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-			"integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
-			"requires": {
-				"cross-spawn": "^7.0.0",
-				"get-stream": "^5.0.0",
-				"human-signals": "^1.1.1",
-				"is-stream": "^2.0.0",
-				"merge-stream": "^2.0.0",
-				"npm-run-path": "^4.0.0",
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2",
-				"strip-final-newline": "^2.0.0"
-			},
-			"dependencies": {
-				"get-stream": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"is-stream": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
-				}
-			}
-		},
 		"express": {
 			"version": "4.17.1",
 			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -1834,10 +1792,9 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-			"integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
-			"dev": true
+			"version": "1.13.3",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+			"integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -1929,20 +1886,6 @@
 				"min-document": "^2.19.0",
 				"process": "~0.5.1"
 			}
-		},
-		"go-bin": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/go-bin/-/go-bin-1.4.0.tgz",
-			"integrity": "sha512-T+jeJFVboLESIVqi3v8vJMAoHvsauR8XRKBkTwLwE1PUdDWOSAyrIQ9ymWFJ6suaDNEcNNglBCOc6AFbtVkqow==",
-			"requires": {
-				"decompress": "^4.2.1",
-				"mkdirp": "^1.0.4"
-			}
-		},
-		"go-versions": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/go-versions/-/go-versions-1.3.2.tgz",
-			"integrity": "sha512-nKjEKqRT1BUPVGO8WO5EKUWgJ6l1sThfSdYuRi6WwNyiwR4SOfC/FoB7aRRUtfmMHBU3ZJNMG2x8GiE51/tbhg=="
 		},
 		"got": {
 			"version": "9.6.0",
@@ -2497,11 +2440,6 @@
 			"resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.1.4.tgz",
 			"integrity": "sha512-MZVIsLKGVOVE1KEnldppe6Ij+vmemMuApDfjhVSLzyYP+td0bREEYyAoIw9yFePoBXManCuBqmiNP5FqJS5Xkg=="
 		},
-		"human-signals": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-			"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
-		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -2627,11 +2565,6 @@
 			"requires": {
 				"punycode": "2.x.x"
 			}
-		},
-		"isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -2841,11 +2774,6 @@
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
 			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
 		},
-		"merge-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
-		},
 		"methods": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -2877,11 +2805,6 @@
 			"requires": {
 				"mime-db": "1.44.0"
 			}
-		},
-		"mimic-fn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
 		},
 		"mimic-response": {
 			"version": "1.0.1",
@@ -3034,16 +2957,6 @@
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
 			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
 		},
-		"ngo": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/ngo/-/ngo-2.6.2.tgz",
-			"integrity": "sha512-fOAX8YlMFUHvJUBp0uNOqYMS/OqK05iV9lPzLVhn9sFJR0n4wFIfz9Y59Kg0v9mtrxZizN8L0mkimn7ikyIbbA==",
-			"requires": {
-				"execa": "^4.0.0",
-				"go-bin": "^1.4.0",
-				"go-versions": "^1.3.2"
-			}
-		},
 		"node-addon-api": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
@@ -3080,14 +2993,6 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
 			"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
-		},
-		"npm-run-path": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-			"requires": {
-				"path-key": "^3.0.0"
-			}
 		},
 		"number-is-nan": {
 			"version": "1.0.1",
@@ -3142,14 +3047,6 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
 				"wrappy": "1"
-			}
-		},
-		"onetime": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"requires": {
-				"mimic-fn": "^2.1.0"
 			}
 		},
 		"ono": {
@@ -3222,11 +3119,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-		},
-		"path-key": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -3637,28 +3529,10 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"shebang-command": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"requires": {
-				"shebang-regex": "^3.0.0"
-			}
-		},
-		"shebang-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-		},
 		"shell-escape": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/shell-escape/-/shell-escape-0.2.0.tgz",
 			"integrity": "sha1-aP0CXrBJC09WegJ/C/IkgLX4QTM="
-		},
-		"signal-exit": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
 		},
 		"simple-concat": {
 			"version": "1.0.1",
@@ -3779,11 +3653,6 @@
 			"requires": {
 				"is-natural-number": "^4.0.1"
 			}
-		},
-		"strip-final-newline": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
 		},
 		"strip-hex-prefix": {
 			"version": "1.0.0",
@@ -3928,11 +3797,22 @@
 			}
 		},
 		"temp": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/temp/-/temp-0.9.1.tgz",
-			"integrity": "sha512-WMuOgiua1xb5R56lE0eH6ivpVmg/lq2OHm4+LtT/xtEtPQ+sz6N3bBM6WZ5FvO1lO4IKIOb43qnhoc4qxP5OeA==",
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+			"integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
 			"requires": {
+				"mkdirp": "^0.5.1",
 				"rimraf": "~2.6.2"
+			},
+			"dependencies": {
+				"mkdirp": {
+					"version": "0.5.5",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				}
 			}
 		},
 		"through": {
@@ -4961,14 +4841,6 @@
 						"xhr-request-promise": "^0.1.2"
 					}
 				}
-			}
-		},
-		"which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"requires": {
-				"isexe": "^2.0.0"
 			}
 		},
 		"window-size": {

--- a/packages/cactus-plugin-ledger-connector-fabric/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/package.json
@@ -33,7 +33,10 @@
       "ignore": [
         "src/**/generated/*"
       ],
-      "extensions": ["ts", "json"],
+      "extensions": [
+        "ts",
+        "json"
+      ],
       "quiet": true,
       "verbose": false,
       "runOnChangeOnly": true
@@ -83,6 +86,7 @@
     "@hyperledger/cactus-common": "0.3.0",
     "@hyperledger/cactus-core": "0.3.0",
     "@hyperledger/cactus-core-api": "0.3.0",
+    "axios": "0.21.1",
     "bl": "1.2.3",
     "express": "4.17.1",
     "express-openapi-validator": "3.16.11",
@@ -92,11 +96,10 @@
     "http-status-codes": "2.1.4",
     "joi": "14.3.1",
     "multer": "1.4.2",
-    "ngo": "2.6.2",
     "node-ssh": "11.0.0",
     "openapi-types": "7.0.1",
     "prom-client": "13.0.0",
-    "temp": "0.9.1",
+    "temp": "0.9.4",
     "typescript-optional": "2.0.1",
     "uuid": "8.3.0",
     "web3": "1.2.7",
@@ -110,8 +113,6 @@
     "@types/multer": "1.4.4",
     "@types/ssh2": "0.5.44",
     "@types/temp": "0.8.34",
-    "@types/uuid": "8.3.0",
-    "axios": "0.21.1",
-    "form-data": "3.0.0"
+    "@types/uuid": "8.3.0"
   }
 }

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/json/openapi.json
@@ -165,6 +165,33 @@
                     "FabricContractInvocationType.CALL"
                 ]
             },
+            "SSHExecCommandResponse": {
+                "type": "object",
+                "required": [
+                    "stdout",
+                    "stderr",
+                    "code",
+                    "signal"
+                ],
+                "properties": {
+                    "stdout": {
+                        "type": "string",
+                        "nullable": false
+                    },
+                    "stderr": {
+                        "type": "string",
+                        "nullable": false
+                    },
+                    "code": {
+                        "type": "integer",
+                        "nullable": true
+                    },
+                    "signal": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                }
+            },
             "RunTransactionRequest": {
                 "type": "object",
                 "required": [
@@ -235,12 +262,136 @@
                     }
                 }
             },
+            "DeploymentTargetOrganization": {
+                "type": "object",
+                "required": [
+                    "CORE_PEER_LOCALMSPID",
+                    "CORE_PEER_ADDRESS",
+                    "CORE_PEER_MSPCONFIGPATH",
+                    "CORE_PEER_TLS_ROOTCERT_FILE",
+                    "ORDERER_TLS_ROOTCERT_FILE"
+                ],
+                "properties": {
+                    "CORE_PEER_LOCALMSPID": {
+                        "type": "string",
+                        "example": "Org1MSP",
+                        "nullable": false,
+                        "minLength": 1,
+                        "maxLength": 1024,
+                        "description": "Mapped to environment variables of the Fabric CLI container."
+                    },
+                    "CORE_PEER_ADDRESS": {
+                        "type": "string",
+                        "example": "peer0.org1.example.com:7051",
+                        "nullable": false,
+                        "minLength": 1,
+                        "maxLength": 1024,
+                        "description": "Mapped to environment variables of the Fabric CLI container."
+                    },
+                    "CORE_PEER_MSPCONFIGPATH": {
+                        "type": "string",
+                        "example": "/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp",
+                        "nullable": false,
+                        "minLength": 1,
+                        "maxLength": 1024,
+                        "description": "Mapped to environment variables of the Fabric CLI container."
+                    },
+                    "CORE_PEER_TLS_ROOTCERT_FILE": {
+                        "type": "string",
+                        "example": "/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt",
+                        "nullable": false,
+                        "minLength": 1,
+                        "maxLength": 1024,
+                        "description": "Mapped to environment variables of the Fabric CLI container."
+                    },
+                    "ORDERER_TLS_ROOTCERT_FILE": {
+                        "type": "string",
+                        "example": "/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem",
+                        "nullable": false,
+                        "minLength": 1,
+                        "maxLength": 1024,
+                        "description": "Mapped to environment variables of the Fabric CLI container."
+                    }
+                }
+            },
             "DeployContractGoSourceV1Request": {
                 "type": "object",
                 "required": [
-                    "goSource"
+                    "goSource",
+                    "targetOrganizations",
+                    "chainCodeVersion",
+                    "channelId",
+                    "policyDslSource",
+                    "targetPeerAddresses",
+                    "tlsRootCertFiles"
                 ],
                 "properties": {
+                    "policyDslSource": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 65535,
+                        "nullable": false,
+                        "example": "AND('Org1MSP.member','Org2MSP.member')"
+                    },
+                    "tlsRootCertFiles": {
+                        "type": "string",
+                        "description": "The TLS root cert files that will be passed to the chaincode instantiation command.",
+                        "minLength": 1,
+                        "maxLength": 65535,
+                        "nullable": false,
+                        "example": "/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt"
+                    },
+                    "channelId": {
+                        "type": "string",
+                        "description": "The name of the Fabric channel where the contract will get instantiated.",
+                        "example": "mychannel",
+                        "minLength": 1,
+                        "maxLength": 2048,
+                        "nullable": false
+                    },
+                    "targetOrganizations": {
+                        "type": "array",
+                        "minItems": 1,
+                        "nullable": false,
+                        "maxItems": 1024,
+                        "items": {
+                            "$ref": "#/components/schemas/DeploymentTargetOrganization"
+                        }
+                    },
+                    "targetPeerAddresses": {
+                        "type": "array",
+                        "description": "An array of peer addresses where the contract will be instantiated.",
+                        "example": [
+                            "peer0.org1.example.com:7051"
+                        ],
+                        "minItems": 1,
+                        "maxItems": 2048,
+                        "items": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 4096
+                        }
+                    },
+                    "constructorArgs": {
+                        "type": "object",
+                        "example": "{} - An empty object literal can be sufficient if your contract does not have parameters.",
+                        "nullable": false,
+                        "properties": {
+                            "Args": {
+                                "type": "array",
+                                "minLength": 0,
+                                "maxLength": 2048,
+                                "items": {}
+                            }
+                        }
+                    },
+                    "chainCodeVersion": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 128,
+                        "example": "1.0.0",
+                        "nullable": false
+                    },
                     "goSource": {
                         "description": "The your-smart-contract.go file where the functionality of your contract is implemented.",
                         "$ref": "#/components/schemas/FileBase64",
@@ -279,11 +430,19 @@
             "DeployContractGoSourceV1Response": {
                 "type": "object",
                 "required": [
-                    "result"
+                    "success",
+                    "installationCommandResponse",
+                    "instantiationCommandResponse"
                 ],
                 "properties": {
-                    "result": {
-                        "type": "string"
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "installationCommandResponse": {
+                        "$ref": "#/components/schemas/SSHExecCommandResponse"
+                    },
+                    "instantiationCommandResponse": {
+                        "$ref": "#/components/schemas/SSHExecCommandResponse"
                     }
                 }
             },
@@ -335,14 +494,14 @@
         },
         "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-fabric/deploy-contract-go-source": {
             "post": {
+                "operationId": "deployContractGoSourceV1",
+                "summary": "Deploys a chaincode contract in the form of a go sources.",
                 "x-hyperledger-cactus": {
                     "http": {
                         "verbLowerCase": "post",
                         "path": "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-fabric/deploy-contract-go-source"
                     }
                 },
-                "operationId": "deployContractGoSourceV1",
-                "summary": "Deploys a chaincode contract in the form of a go sources.",
                 "parameters": [],
                 "requestBody": {
                     "content": {

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/chain-code-compiler.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/chain-code-compiler.ts
@@ -59,7 +59,11 @@ export interface ICompilationResult {
   sourceFilePath: string;
   goModFilePath: string;
 }
-
+/**
+ * TODO: Refactor this to not use the ngo module at all and instead rely on
+ * SSH/docker exec-ing into environments where go is provided such as the
+ * Fabric CLI container.
+ */
 export class ChainCodeCompiler {
   private readonly log: Logger;
 

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/deploy-contract-go-source/deploy-contract-go-source-endpoint-v1.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/deploy-contract-go-source/deploy-contract-go-source-endpoint-v1.ts
@@ -16,6 +16,7 @@ import {
 import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";
 
 import { PluginLedgerConnectorFabric } from "../plugin-ledger-connector-fabric";
+import { DeployContractGoSourceV1Request } from "../generated/openapi/typescript-axios/index";
 import OAS from "../../json/openapi.json";
 
 export interface IDeployContractGoSourceEndpointV1Options {
@@ -28,7 +29,7 @@ export class DeployContractGoSourceEndpointV1 implements IWebServiceEndpoint {
 
   private readonly log: Logger;
 
-  public get className() {
+  public get className(): string {
     return DeployContractGoSourceEndpointV1.CLASS_NAME;
   }
 
@@ -46,24 +47,18 @@ export class DeployContractGoSourceEndpointV1 implements IWebServiceEndpoint {
     return this.handleRequest.bind(this);
   }
 
-  public getOasPath() {
+  public get oasPath() {
     return OAS.paths[
       "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-fabric/deploy-contract-go-source"
     ];
   }
 
   public getPath(): string {
-    const apiPath = this.getOasPath();
-    return apiPath.post["x-hyperledger-cactus"].http.path;
+    return this.oasPath.post["x-hyperledger-cactus"].http.path;
   }
 
   public getVerbLowerCase(): string {
-    const apiPath = this.getOasPath();
-    return apiPath.post["x-hyperledger-cactus"].http.verbLowerCase;
-  }
-
-  public getOperationId(): string {
-    return this.getOasPath().post.operationId;
+    return this.oasPath.post["x-hyperledger-cactus"].http.verbLowerCase;
   }
 
   public registerExpress(app: Express): IWebServiceEndpoint {
@@ -72,23 +67,19 @@ export class DeployContractGoSourceEndpointV1 implements IWebServiceEndpoint {
   }
 
   async handleRequest(req: Request, res: Response): Promise<void> {
-    const fnTag = "DeployContractGoSourceEndpointV1#handleRequest()";
-    this.log.debug(`POST ${this.getPath()}`);
+    const fnTag = `${this.className}#handleRequest()`;
+    const verbUpper = this.getVerbLowerCase().toUpperCase();
+    this.log.debug(`${verbUpper} ${this.getPath()}`);
 
     try {
-      const message =
-        `${this.opts.connector.className} does not support ` +
-        ` contract deployment yet. This is a feature that is under ` +
-        ` development for now. Stay tuned!`;
-      const resBody = { message };
-      // const { connector } = this.opts;
-      // const reqBody = req.body as DeployContractGoSourceV1Request;
-      // const resBody = await connector.deployContract(reqBody);
-      res.status(HttpStatus.NOT_IMPLEMENTED);
+      const { connector } = this.opts;
+      const reqBody = req.body as DeployContractGoSourceV1Request;
+      const resBody = await connector.deployContract(reqBody);
+      res.status(HttpStatus.OK);
       res.json(resBody);
     } catch (ex) {
-      this.log.error(`${fnTag} failed to serve request`, ex);
-      res.status(500);
+      this.log.error(`${fnTag} failed to serve contract deploy request`, ex);
+      res.status(HttpStatus.INTERNAL_SERVER_ERROR);
       res.statusMessage = ex.message;
       res.json({ error: ex.stack });
     }

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -121,6 +121,48 @@ export enum DefaultEventHandlerStrategy {
 export interface DeployContractGoSourceV1Request {
     /**
      * 
+     * @type {string}
+     * @memberof DeployContractGoSourceV1Request
+     */
+    policyDslSource: string;
+    /**
+     * The TLS root cert files that will be passed to the chaincode instantiation command.
+     * @type {string}
+     * @memberof DeployContractGoSourceV1Request
+     */
+    tlsRootCertFiles: string;
+    /**
+     * The name of the Fabric channel where the contract will get instantiated.
+     * @type {string}
+     * @memberof DeployContractGoSourceV1Request
+     */
+    channelId: string;
+    /**
+     * 
+     * @type {Array<DeploymentTargetOrganization>}
+     * @memberof DeployContractGoSourceV1Request
+     */
+    targetOrganizations: Array<DeploymentTargetOrganization>;
+    /**
+     * An array of peer addresses where the contract will be instantiated.
+     * @type {Array<string>}
+     * @memberof DeployContractGoSourceV1Request
+     */
+    targetPeerAddresses: Array<string>;
+    /**
+     * 
+     * @type {DeployContractGoSourceV1RequestConstructorArgs}
+     * @memberof DeployContractGoSourceV1Request
+     */
+    constructorArgs?: DeployContractGoSourceV1RequestConstructorArgs;
+    /**
+     * 
+     * @type {string}
+     * @memberof DeployContractGoSourceV1Request
+     */
+    chainCodeVersion: string;
+    /**
+     * 
      * @type {FileBase64}
      * @memberof DeployContractGoSourceV1Request
      */
@@ -153,15 +195,77 @@ export interface DeployContractGoSourceV1Request {
 /**
  * 
  * @export
+ * @interface DeployContractGoSourceV1RequestConstructorArgs
+ */
+export interface DeployContractGoSourceV1RequestConstructorArgs {
+    /**
+     * 
+     * @type {Array<any>}
+     * @memberof DeployContractGoSourceV1RequestConstructorArgs
+     */
+    Args?: Array<any>;
+}
+/**
+ * 
+ * @export
  * @interface DeployContractGoSourceV1Response
  */
 export interface DeployContractGoSourceV1Response {
     /**
      * 
-     * @type {string}
+     * @type {boolean}
      * @memberof DeployContractGoSourceV1Response
      */
-    result: string;
+    success: boolean;
+    /**
+     * 
+     * @type {SSHExecCommandResponse}
+     * @memberof DeployContractGoSourceV1Response
+     */
+    installationCommandResponse: SSHExecCommandResponse;
+    /**
+     * 
+     * @type {SSHExecCommandResponse}
+     * @memberof DeployContractGoSourceV1Response
+     */
+    instantiationCommandResponse: SSHExecCommandResponse;
+}
+/**
+ * 
+ * @export
+ * @interface DeploymentTargetOrganization
+ */
+export interface DeploymentTargetOrganization {
+    /**
+     * Mapped to environment variables of the Fabric CLI container.
+     * @type {string}
+     * @memberof DeploymentTargetOrganization
+     */
+    CORE_PEER_LOCALMSPID: string;
+    /**
+     * Mapped to environment variables of the Fabric CLI container.
+     * @type {string}
+     * @memberof DeploymentTargetOrganization
+     */
+    CORE_PEER_ADDRESS: string;
+    /**
+     * Mapped to environment variables of the Fabric CLI container.
+     * @type {string}
+     * @memberof DeploymentTargetOrganization
+     */
+    CORE_PEER_MSPCONFIGPATH: string;
+    /**
+     * Mapped to environment variables of the Fabric CLI container.
+     * @type {string}
+     * @memberof DeploymentTargetOrganization
+     */
+    CORE_PEER_TLS_ROOTCERT_FILE: string;
+    /**
+     * Mapped to environment variables of the Fabric CLI container.
+     * @type {string}
+     * @memberof DeploymentTargetOrganization
+     */
+    ORDERER_TLS_ROOTCERT_FILE: string;
 }
 /**
  * 
@@ -304,6 +408,37 @@ export interface RunTransactionResponse {
      * @memberof RunTransactionResponse
      */
     functionOutput: string;
+}
+/**
+ * 
+ * @export
+ * @interface SSHExecCommandResponse
+ */
+export interface SSHExecCommandResponse {
+    /**
+     * 
+     * @type {string}
+     * @memberof SSHExecCommandResponse
+     */
+    stdout: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof SSHExecCommandResponse
+     */
+    stderr: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof SSHExecCommandResponse
+     */
+    code: number | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof SSHExecCommandResponse
+     */
+    signal: string | null;
 }
 
 /**

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/plugin-ledger-connector-fabric.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/plugin-ledger-connector-fabric.ts
@@ -1,9 +1,17 @@
+import fs from "fs";
+import path from "path";
 import { Server } from "http";
 import { Server as SecureServer } from "https";
-import { Express } from "express";
 
+import { Express } from "express";
 import "multer";
-import { Config as SshConfig } from "node-ssh";
+import temp from "temp";
+import {
+  NodeSSH,
+  Config as SshConfig,
+  SSHExecCommandOptions,
+  SSHExecCommandResponse,
+} from "node-ssh";
 import {
   DefaultEventHandlerOptions,
   DefaultEventHandlerStrategies,
@@ -62,9 +70,25 @@ import {
 
 import { PrometheusExporter } from "./prometheus-exporter/prometheus-exporter";
 
+/**
+ * Constant value holding the default $GOPATH in the Fabric CLI container as
+ * observed on fabric deployments that are produced by the official examples
+ * found in the https://github.com/hyperledger/fabric-samples repository.
+ */
+export const K_DEFAULT_CLI_CONTAINER_GO_PATH = "/opt/gopath/";
+
+/**
+ * The command that will be used to issue docker commands while controlling
+ * the Fabric CLI container and the peers.
+ */
+export const K_DEFAULT_DOCKER_BINARY = "docker";
+
 export interface IPluginLedgerConnectorFabricOptions
   extends ICactusPluginOptions {
   logLevel?: LogLevelDesc;
+  dockerBinary?: string;
+  cliContainerGoPath?: string;
+  cliContainerEnv: NodeJS.ProcessEnv;
   pluginRegistry: PluginRegistry;
   sshConfig: SshConfig;
   connectionProfile: ConnectionProfile;
@@ -86,6 +110,8 @@ export class PluginLedgerConnectorFabric
   public static readonly CLASS_NAME = "PluginLedgerConnectorFabric";
   private readonly instanceId: string;
   private readonly log: Logger;
+  private readonly dockerBinary: string;
+  private readonly cliContainerGoPath: string;
   public prometheusExporter: PrometheusExporter;
 
   public get className(): string {
@@ -104,6 +130,15 @@ export class PluginLedgerConnectorFabric
     Checks.truthy(
       this.prometheusExporter,
       `${fnTag} options.prometheusExporter`,
+    );
+    this.dockerBinary = opts.dockerBinary || K_DEFAULT_DOCKER_BINARY;
+    Checks.truthy(this.dockerBinary != null, `${fnTag}:dockerBinary`);
+
+    this.cliContainerGoPath =
+      opts.cliContainerGoPath || K_DEFAULT_CLI_CONTAINER_GO_PATH;
+    Checks.nonBlankString(
+      this.cliContainerGoPath,
+      `${fnTag}:cliContainerGoPath`,
     );
 
     const level = this.opts.logLevel || "INFO";
@@ -149,17 +184,207 @@ export class PluginLedgerConnectorFabric
     return ConsensusAlgorithmFamily.AUTHORITY;
   }
 
+  private async sshExec(
+    cmd: string,
+    label: string,
+    ssh: NodeSSH,
+    sshCmdOptions: SSHExecCommandOptions,
+  ): Promise<SSHExecCommandResponse> {
+    this.log.debug(`${label} CMD: ${cmd}`);
+    const cmdRes = await ssh.execCommand(cmd, sshCmdOptions);
+    this.log.debug(`${label} CMD Response: %o`, cmdRes);
+    Checks.truthy(cmdRes.code === null, `${label} cmdRes.code === null`);
+    return cmdRes;
+  }
+
   /**
-   * FIXME: Implement this feature of the connector.
-   *
    * @param req The object containing all the necessary metadata and parameters
    * in order to have the contract deployed.
    */
   public async deployContract(
     req: DeployContractGoSourceV1Request,
   ): Promise<DeployContractGoSourceV1Response> {
-    const fnTag = "PluginLedgerConnectorFabric#deployContract()";
-    throw new Error(`${fnTag} Not yet implemented! ${req}`);
+    const fnTag = `${this.className}#deployContract()`;
+
+    const ssh = new NodeSSH();
+    await ssh.connect(this.opts.sshConfig);
+    this.log.debug(`SSH connection OK`);
+
+    try {
+      this.log.debug(`${fnTag} Deploying .go source: ${req.goSource.filename}`);
+
+      Checks.truthy(req.goSource, `${fnTag}:req.goSource`);
+
+      temp.track();
+      const tmpDirPrefix = `hyperledger-cactus-${this.className}`;
+      const tmpDirPath = temp.mkdirSync(tmpDirPrefix);
+
+      // The module name of the chain-code, for example this will extract
+      // ccName to be "hello-world" from a filename of "hello-world.go"
+      const inferredModuleName = path.basename(req.goSource.filename, ".go");
+      this.log.debug(`Inferred module name: ${inferredModuleName}`);
+      const ccName = req.moduleName || inferredModuleName;
+      this.log.debug(`Determined ChainCode name: ${ccName}`);
+
+      const remoteDirPath = path.join(this.cliContainerGoPath, "src/", ccName);
+      this.log.debug(`Remote dir path on CLI container: ${remoteDirPath}`);
+
+      const localFilePath = path.join(tmpDirPath, req.goSource.filename);
+      fs.writeFileSync(localFilePath, req.goSource.body, "base64");
+
+      const remoteFilePath = path.join(remoteDirPath, req.goSource.filename);
+
+      this.log.debug(`SCP from/to %o => %o`, localFilePath, remoteFilePath);
+      await ssh.putFile(localFilePath, remoteFilePath);
+      this.log.debug(`SCP OK %o`, remoteFilePath);
+
+      const sshCmdOptions: SSHExecCommandOptions = {
+        execOptions: {
+          pty: true,
+          env: {
+            // just in case go modules would be otherwise disabled
+            GO111MODULE: "on",
+            FABRIC_LOGGING_SPEC: "DEBUG",
+          },
+        },
+        cwd: remoteDirPath,
+      };
+
+      const dockerExecEnv = Object.entries(this.opts.cliContainerEnv)
+        .map(([key, value]) => `--env ${key}=${value}`)
+        .join(" ");
+
+      const { dockerBinary } = this;
+      const dockerBuildCmd =
+        `${dockerBinary} exec ` +
+        dockerExecEnv +
+        ` --env GO111MODULE=on` +
+        ` --workdir=${remoteDirPath}` +
+        ` cli `;
+
+      await this.sshExec(
+        `${dockerBinary} exec cli mkdir -p ${remoteDirPath}/`,
+        "Create ChainCode project (go module) directory",
+        ssh,
+        sshCmdOptions,
+      );
+
+      await this.sshExec(
+        `${dockerBinary} exec cli go version`,
+        "Print go version",
+        ssh,
+        sshCmdOptions,
+      );
+
+      const copyToCliCmd = `${dockerBinary} cp ${remoteFilePath} cli:${remoteFilePath}`;
+      this.log.debug(`Copy to CLI Container CMD: ${copyToCliCmd}`);
+      const copyToCliRes = await ssh.execCommand(copyToCliCmd, sshCmdOptions);
+      this.log.debug(`Copy to CLI Container CMD Response: %o`, copyToCliRes);
+      Checks.truthy(copyToCliRes.code === null, `copyToCliRes.code === null`);
+
+      {
+        const goModInitCmd = `${dockerBuildCmd} go mod init ${ccName}`;
+        this.log.debug(`go mod init CMD: ${goModInitCmd}`);
+        const goModInitRes = await ssh.execCommand(goModInitCmd, sshCmdOptions);
+        this.log.debug(`go mod init CMD Response: %o`, goModInitRes);
+        Checks.truthy(goModInitRes.code === null, `goModInitRes.code === null`);
+      }
+
+      const pinnedDeps = req.pinnedDeps || [];
+      for (const dep of pinnedDeps) {
+        const goGetCmd = `${dockerBuildCmd} go get ${dep}`;
+        this.log.debug(`go get CMD: ${goGetCmd}`);
+        const goGetRes = await ssh.execCommand(goGetCmd, sshCmdOptions);
+        this.log.debug(`go get CMD Response: %o`, goGetRes);
+        Checks.truthy(goGetRes.code === null, `goGetRes.code === null`);
+      }
+
+      {
+        const goModTidyCmd = `${dockerBuildCmd} go mod tidy`;
+        this.log.debug(`go mod tidy CMD: ${goModTidyCmd}`);
+        const goModTidyRes = await ssh.execCommand(goModTidyCmd, sshCmdOptions);
+        this.log.debug(`go mod tidy CMD Response: %o`, goModTidyRes);
+        Checks.truthy(goModTidyRes.code === null, `goModTidyRes.code === null`);
+      }
+
+      {
+        const goVendorCmd = `${dockerBuildCmd} go mod vendor`;
+        this.log.debug(`go mod vendor CMD: ${goVendorCmd}`);
+        const goVendorRes = await ssh.execCommand(goVendorCmd, sshCmdOptions);
+        this.log.debug(`go mod vendor CMD Response: %o`, goVendorRes);
+        Checks.truthy(goVendorRes.code === null, `goVendorRes.code === null`);
+      }
+
+      {
+        const goBuildCmd = `${dockerBuildCmd} go build`;
+        this.log.debug(`go build CMD: ${goBuildCmd}`);
+        const goBuildRes = await ssh.execCommand(goBuildCmd, sshCmdOptions);
+        this.log.debug(`go build CMD Response: %o`, goBuildRes);
+        Checks.truthy(goBuildRes.code === null, `goBuildRes.code === null`);
+      }
+
+      // https://github.com/hyperledger/fabric-samples/blob/release-1.4/fabcar/startFabric.sh
+      for (const org of req.targetOrganizations) {
+        const env =
+          ` --env CORE_PEER_LOCALMSPID=${org.CORE_PEER_LOCALMSPID}` +
+          ` --env CORE_PEER_ADDRESS=${org.CORE_PEER_ADDRESS}` +
+          ` --env CORE_PEER_MSPCONFIGPATH=${org.CORE_PEER_MSPCONFIGPATH}` +
+          ` --env CORE_PEER_TLS_ROOTCERT_FILE=${org.CORE_PEER_TLS_ROOTCERT_FILE}`;
+
+        await this.sshExec(
+          dockerBinary +
+            ` exec ${env} cli peer chaincode install` +
+            ` --name ${ccName} ` +
+            ` --path ${ccName} ` +
+            ` --version ${req.chainCodeVersion} ` +
+            ` --lang golang`,
+          `Install ChainCode in ${org.CORE_PEER_LOCALMSPID}`,
+          ssh,
+          sshCmdOptions,
+        );
+      }
+
+      let success = true;
+
+      const ctorArgsJson = JSON.stringify(req.constructorArgs || {});
+      const ordererCaFile =
+        "/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt";
+
+      const instantiateCmd =
+        `${dockerBuildCmd} peer chaincode instantiate ` +
+        ` --name ${ccName} ` +
+        ` --version ${req.chainCodeVersion} ` +
+        ` --ctor '${ctorArgsJson}' ` +
+        ` --channelID ${req.channelId} ` +
+        ` --peerAddresses ${req.targetPeerAddresses[0]}` +
+        ` --lang golang ` +
+        ` --tlsRootCertFiles ${req.tlsRootCertFiles}` +
+        ` --policy "${req.policyDslSource}"` +
+        ` --tls --cafile ${ordererCaFile}`;
+
+      this.log.debug(`Instantiate CMD: %o`, instantiateCmd);
+      const instantiateCmdRes = await ssh.execCommand(
+        instantiateCmd,
+        sshCmdOptions,
+      );
+
+      this.log.debug(`Instantiate CMD Response: %o`, instantiateCmdRes);
+      success = success && instantiateCmdRes.code === null;
+
+      this.log.debug(`EXIT doDeploy()`);
+      const res: DeployContractGoSourceV1Response = {
+        success,
+        installationCommandResponse: {} as any,
+        instantiationCommandResponse: instantiateCmdRes,
+      };
+      return res;
+    } finally {
+      try {
+        ssh.dispose();
+      } finally {
+        temp.cleanup();
+      }
+    }
   }
 
   public async installWebServices(

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts
@@ -41,6 +41,7 @@ test("runs tx on a Fabric v1.4.8 ledger", async (t: Test) => {
 
   const ledger = new FabricTestLedgerV1({
     publishAllPorts: true,
+    emitContainerLogs: false,
     logLevel,
     imageName: "hyperledger/cactus-fabric-all-in-one",
     imageVersion: "2020-12-16-3ddfd8f-v1.4.8",
@@ -92,6 +93,7 @@ test("runs tx on a Fabric v1.4.8 ledger", async (t: Test) => {
     instanceId: uuidv4(),
     pluginRegistry,
     sshConfig,
+    cliContainerEnv: {},
     logLevel,
     connectionProfile,
     discoveryOptions,

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
@@ -7,7 +7,10 @@ import { v4 as uuidv4 } from "uuid";
 import bodyParser from "body-parser";
 import express from "express";
 
-import { FabricTestLedgerV1 } from "@hyperledger/cactus-test-tooling";
+import {
+  Containers,
+  FabricTestLedgerV1,
+} from "@hyperledger/cactus-test-tooling";
 import { PluginRegistry } from "@hyperledger/cactus-core";
 
 import {
@@ -37,6 +40,16 @@ import { DiscoveryOptions } from "fabric-network";
  */
 
 test("runs tx on a Fabric v2.2.0 ledger", async (t: Test) => {
+  // Always set to true when GitHub Actions is running the workflow.
+  // You can use this variable to differentiate when tests are being run locally or by GitHub Actions.
+  // @see https://docs.github.com/en/actions/reference/environment-variables
+  if (process.env.GITHUB_ACTIONS === "true") {
+    // Github Actions started to run out of disk space recently so we have this
+    // hack here to attempt to free up disk space when running inside a VM of
+    // the CI system.
+    await Containers.pruneDockerResources();
+  }
+
   const logLevel: LogLevelDesc = "TRACE";
 
   const ledger = new FabricTestLedgerV1({

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/unit/chain-code-compiler.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/unit/chain-code-compiler.test.ts
@@ -9,7 +9,9 @@ import {
 
 import { HELLO_WORLD_CONTRACT_GO_SOURCE } from "../fixtures/go/hello-world-contract-fabric-v14/hello-world-contract-go-source";
 
-test("compiles chaincode straight from go source code", async (t: Test) => {
+// FIXME - the chain code compiler will undergo a refactor to make it work via
+// SSH/docker exec. Until then, leave this test out.
+test.skip("compiles chaincode straight from go source code", async (t: Test) => {
   const compiler = new ChainCodeCompiler({ logLevel: "TRACE" });
 
   const opts: ICompilationOptions = {

--- a/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
@@ -373,4 +373,28 @@ export class Containers {
       await new Promise((resolve2) => setTimeout(resolve2, 1000));
     } while (!reachable);
   }
+
+  public static async pruneDockerResources(): Promise<void> {
+    const docker = new Dockerode();
+    try {
+      await docker.pruneContainers();
+    } catch (ex) {
+      console.warn(`Failed to prune docker containers: `, ex);
+    }
+    try {
+      await docker.pruneVolumes();
+    } catch (ex) {
+      console.warn(`Failed to prune docker volumes: `, ex);
+    }
+    try {
+      await docker.pruneImages();
+    } catch (ex) {
+      console.warn(`Failed to prune docker images: `, ex);
+    }
+    try {
+      await docker.pruneNetworks();
+    } catch (ex) {
+      console.warn(`Failed to prune docker networks: `, ex);
+    }
+  }
 }

--- a/tools/docker/fabric-all-in-one/Dockerfile_v2.x
+++ b/tools/docker/fabric-all-in-one/Dockerfile_v2.x
@@ -80,25 +80,7 @@ RUN ["/bin/bash", "-c", "ssh-keygen -t rsa -N '' -f $CACTUS_CFG_PATH/fabric-aio-
 RUN mv $CACTUS_CFG_PATH/fabric-aio-image $CACTUS_CFG_PATH/fabric-aio-image.key
 RUN cp $CACTUS_CFG_PATH/fabric-aio-image.pub ~/.ssh/authorized_keys
 
-# Download and execute the Fabric bootstrap script, but instruct it with the -d
-# flag to avoid pulling docker images because during the build phase of this image
-# there is no docker daemon running yet so this has to happen in the CMD once a
-# container has been started from the image => see ./run-fabric-network-sh
-RUN curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/release-2.2/scripts/bootstrap.sh > /bootstrap.sh
-RUN chmod +x bootstrap.sh
-# Run the bootstrap here so that at least we can pre-fetch the git clone and the binary downloads resulting in
-# faster container startup speed since these steps will not have to be done, only the docker image pulls.
-RUN /bootstrap.sh ${FABRIC_VERSION} ${CA_VERSION} -d
-
-# Install supervisord because we need to run the docker daemon and also the fabric network
-# meaning that we have multiple processes to run.
-RUN apk add --no-cache supervisor
-COPY supervisord.conf /etc/supervisord.conf
-
-COPY run-fabric-network.sh /
-COPY healthcheck.sh /
-
-# OpenSSH Server (needed for chaincode deployment ) 
+# OpenSSH Server (needed for chaincode deployment )
 EXPOSE 22
 
 # supervisord web ui/dashboard
@@ -132,6 +114,55 @@ RUN apk add --no-cache util-linux
 
 # FIXME - make it so that SSHd does not need this to work
 RUN echo "root:$(uuidgen)" | chpasswd
+
+RUN curl -sSL https://raw.githubusercontent.com/cloudflare/semver_bash/c1133faf0efe17767b654b213f212c326df73fa3/semver.sh > /semver.sh
+RUN chmod +x /semver.sh
+
+# jq is needed by the /download-frozen-image-v2.sh script to pre-fetch docker images without docker.
+RUN apk add --no-cache jq
+
+# Get the utility script that can pre-fetch the Fabric docker images without
+# a functioning Docker daemon available which we do not have at image build
+# time so have to resort to manually get the Fabric images insteadd of just saying
+# "docker pull hyperledger/fabric..." etc.
+# The reason to jump trough these hoops is to speed up the boot time of the
+# container which won't have to download the images at container startup since
+# they'll have been cached already at build time.
+RUN curl -sSL https://raw.githubusercontent.com/moby/moby/dedf8528a51c6db40686ed6676e9486d1ed5f9c0/contrib/download-frozen-image-v2.sh > /download-frozen-image-v2.sh
+RUN chmod +x /download-frozen-image-v2.sh
+
+RUN mkdir -p /etc/hyperledger/fabric
+RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/ hyperledger/fabric-peer:${FABRIC_VERSION}
+RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/ hyperledger/fabric-orderer:${FABRIC_VERSION}
+RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/ hyperledger/fabric-ccenv:${FABRIC_VERSION}
+RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/ hyperledger/fabric-tools:${FABRIC_VERSION}
+RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/ hyperledger/fabric-baseos:${FABRIC_VERSION}
+RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/ hyperledger/fabric-ca:${CA_VERSION}
+
+# Download and execute the Fabric bootstrap script, but instruct it with the -d
+# flag to avoid pulling docker images because during the build phase of this image
+# there is no docker daemon running yet
+RUN curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/2f69b4222e9c9090b5c1ca235c1b59687566f13e/scripts/bootstrap.sh > /bootstrap.sh
+RUN chmod +x bootstrap.sh
+# Run the bootstrap here so that at least we can pre-fetch the git clone and the binary downloads resulting in
+# faster container startup speed since these steps will not have to be done, only the docker image pulls.
+RUN /bootstrap.sh ${FABRIC_VERSION} ${CA_VERSION} -d
+
+# Install supervisord because we need to run the docker daemon and also the fabric network
+# meaning that we have multiple processes to run.
+RUN apk add --no-cache supervisor
+
+COPY supervisord.conf /etc/supervisord.conf
+COPY run-fabric-network.sh /
+COPY healthcheck.sh /
+
+ENV FABRIC_CFG_PATH=/fabric-samples/config/
+ENV CORE_PEER_TLS_ENABLED=true
+ENV CORE_PEER_LOCALMSPID="Org1MSP"
+ENV CORE_PEER_TLS_ROOTCERT_FILE=/fabric-samples/test-network/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
+ENV CORE_PEER_MSPCONFIGPATH=/fabric-samples/test-network/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
+ENV CORE_PEER_ADDRESS=localhost:7051
+ENV COMPOSE_PROJECT_NAME=cactusfabrictestnetwork
 
 # Extend the parent image's entrypoint
 # https://superuser.com/questions/1459466/can-i-add-an-additional-docker-entrypoint-script

--- a/tools/docker/fabric-all-in-one/README.md
+++ b/tools/docker/fabric-all-in-one/README.md
@@ -3,7 +3,16 @@
 > This docker image is for `testing` and `development` only.
 > Do NOT use in production!
 
-An all in one fabric docker image with 1 peer, 1 orderer and 1 channel.
+An all in one fabric docker image with the `fabric-samples` repo fully embedded.
+
+## Usage
+
+### Building Local Image
+
+```sh
+DOCKER_BUILDKIT=1 docker build ./tools/docker/fabric-all-in-one/ -f ./tools/docker/fabric-all-in-one/Dockerfile_v1.4.x -t faio14x
+```
+### VSCode
 
 ## Usage
 
@@ -53,11 +62,11 @@ db676059b79e        faio2x              "/usr/bin/supervisor…"   9 minutes ago
 
 docker cp db676059b79e:/etc/hyperledger/cactus/fabric-aio-image.key ./fabric-aio-image.key
 
-ssh root@localhost -p 32924 -i fabric-aio-image.key 
+ssh root@localhost -p 32924 -i fabric-aio-image.key
 ```
 
 ```sh
-docker build ./tools/docker/fabric-all-in-one/ -f ./tools/docker/fabric-all-in-one/Dockerfile_v1.4.x  -t faio14x
+DOCKER_BUILDKIT=1 docker build ./tools/docker/fabric-all-in-one/ -f ./tools/docker/fabric-all-in-one/Dockerfile_v1.4.x  -t faio14x
 docker run --detach --privileged --publish-all --env FABRIC_VERSION=1.4.8 faio14x
 
 docker ps

--- a/tools/docker/fabric-all-in-one/healthcheck.sh
+++ b/tools/docker/fabric-all-in-one/healthcheck.sh
@@ -1,18 +1,27 @@
-if echo ${FABRIC_VERSION} | grep 2.
-then
-    cd fabric-samples/test-network
-    export PATH=${PWD}/../bin:${PWD}:$PATH
-    export FABRIC_CFG_PATH=$PWD/../config/
-    # for peer command issued to peer0.org1.example.com
-    export CORE_PEER_TLS_ENABLED=true
-    export CORE_PEER_LOCALMSPID="Org1MSP"
-    export CORE_PEER_TLS_ROOTCERT_FILE=${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
-    export CORE_PEER_MSPCONFIGPATH=${PWD}/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
-    export CORE_PEER_ADDRESS=localhost:7051
-    peer chaincode query --channelID mychannel --name fabcar --ctor '{"Args": [], "Function": "queryAllCars"}'
-elif echo ${FABRIC_VERSION} | grep 1.
-then
+#!/bin/sh
+
+# Needed so that we have the "peer" binary on our path
+export PATH=/fabric-samples/bin/:$PATH
+
+# Source the utility that we use to parse semantic version strings in bash
+. /semver.sh
+
+function main()
+{
+  local MAJOR=0
+  local MINOR=0
+  local PATCH=0
+  local SPECIAL=""
+  semverParseInto "${FABRIC_VERSION}" MAJOR MINOR PATCH SPECIAL
+
+  if [ "$MAJOR" -gt 1 ]; then
+    # Major version is 2 or newer (we'll deal with 3.x when it is released)
+    cd /fabric-samples/test-network/
+    peer chaincode invoke -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile "${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem" -C mychannel -n basic --peerAddresses localhost:7051 --tlsRootCertFiles "${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt" --peerAddresses localhost:9051 --tlsRootCertFiles "${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt" -c '{"function":"InitLedger","Args":[]}'
+  else
+    # Major version is 1.x or earlier (assumption is 1.4.x only)
     docker exec cli peer chaincode query --channelID mychannel --name fabcar --ctor '{"Args": [], "Function": "queryAllCars"}'
-else
-    echo "Unsupported fabric version."
-fi
+  fi
+}
+
+main

--- a/tools/docker/fabric-all-in-one/run-fabric-network.sh
+++ b/tools/docker/fabric-all-in-one/run-fabric-network.sh
@@ -1,6 +1,44 @@
 #!/bin/sh
 set -e
 
-/bootstrap.sh ${FABRIC_VERSION} ${CA_VERSION} -b -s
-cd /fabric-samples/fabcar/
-./startFabric.sh
+# Needed so that we have the "peer" binary on our path
+export PATH=/fabric-samples/bin/:$PATH
+
+# Source the utility that we use to parse semantic version strings in bash
+. /semver.sh
+
+function main()
+{
+
+  local MAJOR=0
+  local MINOR=0
+  local PATCH=0
+  local SPECIAL=""
+  semverParseInto "${FABRIC_VERSION}" MAJOR MINOR PATCH SPECIAL
+
+  tar -cC '/etc/hyperledger/fabric/' . | docker load
+
+  /bootstrap.sh ${FABRIC_VERSION} ${CA_VERSION} -b -s
+
+  echo "[FabricAIO] >>> Parsed MAJOR version of Fabric as ${MAJOR}"
+
+  if [ "$MAJOR" -gt 1 ]; then
+    # Major version is 2 or newer (we'll deal with 3.x when it is released)
+    cd /fabric-samples/test-network/
+    echo "[FabricAIO] >>> pulling up test network..."
+    ./network.sh up -ca
+    echo "[FabricAIO] >>> test network pulled up OK."
+    ./network.sh createChannel -c mychannel
+    echo "[FabricAIO] >>> channel created OK."
+    ./network.sh deployCC -ccn basic -ccp ../asset-transfer-basic/chaincode-go -ccl go
+    echo "[FabricAIO] >>> contract deployed OK."
+    echo "[FabricAIO] >>> container healthcheck should begin passing in about 5-15 seconds..."
+  else
+    # Major version is 1.x or earlier (assumption is 1.4.x only)
+    cd /fabric-samples/fabcar/
+    ./startFabric.sh
+  fi
+
+}
+
+main

--- a/tools/docker/fabric-all-in-one/supervisord.conf
+++ b/tools/docker/fabric-all-in-one/supervisord.conf
@@ -2,28 +2,34 @@
 logfile = /var/log/supervisord.log
 logfile_maxbytes = 50MB
 logfile_backups=10
-loglevel = info
+loglevel = debug
 
 [program:sshd]
-command=/usr/sbin/sshd -D
+command=/usr/sbin/sshd -D -dd
 autostart=true
 autorestart=true
-stderr_logfile=/var/log/sshd.err.log
-stdout_logfile=/var/log/sshd.out.log
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:dockerd]
 command=dockerd-entrypoint.sh
 autostart=true
 autorestart=true
-stderr_logfile=/var/log/dockerd.err.log
-stdout_logfile=/var/log/dockerd.out.log
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:fabric-network]
 command=/run-fabric-network.sh
 autostart=true
 autorestart=unexpected
-stderr_logfile=/var/log/fabric-network.err.log
-stdout_logfile=/var/log/fabric-network.out.log
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [inet_http_server]
 port = 0.0.0.0:9001


### PR DESCRIPTION
Depends on #644
Depends on #645
Depends on #646

Primary change
=============

Finally adds real support for chain code deployment with
custom made contracts not just the ones that the fabric
samples container comes pre-built with.

Additional notes, changes
========================

1. Makes assumptions about the ledger being containerized the
same way the fabric-samples repo does it, e.g. there must
be a container called "cli" which is set up to execute the peer
binary and to be able to perform go builds with a version of
go that has go modules support (1.11+ IIRC)
2. Does not yet support Fabric 2.x (at least it was not tested)
3. Magic strings in the connector that still need to be eliminted.
4. Go mod file upload is not supported, for now one must use the
pinned dependencies array to lock dependencies to specific versions.
5. The deployment endpoint supports deploying to multiple orgs
with a single request but this only makes sense for example code
since in a production environment it is not expected that different
organizations will share the same server/container to run their
infrastructure.
6. Output structure is not yet finalized. Priority was for now to
at least allow failure detection. Diagnostics is a bit harder to
achieve but should come in a follow-up improvement nevertheless.

End to end test demonstrating how it all works can be seen at:
packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/deploy-contract-go-bin-endpoint-v1/deploy-contract/deploy-cc-from-golang-source.test.ts

Fixes #616

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>
