### PR TITLE
fix(tools): fabric all-in-one SSH access denied #631

### DIFF
--- a/tools/docker/fabric-all-in-one/Dockerfile_v1.4.x
+++ b/tools/docker/fabric-all-in-one/Dockerfile_v1.4.x
@@ -63,7 +63,10 @@ RUN apk add --no-cache openssh augeas
 RUN augtool 'set /files/etc/ssh/sshd_config/AuthorizedKeysFile ".ssh/authorized_keys /etc/authorized_keys/%u"'
 RUN augtool 'set /files/etc/ssh/sshd_config/PermitRootLogin yes'
 RUN augtool 'set /files/etc/ssh/sshd_config/PasswordAuthentication no'
+RUN augtool 'set /files/etc/ssh/sshd_config/PermitEmptyPasswords no'
 RUN augtool 'set /files/etc/ssh/sshd_config/Port 22'
+RUN augtool 'set /files/etc/ssh/sshd_config/LogLevel DEBUG2'
+RUN augtool 'set /files/etc/ssh/sshd_config/LoginGraceTime 10'
 # Create the server's key - without this sshd will refuse to start
 RUN ssh-keygen -A
 
@@ -95,6 +98,9 @@ COPY supervisord.conf /etc/supervisord.conf
 COPY run-fabric-network.sh /
 COPY healthcheck.sh /
 
+# OpenSSH Server (needed for chaincode deployment ) 
+EXPOSE 22
+
 # supervisord web ui/dashboard
 EXPOSE 9001
 
@@ -121,6 +127,11 @@ EXPOSE 8054
 
 # couchdb0, couchdb1, couchdb2, couchdb3
 EXPOSE 5984 6984 7984 8984
+
+RUN apk add --no-cache util-linux
+
+# FIXME - make it so that SSHd does not need this to work
+RUN echo "root:$(uuidgen)" | chpasswd
 
 # Extend the parent image's entrypoint
 # https://superuser.com/questions/1459466/can-i-add-an-additional-docker-entrypoint-script

--- a/tools/docker/fabric-all-in-one/Dockerfile_v2.x
+++ b/tools/docker/fabric-all-in-one/Dockerfile_v2.x
@@ -63,7 +63,10 @@ RUN apk add --no-cache openssh augeas
 RUN augtool 'set /files/etc/ssh/sshd_config/AuthorizedKeysFile ".ssh/authorized_keys /etc/authorized_keys/%u"'
 RUN augtool 'set /files/etc/ssh/sshd_config/PermitRootLogin yes'
 RUN augtool 'set /files/etc/ssh/sshd_config/PasswordAuthentication no'
+RUN augtool 'set /files/etc/ssh/sshd_config/PermitEmptyPasswords no'
 RUN augtool 'set /files/etc/ssh/sshd_config/Port 22'
+RUN augtool 'set /files/etc/ssh/sshd_config/LogLevel DEBUG2'
+RUN augtool 'set /files/etc/ssh/sshd_config/LoginGraceTime 10'
 # Create the server's key - without this sshd will refuse to start
 RUN ssh-keygen -A
 
@@ -95,6 +98,9 @@ COPY supervisord.conf /etc/supervisord.conf
 COPY run-fabric-network.sh /
 COPY healthcheck.sh /
 
+# OpenSSH Server (needed for chaincode deployment ) 
+EXPOSE 22
+
 # supervisord web ui/dashboard
 EXPOSE 9001
 
@@ -121,6 +127,11 @@ EXPOSE 8054
 
 # couchdb0, couchdb1, couchdb2, couchdb3
 EXPOSE 5984 6984 7984 8984
+
+RUN apk add --no-cache util-linux
+
+# FIXME - make it so that SSHd does not need this to work
+RUN echo "root:$(uuidgen)" | chpasswd
 
 # Extend the parent image's entrypoint
 # https://superuser.com/questions/1459466/can-i-add-an-additional-docker-entrypoint-script

--- a/tools/docker/fabric-all-in-one/README.md
+++ b/tools/docker/fabric-all-in-one/README.md
@@ -45,10 +45,29 @@ From the project root:
 
 ```sh
 docker build ./tools/docker/fabric-all-in-one/ -f ./tools/docker/fabric-all-in-one/Dockerfile_v2.x -t faio2x
+docker run --detach --privileged --publish-all --env FABRIC_VERSION=2.2.0 faio2x
+
+docker ps
+CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                     PORTS                                                                                                                                                                                                                                                                                                                                                                                  NAMES
+db676059b79e        faio2x              "/usr/bin/supervisor…"   9 minutes ago       Up 9 minutes   0.0.0.0:32924->22/tcp, 0.0.0.0:32923->2375/tcp, 0.0.0.0:32922->2376/tcp, 0.0.0.0:32921->5984/tcp, 0.0.0.0:32920->6984/tcp, 0.0.0.0:32919->7050/tcp, 0.0.0.0:32918->7051/tcp, 0.0.0.0:32917->7054/tcp, 0.0.0.0:32916->7984/tcp, 0.0.0.0:32915->8051/tcp, 0.0.0.0:32914->8054/tcp, 0.0.0.0:32913->8984/tcp, 0.0.0.0:32912->9001/tcp, 0.0.0.0:32911->9051/tcp, 0.0.0.0:32910->10051/tcp   sharp_clarke
+
+docker cp db676059b79e:/etc/hyperledger/cactus/fabric-aio-image.key ./fabric-aio-image.key
+
+ssh root@localhost -p 32924 -i fabric-aio-image.key 
 ```
 
 ```sh
 docker build ./tools/docker/fabric-all-in-one/ -f ./tools/docker/fabric-all-in-one/Dockerfile_v1.4.x  -t faio14x
+docker run --detach --privileged --publish-all --env FABRIC_VERSION=1.4.8 faio14x
+
+docker ps
+
+CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                            PORTS                                                                                                                                                                                                                                                                                                                                                                                  NAMES
+c09eb94d94d3        faio14x             "/usr/bin/supervisor…"   5 seconds ago       Up 4 seconds (health: starting)   0.0.0.0:32990->22/tcp, 0.0.0.0:32989->2375/tcp, 0.0.0.0:32988->2376/tcp, 0.0.0.0:32987->5984/tcp, 0.0.0.0:32986->6984/tcp, 0.0.0.0:32985->7050/tcp, 0.0.0.0:32984->7051/tcp, 0.0.0.0:32983->7054/tcp, 0.0.0.0:32982->7984/tcp, 0.0.0.0:32981->8051/tcp, 0.0.0.0:32980->8054/tcp, 0.0.0.0:32979->8984/tcp, 0.0.0.0:32978->9001/tcp, 0.0.0.0:32977->9051/tcp, 0.0.0.0:32976->10051/tcp   funny_jepsen
+
+
+docker cp c09eb94d94d3:/etc/hyperledger/cactus/fabric-aio-image.key ./fabric-aio-image.key
+ssh root@localhost -p 32990 -i fabric-aio-image.key
 ```
 
 ### Running Fabric CLI Container Commands


### PR DESCRIPTION
Fixes #631

The root user account was locked (assuming by default)
so had to give it a password just so that we can log
in with it via SSH.
Since we don't actually plan on using the root password
I just set it to a UUID to make it a little less trivial
to recover it (which shouldn't matter anyway since we
strictly advise against using the AIO images in production
anyway).

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>