### PR TITLE
docs(readme): add GIF showcasing the watch script

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -10,6 +10,23 @@ machine or if you are planning on contributing.
 
 The project uses Typescript for both back-end and front-end components.
 
+## Fast Developer Flow / Code Iterations
+
+We put a lot of thought and effort into making sure that fast developer iterations can be
+achieved (please file a bug if you feel otherwise) while working **on** the framework. 
+
+If you find yourself waiting too much for builds to finish, most of the time 
+that can be helped by using the `npm run watch` script which can automatically 
+recompile packages as you modify them (and only the packages that you have 
+modified, not everything).
+
+It also supports re-running the OpenAPI generator when you update any 
+`openapi.json` spec files that we use to describe our endpoints.
+
+The `npm run watch` script in action:
+
+![Fast Developer Flow / Code Iterations](./docs/hyperledger-cactus-watch-script-tutorial-2021-03-06.gif)
+
 ## Getting Started
 
 * Install OS level dependencies:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Once the last command has finished executing, open link printed on the console w
 * mailing list: [cactus@lists.hyperledger.org](mailto:cactus@lists.hyperledger.org)
 * rocketchat channel: [https://chat.hyperledger.org/channel/cactus](https://chat.hyperledger.org/channel/cactus).
 
+## Build/Development Flow
+
+To go from zero to hero with project setup and working on your contributions: [BUILD.md](./BUILD.md)
+
 ## Contributing
 We welcome contributions to Hyperledger Cactus in many forms, and there’s always plenty to do!
 


### PR DESCRIPTION
## Dependencies

Depends on #656 

## Commit to be reviewed

docs(readme): add reference to BUILD.md

BUILD.md: add GIF showcasing the watch script

We've received feedback from multiple people that long build
times are tedious and reduce general productivity which is
(probably) hindering the growth of the community so here is
a video guide (GIF) on how fast builds can be achieved by
only rebuilding what you actually changed on the package level.

It also comes with support for regenerating the code that we
don't write ourselves but use the OpenAPI generator for it instead.
All the openapi.json files are being watched by the npm run watch
script for code changes the same way that Typescript files are being
watched so this just works out of the box.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>