### PR TITLE
fix(tools): fabric AIO image log access in CI #643

### DIFF
--- a/tools/docker/fabric-all-in-one/supervisord.conf
+++ b/tools/docker/fabric-all-in-one/supervisord.conf
@@ -2,28 +2,34 @@
 logfile = /var/log/supervisord.log
 logfile_maxbytes = 50MB
 logfile_backups=10
-loglevel = info
+loglevel = debug
 
 [program:sshd]
-command=/usr/sbin/sshd -D
+command=/usr/sbin/sshd -D -dd
 autostart=true
 autorestart=true
-stderr_logfile=/var/log/sshd.err.log
-stdout_logfile=/var/log/sshd.out.log
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:dockerd]
 command=dockerd-entrypoint.sh
 autostart=true
 autorestart=true
-stderr_logfile=/var/log/dockerd.err.log
-stdout_logfile=/var/log/dockerd.out.log
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:fabric-network]
 command=/run-fabric-network.sh
 autostart=true
 autorestart=unexpected
-stderr_logfile=/var/log/fabric-network.err.log
-stdout_logfile=/var/log/fabric-network.out.log
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [inet_http_server]
 port = 0.0.0.0:9001


### PR DESCRIPTION
This commit is meant to make it much easier to debug
issues with the Fabric 2.x AIO container image in the
future when new bugs (inevitably) arise.

Meaning that the logs of the child processess such as
the fabric network creator script or the docker daemon will
all be piped through to the logs of the container itself
instead of just being dumped into log files under
/var/log/... which has the upside of not having to
shell into the container when something goes wrong
and one wishes to debug what happened. Instead the
logs of the container will show all the information
right away.

In addition to the above change a flag was added to
the FabricTestLedger class' constructor options so
that one  can tell the class to dump the continer's
log stream straight onto it's own logger meaning
that now if you are debugging a test case you will
be able to see all the logs that are being output
straight in the logs of the test case itself.
This can be very spammy at times, hence the flag
that can be used to turn it on or off depending on
what is needed more.

One more small change that we made to help debugging:
The supervisord config file now specifies the loglevel
of supervisord as debug instead of info.

Fixes #643

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>