### PR TITLE
fix(ci): github action runner disk full error #641

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
@@ -7,7 +7,10 @@ import { v4 as uuidv4 } from "uuid";
 import bodyParser from "body-parser";
 import express from "express";
 
-import { FabricTestLedgerV1 } from "@hyperledger/cactus-test-tooling";
+import {
+  Containers,
+  FabricTestLedgerV1,
+} from "@hyperledger/cactus-test-tooling";
 import { PluginRegistry } from "@hyperledger/cactus-core";
 
 import {
@@ -37,6 +40,16 @@ import { DiscoveryOptions } from "fabric-network";
  */
 
 test("runs tx on a Fabric v2.2.0 ledger", async (t: Test) => {
+  // Always set to true when GitHub Actions is running the workflow.
+  // You can use this variable to differentiate when tests are being run locally or by GitHub Actions.
+  // @see https://docs.github.com/en/actions/reference/environment-variables
+  if (process.env.GITHUB_ACTIONS === "true") {
+    // Github Actions started to run out of disk space recently so we have this
+    // hack here to attempt to free up disk space when running inside a VM of
+    // the CI system.
+    await Containers.pruneDockerResources();
+  }
+
   const logLevel: LogLevelDesc = "TRACE";
 
   const ledger = new FabricTestLedgerV1({

--- a/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
@@ -373,4 +373,28 @@ export class Containers {
       await new Promise((resolve2) => setTimeout(resolve2, 1000));
     } while (!reachable);
   }
+
+  public static async pruneDockerResources(): Promise<void> {
+    const docker = new Dockerode();
+    try {
+      await docker.pruneContainers();
+    } catch (ex) {
+      console.warn(`Failed to prune docker containers: `, ex);
+    }
+    try {
+      await docker.pruneVolumes();
+    } catch (ex) {
+      console.warn(`Failed to prune docker volumes: `, ex);
+    }
+    try {
+      await docker.pruneImages();
+    } catch (ex) {
+      console.warn(`Failed to prune docker images: `, ex);
+    }
+    try {
+      await docker.pruneNetworks();
+    } catch (ex) {
+      console.warn(`Failed to prune docker networks: `, ex);
+    }
+  }
 }

--- a/tools/docker/fabric-all-in-one/supervisord.conf
+++ b/tools/docker/fabric-all-in-one/supervisord.conf
@@ -2,28 +2,34 @@
 logfile = /var/log/supervisord.log
 logfile_maxbytes = 50MB
 logfile_backups=10
-loglevel = info
+loglevel = debug
 
 [program:sshd]
-command=/usr/sbin/sshd -D
+command=/usr/sbin/sshd -D -dd
 autostart=true
 autorestart=true
-stderr_logfile=/var/log/sshd.err.log
-stdout_logfile=/var/log/sshd.out.log
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:dockerd]
 command=dockerd-entrypoint.sh
 autostart=true
 autorestart=true
-stderr_logfile=/var/log/dockerd.err.log
-stdout_logfile=/var/log/dockerd.out.log
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:fabric-network]
 command=/run-fabric-network.sh
 autostart=true
 autorestart=unexpected
-stderr_logfile=/var/log/fabric-network.err.log
-stdout_logfile=/var/log/fabric-network.out.log
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [inet_http_server]
 port = 0.0.0.0:9001


### PR DESCRIPTION
Depends on #644 

Added a docker resource pruning call to the
test case that was triggering the disk full issue
while pulling the Fabric AIO image necessary
for it's operation.

It is expected that this error will crop up in the future with different test cases and if and when that
happens we can add more of the same to
those tests as well, but for now, I did not want to
make this change to every single test case since
it wasn't strictly necessary and a better solution may
come along in the near future as well.

Fixes #641
