### PR TITLE
fix(tools): fabric AIO fabric-samples v2.2.0 breaking change #632

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
@@ -7,7 +7,10 @@ import { v4 as uuidv4 } from "uuid";
 import bodyParser from "body-parser";
 import express from "express";
 
-import { FabricTestLedgerV1 } from "@hyperledger/cactus-test-tooling";
+import {
+  Containers,
+  FabricTestLedgerV1,
+} from "@hyperledger/cactus-test-tooling";
 import { PluginRegistry } from "@hyperledger/cactus-core";
 
 import {
@@ -37,6 +40,16 @@ import { DiscoveryOptions } from "fabric-network";
  */
 
 test("runs tx on a Fabric v2.2.0 ledger", async (t: Test) => {
+  // Always set to true when GitHub Actions is running the workflow.
+  // You can use this variable to differentiate when tests are being run locally or by GitHub Actions.
+  // @see https://docs.github.com/en/actions/reference/environment-variables
+  if (process.env.GITHUB_ACTIONS === "true") {
+    // Github Actions started to run out of disk space recently so we have this
+    // hack here to attempt to free up disk space when running inside a VM of
+    // the CI system.
+    await Containers.pruneDockerResources();
+  }
+
   const logLevel: LogLevelDesc = "TRACE";
 
   const ledger = new FabricTestLedgerV1({

--- a/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
@@ -373,4 +373,28 @@ export class Containers {
       await new Promise((resolve2) => setTimeout(resolve2, 1000));
     } while (!reachable);
   }
+
+  public static async pruneDockerResources(): Promise<void> {
+    const docker = new Dockerode();
+    try {
+      await docker.pruneContainers();
+    } catch (ex) {
+      console.warn(`Failed to prune docker containers: `, ex);
+    }
+    try {
+      await docker.pruneVolumes();
+    } catch (ex) {
+      console.warn(`Failed to prune docker volumes: `, ex);
+    }
+    try {
+      await docker.pruneImages();
+    } catch (ex) {
+      console.warn(`Failed to prune docker images: `, ex);
+    }
+    try {
+      await docker.pruneNetworks();
+    } catch (ex) {
+      console.warn(`Failed to prune docker networks: `, ex);
+    }
+  }
 }

--- a/tools/docker/fabric-all-in-one/Dockerfile_v2.x
+++ b/tools/docker/fabric-all-in-one/Dockerfile_v2.x
@@ -80,25 +80,7 @@ RUN ["/bin/bash", "-c", "ssh-keygen -t rsa -N '' -f $CACTUS_CFG_PATH/fabric-aio-
 RUN mv $CACTUS_CFG_PATH/fabric-aio-image $CACTUS_CFG_PATH/fabric-aio-image.key
 RUN cp $CACTUS_CFG_PATH/fabric-aio-image.pub ~/.ssh/authorized_keys
 
-# Download and execute the Fabric bootstrap script, but instruct it with the -d
-# flag to avoid pulling docker images because during the build phase of this image
-# there is no docker daemon running yet so this has to happen in the CMD once a
-# container has been started from the image => see ./run-fabric-network-sh
-RUN curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/release-2.2/scripts/bootstrap.sh > /bootstrap.sh
-RUN chmod +x bootstrap.sh
-# Run the bootstrap here so that at least we can pre-fetch the git clone and the binary downloads resulting in
-# faster container startup speed since these steps will not have to be done, only the docker image pulls.
-RUN /bootstrap.sh ${FABRIC_VERSION} ${CA_VERSION} -d
-
-# Install supervisord because we need to run the docker daemon and also the fabric network
-# meaning that we have multiple processes to run.
-RUN apk add --no-cache supervisor
-COPY supervisord.conf /etc/supervisord.conf
-
-COPY run-fabric-network.sh /
-COPY healthcheck.sh /
-
-# OpenSSH Server (needed for chaincode deployment ) 
+# OpenSSH Server (needed for chaincode deployment )
 EXPOSE 22
 
 # supervisord web ui/dashboard
@@ -132,6 +114,55 @@ RUN apk add --no-cache util-linux
 
 # FIXME - make it so that SSHd does not need this to work
 RUN echo "root:$(uuidgen)" | chpasswd
+
+RUN curl -sSL https://raw.githubusercontent.com/cloudflare/semver_bash/c1133faf0efe17767b654b213f212c326df73fa3/semver.sh > /semver.sh
+RUN chmod +x /semver.sh
+
+# jq is needed by the /download-frozen-image-v2.sh script to pre-fetch docker images without docker.
+RUN apk add --no-cache jq
+
+# Get the utility script that can pre-fetch the Fabric docker images without
+# a functioning Docker daemon available which we do not have at image build
+# time so have to resort to manually get the Fabric images insteadd of just saying
+# "docker pull hyperledger/fabric..." etc.
+# The reason to jump trough these hoops is to speed up the boot time of the
+# container which won't have to download the images at container startup since
+# they'll have been cached already at build time.
+RUN curl -sSL https://raw.githubusercontent.com/moby/moby/dedf8528a51c6db40686ed6676e9486d1ed5f9c0/contrib/download-frozen-image-v2.sh > /download-frozen-image-v2.sh
+RUN chmod +x /download-frozen-image-v2.sh
+
+RUN mkdir -p /etc/hyperledger/fabric
+RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/ hyperledger/fabric-peer:${FABRIC_VERSION}
+RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/ hyperledger/fabric-orderer:${FABRIC_VERSION}
+RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/ hyperledger/fabric-ccenv:${FABRIC_VERSION}
+RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/ hyperledger/fabric-tools:${FABRIC_VERSION}
+RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/ hyperledger/fabric-baseos:${FABRIC_VERSION}
+RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/ hyperledger/fabric-ca:${CA_VERSION}
+
+# Download and execute the Fabric bootstrap script, but instruct it with the -d
+# flag to avoid pulling docker images because during the build phase of this image
+# there is no docker daemon running yet
+RUN curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/2f69b4222e9c9090b5c1ca235c1b59687566f13e/scripts/bootstrap.sh > /bootstrap.sh
+RUN chmod +x bootstrap.sh
+# Run the bootstrap here so that at least we can pre-fetch the git clone and the binary downloads resulting in
+# faster container startup speed since these steps will not have to be done, only the docker image pulls.
+RUN /bootstrap.sh ${FABRIC_VERSION} ${CA_VERSION} -d
+
+# Install supervisord because we need to run the docker daemon and also the fabric network
+# meaning that we have multiple processes to run.
+RUN apk add --no-cache supervisor
+
+COPY supervisord.conf /etc/supervisord.conf
+COPY run-fabric-network.sh /
+COPY healthcheck.sh /
+
+ENV FABRIC_CFG_PATH=/fabric-samples/config/
+ENV CORE_PEER_TLS_ENABLED=true
+ENV CORE_PEER_LOCALMSPID="Org1MSP"
+ENV CORE_PEER_TLS_ROOTCERT_FILE=/fabric-samples/test-network/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
+ENV CORE_PEER_MSPCONFIGPATH=/fabric-samples/test-network/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
+ENV CORE_PEER_ADDRESS=localhost:7051
+ENV COMPOSE_PROJECT_NAME=cactusfabrictestnetwork
 
 # Extend the parent image's entrypoint
 # https://superuser.com/questions/1459466/can-i-add-an-additional-docker-entrypoint-script

--- a/tools/docker/fabric-all-in-one/README.md
+++ b/tools/docker/fabric-all-in-one/README.md
@@ -3,7 +3,16 @@
 > This docker image is for `testing` and `development` only.
 > Do NOT use in production!
 
-An all in one fabric docker image with 1 peer, 1 orderer and 1 channel.
+An all in one fabric docker image with the `fabric-samples` repo fully embedded.
+
+## Usage
+
+### Building Local Image
+
+```sh
+DOCKER_BUILDKIT=1 docker build ./tools/docker/fabric-all-in-one/ -f ./tools/docker/fabric-all-in-one/Dockerfile_v1.4.x -t faio14x
+```
+### VSCode
 
 ## Usage
 
@@ -53,11 +62,11 @@ db676059b79e        faio2x              "/usr/bin/supervisor…"   9 minutes ago
 
 docker cp db676059b79e:/etc/hyperledger/cactus/fabric-aio-image.key ./fabric-aio-image.key
 
-ssh root@localhost -p 32924 -i fabric-aio-image.key 
+ssh root@localhost -p 32924 -i fabric-aio-image.key
 ```
 
 ```sh
-docker build ./tools/docker/fabric-all-in-one/ -f ./tools/docker/fabric-all-in-one/Dockerfile_v1.4.x  -t faio14x
+DOCKER_BUILDKIT=1 docker build ./tools/docker/fabric-all-in-one/ -f ./tools/docker/fabric-all-in-one/Dockerfile_v1.4.x  -t faio14x
 docker run --detach --privileged --publish-all --env FABRIC_VERSION=1.4.8 faio14x
 
 docker ps

--- a/tools/docker/fabric-all-in-one/healthcheck.sh
+++ b/tools/docker/fabric-all-in-one/healthcheck.sh
@@ -1,18 +1,27 @@
-if echo ${FABRIC_VERSION} | grep 2.
-then
-    cd fabric-samples/test-network
-    export PATH=${PWD}/../bin:${PWD}:$PATH
-    export FABRIC_CFG_PATH=$PWD/../config/
-    # for peer command issued to peer0.org1.example.com
-    export CORE_PEER_TLS_ENABLED=true
-    export CORE_PEER_LOCALMSPID="Org1MSP"
-    export CORE_PEER_TLS_ROOTCERT_FILE=${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
-    export CORE_PEER_MSPCONFIGPATH=${PWD}/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
-    export CORE_PEER_ADDRESS=localhost:7051
-    peer chaincode query --channelID mychannel --name fabcar --ctor '{"Args": [], "Function": "queryAllCars"}'
-elif echo ${FABRIC_VERSION} | grep 1.
-then
+#!/bin/sh
+
+# Needed so that we have the "peer" binary on our path
+export PATH=/fabric-samples/bin/:$PATH
+
+# Source the utility that we use to parse semantic version strings in bash
+. /semver.sh
+
+function main()
+{
+  local MAJOR=0
+  local MINOR=0
+  local PATCH=0
+  local SPECIAL=""
+  semverParseInto "${FABRIC_VERSION}" MAJOR MINOR PATCH SPECIAL
+
+  if [ "$MAJOR" -gt 1 ]; then
+    # Major version is 2 or newer (we'll deal with 3.x when it is released)
+    cd /fabric-samples/test-network/
+    peer chaincode invoke -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile "${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem" -C mychannel -n basic --peerAddresses localhost:7051 --tlsRootCertFiles "${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt" --peerAddresses localhost:9051 --tlsRootCertFiles "${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt" -c '{"function":"InitLedger","Args":[]}'
+  else
+    # Major version is 1.x or earlier (assumption is 1.4.x only)
     docker exec cli peer chaincode query --channelID mychannel --name fabcar --ctor '{"Args": [], "Function": "queryAllCars"}'
-else
-    echo "Unsupported fabric version."
-fi
+  fi
+}
+
+main

--- a/tools/docker/fabric-all-in-one/run-fabric-network.sh
+++ b/tools/docker/fabric-all-in-one/run-fabric-network.sh
@@ -1,6 +1,44 @@
 #!/bin/sh
 set -e
 
-/bootstrap.sh ${FABRIC_VERSION} ${CA_VERSION} -b -s
-cd /fabric-samples/fabcar/
-./startFabric.sh
+# Needed so that we have the "peer" binary on our path
+export PATH=/fabric-samples/bin/:$PATH
+
+# Source the utility that we use to parse semantic version strings in bash
+. /semver.sh
+
+function main()
+{
+
+  local MAJOR=0
+  local MINOR=0
+  local PATCH=0
+  local SPECIAL=""
+  semverParseInto "${FABRIC_VERSION}" MAJOR MINOR PATCH SPECIAL
+
+  tar -cC '/etc/hyperledger/fabric/' . | docker load
+
+  /bootstrap.sh ${FABRIC_VERSION} ${CA_VERSION} -b -s
+
+  echo "[FabricAIO] >>> Parsed MAJOR version of Fabric as ${MAJOR}"
+
+  if [ "$MAJOR" -gt 1 ]; then
+    # Major version is 2 or newer (we'll deal with 3.x when it is released)
+    cd /fabric-samples/test-network/
+    echo "[FabricAIO] >>> pulling up test network..."
+    ./network.sh up -ca
+    echo "[FabricAIO] >>> test network pulled up OK."
+    ./network.sh createChannel -c mychannel
+    echo "[FabricAIO] >>> channel created OK."
+    ./network.sh deployCC -ccn basic -ccp ../asset-transfer-basic/chaincode-go -ccl go
+    echo "[FabricAIO] >>> contract deployed OK."
+    echo "[FabricAIO] >>> container healthcheck should begin passing in about 5-15 seconds..."
+  else
+    # Major version is 1.x or earlier (assumption is 1.4.x only)
+    cd /fabric-samples/fabcar/
+    ./startFabric.sh
+  fi
+
+}
+
+main

--- a/tools/docker/fabric-all-in-one/supervisord.conf
+++ b/tools/docker/fabric-all-in-one/supervisord.conf
@@ -2,28 +2,34 @@
 logfile = /var/log/supervisord.log
 logfile_maxbytes = 50MB
 logfile_backups=10
-loglevel = info
+loglevel = debug
 
 [program:sshd]
-command=/usr/sbin/sshd -D
+command=/usr/sbin/sshd -D -dd
 autostart=true
 autorestart=true
-stderr_logfile=/var/log/sshd.err.log
-stdout_logfile=/var/log/sshd.out.log
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:dockerd]
 command=dockerd-entrypoint.sh
 autostart=true
 autorestart=true
-stderr_logfile=/var/log/dockerd.err.log
-stdout_logfile=/var/log/dockerd.out.log
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:fabric-network]
 command=/run-fabric-network.sh
 autostart=true
 autorestart=unexpected
-stderr_logfile=/var/log/fabric-network.err.log
-stdout_logfile=/var/log/fabric-network.out.log
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [inet_http_server]
 port = 0.0.0.0:9001


### PR DESCRIPTION
Depends on #644
Depends on #645
Fixes #632 

Primary change
============

Not sure how exactly, but the rug got pulled from under our
image build despite it specifying all tags/versions for fabric
explicitly. Suspicion right now is that the release tags were force
pushed to something new which no longer supported the fabcar
example chaincode that we were depending on.
Evidence to the above is also that our old image works just fine
that was built back in December 2020 (who knew 2020 was
going to be the year we depend on for stability...)

The fix itself: Migrated over the image to be compatible with
the 2.x fabric-samples code which meant no more fabcar
instead of which we now have the basic asset transfer
chaincode that gets deployed by default and then also serves
as the backbone for the healthchecks.

Secondary/misc. changes
====================

Updated the README.md file of the fabric AIO image to
state that it's using fabric-samples interanlly instead of
a hand-rolled deployment (which is what we had in the
very early phases of the Fabric AIO, but that's long gone
by now so the README update was badly needed)

Updated the example build commands to use DOCKER_BUILDKIT=1
where applicable because it is much faster
than the old builder so people should probably
use it.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>
