### PR TITLE
fix(fabric): issue with multiple objects of prometheus metrics

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/prometheus-exporter/prometheus-exporter.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/prometheus-exporter/prometheus-exporter.ts
@@ -34,6 +34,8 @@ export class PrometheusExporter {
   }
 
   public startMetricsCollection(): void {
-    promClient.collectDefaultMetrics();
+    const Registry = promClient.Registry;
+    const register = new Registry();
+    promClient.collectDefaultMetrics({ register });
   }
 }


### PR DESCRIPTION
# Commit to be reviewed
---------------------------------

fix(fabric): issue with mulitple objects of prometheus metrics
	
	Primary Change
	--------------

	1. Adding the default_metrics to the registry object which will differ for different objects.

	

Resolve #634
Signed-off-by: Jagpreet Singh Sasan <jagpreet.singh.sasan@accenture.com>