### PR TITLE
feat(corda-connector): node diagnostics endpoint #623

### DIFF
--- a/packages/cactus-plugin-ledger-connector-corda/README.md
+++ b/packages/cactus-plugin-ledger-connector-corda/README.md
@@ -159,3 +159,91 @@ From the project root:
 ```sh
 DOCKER_BUILDKIT=1 docker build ./packages/cactus-plugin-ledger-connector-corda/src/main-server/ -t cccs
 ```
+
+## Example NodeDiagnosticInfo JSON Response
+
+```json
+{
+  "version": "4.6",
+  "revision": "85e387ea730d9be7d6dc2b23caba1ee18305af74",
+  "platformVersion": 8,
+  "vendor": "Corda Open Source",
+  "cordapps": [
+    {
+      "type": "Workflow CorDapp",
+      "name": "workflows-1.0",
+      "shortName": "Obligation Flows",
+      "minimumPlatformVersion": 8,
+      "targetPlatformVersion": 8,
+      "version": "1",
+      "vendor": "Corda Open Source",
+      "licence": "Apache License, Version 2.0",
+      "jarHash": {
+        "bytes": "Vf9MllnrC7vrWxrlDE94OzPMZW7At1HhTETL/XjiAmc=",
+        "offset": 0,
+        "size": 32
+      }
+    },
+    {
+      "type": "CorDapp",
+      "name": "corda-confidential-identities-4.6",
+      "shortName": "corda-confidential-identities-4.6",
+      "minimumPlatformVersion": 1,
+      "targetPlatformVersion": 1,
+      "version": "Unknown",
+      "vendor": "Unknown",
+      "licence": "Unknown",
+      "jarHash": {
+        "bytes": "nqBwqHJMbLW80hmRbKEYk0eAknFiX8N40LKuGsD0bPo=",
+        "offset": 0,
+        "size": 32
+      }
+    },
+    {
+      "type": "Contract CorDapp",
+      "name": "corda-finance-contracts-4.6",
+      "shortName": "Corda Finance Demo",
+      "minimumPlatformVersion": 1,
+      "targetPlatformVersion": 8,
+      "version": "1",
+      "vendor": "R3",
+      "licence": "Open Source (Apache 2)",
+      "jarHash": {
+        "bytes": "a43Q/GJG6JKTZzq3U80P8L1DWWcB/D+Pl5uitEtAeQQ=",
+        "offset": 0,
+        "size": 32
+      }
+    },
+    {
+      "type": "Workflow CorDapp",
+      "name": "corda-finance-workflows-4.6",
+      "shortName": "Corda Finance Demo",
+      "minimumPlatformVersion": 1,
+      "targetPlatformVersion": 8,
+      "version": "1",
+      "vendor": "R3",
+      "licence": "Open Source (Apache 2)",
+      "jarHash": {
+        "bytes": "wXdD4Iy50RaWzPp7n9s1xwf4K4MB8eA1nmhPquTMvxg=",
+        "offset": 0,
+        "size": 32
+      }
+    },
+    {
+      "type": "Contract CorDapp",
+      "name": "contracts-1.0",
+      "shortName": "Obligation Contracts",
+      "minimumPlatformVersion": 8,
+      "targetPlatformVersion": 8,
+      "version": "1",
+      "vendor": "Corda Open Source",
+      "licence": "Apache License, Version 2.0",
+      "jarHash": {
+        "bytes": "grTZzN71Cpxw6rZe/U5SB6/ehl99B6VQ1+ZJEx1rixs=",
+        "offset": 0,
+        "size": 32
+      }
+    }
+  ]
+}
+```

--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/.openapi-generator/FILES
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/.openapi-generator/FILES
@@ -5,9 +5,12 @@ src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/api/
 src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/api/ApiPluginLedgerConnectorCordaService.kt
 src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/api/ApiUtil.kt
 src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/CordaX500Name.kt
+src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/CordappInfo.kt
 src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/DeployContractJarsBadRequestV1Response.kt
 src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/DeployContractJarsSuccessV1Response.kt
 src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/DeployContractJarsV1Request.kt
+src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/DiagnoseNodeV1Request.kt
+src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/DiagnoseNodeV1Response.kt
 src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/FlowInvocationType.kt
 src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/InvokeContractV1Request.kt
 src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/InvokeContractV1Response.kt
@@ -18,8 +21,10 @@ src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/mode
 src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/ListFlowsV1Request.kt
 src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/ListFlowsV1Response.kt
 src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/NetworkHostAndPort.kt
+src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/NodeDiagnosticInfo.kt
 src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/NodeInfo.kt
 src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/Party.kt
 src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/PublicKey.kt
+src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/SHA256.kt
 src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/X500Principal.kt
 src/main/resources/application.yaml

--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/api/ApiPluginLedgerConnectorCorda.kt
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/api/ApiPluginLedgerConnectorCorda.kt
@@ -3,6 +3,8 @@ package org.hyperledger.cactus.plugin.ledger.connector.corda.server.api
 import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.DeployContractJarsBadRequestV1Response
 import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.DeployContractJarsSuccessV1Response
 import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.DeployContractJarsV1Request
+import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.DiagnoseNodeV1Request
+import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.DiagnoseNodeV1Response
 import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.InvokeContractV1Request
 import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.InvokeContractV1Response
 import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.ListFlowsV1Request
@@ -43,6 +45,17 @@ class ApiPluginLedgerConnectorCordaController(@Autowired(required = true) val se
     fun deployContractJarsV1( @Valid @RequestBody(required = false) deployContractJarsV1Request: DeployContractJarsV1Request?
 ): ResponseEntity<DeployContractJarsSuccessV1Response> {
         return ResponseEntity(service.deployContractJarsV1(deployContractJarsV1Request), HttpStatus.valueOf(200))
+    }
+
+
+    @PostMapping(
+        value = ["/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-corda/diagnose-node"],
+        produces = ["application/json"],
+        consumes = ["application/json"]
+    )
+    fun diagnoseNodeV1( @Valid @RequestBody(required = false) diagnoseNodeV1Request: DiagnoseNodeV1Request?
+): ResponseEntity<DiagnoseNodeV1Response> {
+        return ResponseEntity(service.diagnoseNodeV1(diagnoseNodeV1Request), HttpStatus.valueOf(200))
     }
 
 

--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/api/ApiPluginLedgerConnectorCordaService.kt
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/api/ApiPluginLedgerConnectorCordaService.kt
@@ -3,6 +3,8 @@ package org.hyperledger.cactus.plugin.ledger.connector.corda.server.api
 import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.DeployContractJarsBadRequestV1Response
 import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.DeployContractJarsSuccessV1Response
 import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.DeployContractJarsV1Request
+import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.DiagnoseNodeV1Request
+import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.DiagnoseNodeV1Response
 import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.InvokeContractV1Request
 import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.InvokeContractV1Response
 import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.ListFlowsV1Request
@@ -11,6 +13,8 @@ import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.NodeInf
 interface ApiPluginLedgerConnectorCordaService {
 
 	fun deployContractJarsV1(deployContractJarsV1Request: DeployContractJarsV1Request?): DeployContractJarsSuccessV1Response
+
+	fun diagnoseNodeV1(diagnoseNodeV1Request: DiagnoseNodeV1Request?): DiagnoseNodeV1Response
 
 	fun invokeContractV1(invokeContractV1Request: InvokeContractV1Request?): InvokeContractV1Response
 

--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/CordappInfo.kt
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/CordappInfo.kt
@@ -1,0 +1,59 @@
+package org.hyperledger.cactus.plugin.ledger.connector.corda.server.model
+
+import java.util.Objects
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.SHA256
+import javax.validation.constraints.DecimalMax
+import javax.validation.constraints.DecimalMin
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Pattern
+import javax.validation.constraints.Size
+import javax.validation.Valid
+
+/**
+ * A CordappInfo describes a single CorDapp currently installed on the node
+ * @param jarHash 
+ * @param licence The name of the licence this CorDapp is released under
+ * @param minimumPlatformVersion The minimum platform version the node must be at for the CorDapp to run
+ * @param name The name of the JAR file that defines the CorDapp
+ * @param shortName The name of the CorDapp
+ * @param targetPlatformVersion The target platform version this CorDapp has been tested against
+ * @param type A description of what sort of CorDapp this is - either a contract, workflow, or a combination.
+ * @param vendor The vendor of this CorDapp
+ * @param version The version of this CorDapp
+ */
+data class CordappInfo(
+
+    @get:NotNull  
+    @field:Valid
+    @field:JsonProperty("jarHash") val jarHash: SHA256,
+
+    @get:NotNull  
+    @field:JsonProperty("licence") val licence: kotlin.String,
+
+    @get:NotNull  
+    @field:JsonProperty("minimumPlatformVersion") val minimumPlatformVersion: kotlin.Int,
+
+    @get:NotNull  
+    @field:JsonProperty("name") val name: kotlin.String,
+
+    @get:NotNull  
+    @field:JsonProperty("shortName") val shortName: kotlin.String,
+
+    @get:NotNull  
+    @field:JsonProperty("targetPlatformVersion") val targetPlatformVersion: kotlin.Int,
+
+    @get:NotNull  
+    @field:JsonProperty("type") val type: kotlin.String,
+
+    @get:NotNull  
+    @field:JsonProperty("vendor") val vendor: kotlin.String,
+
+    @get:NotNull  
+    @field:JsonProperty("version") val version: kotlin.String
+) {
+
+}
+

--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/DiagnoseNodeV1Request.kt
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/DiagnoseNodeV1Request.kt
@@ -1,0 +1,25 @@
+package org.hyperledger.cactus.plugin.ledger.connector.corda.server.model
+
+import java.util.Objects
+import com.fasterxml.jackson.annotation.JsonProperty
+import javax.validation.constraints.DecimalMax
+import javax.validation.constraints.DecimalMin
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Pattern
+import javax.validation.constraints.Size
+import javax.validation.Valid
+
+/**
+ * 
+ * @param nodeIds Optional property specifying which Corda Node should be the one being diagnosed in case the Connector has multiple connections established for different nodes (which is not yet a supported feature, but we want to keep this possibility open for the future).
+ */
+data class DiagnoseNodeV1Request(
+
+    @get:Size(min=0,max=1024) 
+    @field:JsonProperty("nodeIds") val nodeIds: kotlin.collections.List<kotlin.String>? = null
+) {
+
+}
+

--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/DiagnoseNodeV1Response.kt
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/DiagnoseNodeV1Response.kt
@@ -1,0 +1,27 @@
+package org.hyperledger.cactus.plugin.ledger.connector.corda.server.model
+
+import java.util.Objects
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.NodeDiagnosticInfo
+import javax.validation.constraints.DecimalMax
+import javax.validation.constraints.DecimalMin
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Pattern
+import javax.validation.constraints.Size
+import javax.validation.Valid
+
+/**
+ * 
+ * @param nodeDiagnosticInfo 
+ */
+data class DiagnoseNodeV1Response(
+
+    @get:NotNull  
+    @field:Valid
+    @field:JsonProperty("nodeDiagnosticInfo") val nodeDiagnosticInfo: NodeDiagnosticInfo
+) {
+
+}
+

--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/NodeDiagnosticInfo.kt
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/NodeDiagnosticInfo.kt
@@ -1,0 +1,44 @@
+package org.hyperledger.cactus.plugin.ledger.connector.corda.server.model
+
+import java.util.Objects
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.CordappInfo
+import javax.validation.constraints.DecimalMax
+import javax.validation.constraints.DecimalMin
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Pattern
+import javax.validation.constraints.Size
+import javax.validation.Valid
+
+/**
+ * A NodeDiagnosticInfo holds information about the current node version.
+ * @param cordapps A list of CorDapps currently installed on this node
+ * @param platformVersion The platform version of this node. This number represents a released API version, and should be used to make functionality decisions (e.g. enabling an app feature only if an underlying platform feature exists)
+ * @param revision The git commit hash this node was built from
+ * @param vendor The vendor of this node
+ * @param version The current node version string, e.g. 4.3, 4.4-SNAPSHOT. Note that this string is effectively freeform, and so should only be used for providing diagnostic information. It should not be used to make functionality decisions (the platformVersion is a better fit for this).
+ */
+data class NodeDiagnosticInfo(
+
+    @get:NotNull  
+    @field:Valid
+    @get:Size(min=0,max=4096) 
+    @field:JsonProperty("cordapps") val cordapps: kotlin.collections.List<CordappInfo>,
+
+    @get:NotNull  
+    @field:JsonProperty("platformVersion") val platformVersion: kotlin.Int,
+
+    @get:NotNull  
+    @field:JsonProperty("revision") val revision: kotlin.String,
+
+    @get:NotNull  
+    @field:JsonProperty("vendor") val vendor: kotlin.String,
+
+    @get:NotNull  
+    @field:JsonProperty("version") val version: kotlin.String
+) {
+
+}
+

--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/SHA256.kt
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/SHA256.kt
@@ -1,0 +1,33 @@
+package org.hyperledger.cactus.plugin.ledger.connector.corda.server.model
+
+import java.util.Objects
+import com.fasterxml.jackson.annotation.JsonProperty
+import javax.validation.constraints.DecimalMax
+import javax.validation.constraints.DecimalMin
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Pattern
+import javax.validation.constraints.Size
+import javax.validation.Valid
+
+/**
+ * SHA-256 is part of the SHA-2 hash function family. Generated hash is fixed size, 256-bits (32-bytes).
+ * @param bytes 
+ * @param offset 
+ * @param size 
+ */
+data class SHA256(
+
+    @get:NotNull  
+    @field:JsonProperty("bytes") val bytes: kotlin.String,
+
+    @get:NotNull  
+    @field:JsonProperty("offset") val offset: kotlin.Int,
+
+    @get:NotNull  
+    @field:JsonProperty("size") val size: kotlin.Int
+) {
+
+}
+

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/json/openapi.json
@@ -31,6 +31,134 @@
     ],
     "components": {
         "schemas": {
+            "SHA256": {
+                "description": "SHA-256 is part of the SHA-2 hash function family. Generated hash is fixed size, 256-bits (32-bytes).",
+                "externalDocs": {
+                    "description": "Official Corda documentation of the SHA256 class.",
+                    "url": "https://api.corda.net/api/corda-os/4.6/html/api/kotlin/corda/net.corda.core.crypto/-secure-hash/-s-h-a256/index.html"
+                },
+                "type": "object",
+                "required": [
+                    "bytes",
+                    "offset",
+                    "size"
+                ],
+                "properties": {
+                    "bytes": {
+                        "type": "string",
+                        "example": "Vf9MllnrC7vrWxrlDE94OzPMZW7At1HhTETL/XjiAmc="
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "example": 0
+                    },
+                    "size": {
+                        "type": "integer",
+                        "example": 32
+                    }
+                }
+            },
+            "CordappInfo": {
+                "type": "object",
+                "externalDocs": {
+                    "description": "Official Corda Documentation of the class CordappInfo",
+                    "url": "https://api.corda.net/api/corda-os/4.6/html/api/kotlin/corda/net.corda.core.cordapp/-cordapp-info/index.html"
+                },
+                "description": "A CordappInfo describes a single CorDapp currently installed on the node",
+                "required": [
+                    "jarHash",
+                    "licence",
+                    "minimumPlatformVersion",
+                    "name",
+                    "shortName",
+                    "targetPlatformVersion",
+                    "type",
+                    "vendor",
+                    "version"
+                ],
+                "properties": {
+                    "jarHash": {
+                        "type": "object",
+                        "format": "SHA256",
+                        "description": "The hash of the JAR file that defines this CorDapp",
+                        "$ref": "#/components/schemas/SHA256"
+                    },
+                    "licence": {
+                        "type": "string",
+                        "description": "The name of the licence this CorDapp is released under"
+                    },
+                    "minimumPlatformVersion": {
+                        "type": "integer",
+                        "description": "The minimum platform version the node must be at for the CorDapp to run"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the JAR file that defines the CorDapp"
+                    },
+                    "shortName": {
+                        "type": "string",
+                        "description": "The name of the CorDapp"
+                    },
+                    "targetPlatformVersion": {
+                        "type": "integer",
+                        "description": "The target platform version this CorDapp has been tested against"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "A description of what sort of CorDapp this is - either a contract, workflow, or a combination."
+                    },
+                    "vendor": {
+                        "type": "string",
+                        "description": "The vendor of this CorDapp"
+                    },
+                    "version": {
+                        "type": "string",
+                        "description": "The version of this CorDapp"
+                    }
+                }
+            },
+            "NodeDiagnosticInfo": {
+                "type": "object",
+                "externalDocs": {
+                    "description": "Official Corda Documentation of the class NodeDiagnosticInfo",
+                    "url": "https://api.corda.net/api/corda-os/4.6/html/api/kotlin/corda/net.corda.core.node/-node-diagnostic-info/index.html"
+                },
+                "description": "A NodeDiagnosticInfo holds information about the current node version.",
+                "required": [
+                    "cordapps",
+                    "platformVersion",
+                    "revision",
+                    "vendor",
+                    "version"
+                ],
+                "properties": {
+                    "cordapps": {
+                        "type": "array",
+                        "description": "A list of CorDapps currently installed on this node",
+                        "items": {
+                            "$ref": "#/components/schemas/CordappInfo"
+                        },
+                        "minItems": 0,
+                        "maxItems": 4096
+                    },
+                    "platformVersion": {
+                        "type": "integer",
+                        "description": "The platform version of this node. This number represents a released API version, and should be used to make functionality decisions (e.g. enabling an app feature only if an underlying platform feature exists)"
+                    },
+                    "revision": {
+                        "type": "string",
+                        "description": "The git commit hash this node was built from"
+                    },
+                    "vendor": {
+                        "type": "string",
+                        "description": "The vendor of this node"
+                    },
+                    "version": {
+                        "type": "string",
+                        "description": "The current node version string, e.g. 4.3, 4.4-SNAPSHOT. Note that this string is effectively freeform, and so should only be used for providing diagnostic information. It should not be used to make functionality decisions (the platformVersion is a better fit for this)."
+                    }
+                }
+            },
             "FlowInvocationType": {
                 "type": "string",
                 "nullable": false,
@@ -431,6 +559,33 @@
                 "items": {
                     "$ref": "#/components/schemas/NodeInfo"
                 }
+            },
+            "DiagnoseNodeV1Request": {
+                "type": "object",
+                "properties": {
+                    "nodeIds": {
+                        "type": "array",
+                        "description": "Optional property specifying which Corda Node should be the one being diagnosed in case the Connector has multiple connections established for different nodes (which is not yet a supported feature, but we want to keep this possibility open for the future).",
+                        "minItems": 0,
+                        "maxItems": 1024,
+                        "default": [],
+                        "items": {
+                            "type": "string",
+                            "nullable": false
+                        }
+                    }
+                }
+            },
+            "DiagnoseNodeV1Response": {
+                "type": "object",
+                "required": [
+                    "nodeDiagnosticInfo"
+                ],
+                "properties": {
+                    "nodeDiagnosticInfo": {
+                        "$ref": "#/components/schemas/NodeDiagnosticInfo"
+                    }
+                }
             }
         }
     },
@@ -574,6 +729,40 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ListFlowsV1Response"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-corda/diagnose-node": {
+            "post": {
+                "operationId": "diagnoseNodeV1",
+                "x-hyperledger-cactus": {
+                    "http": {
+                        "path": "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-corda/diagnose-node",
+                        "verbLowerCase": "post"
+                    }
+                },
+                "description": "Responds with diagnostic information about the Corda node",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DiagnoseNodeV1Request"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DiagnoseNodeV1Response"
                                 }
                             }
                         }

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -69,6 +69,67 @@ export interface CordaX500Name {
     x500Principal: X500Principal;
 }
 /**
+ * A CordappInfo describes a single CorDapp currently installed on the node
+ * @export
+ * @interface CordappInfo
+ */
+export interface CordappInfo {
+    /**
+     * 
+     * @type {SHA256}
+     * @memberof CordappInfo
+     */
+    jarHash: SHA256;
+    /**
+     * The name of the licence this CorDapp is released under
+     * @type {string}
+     * @memberof CordappInfo
+     */
+    licence: string;
+    /**
+     * The minimum platform version the node must be at for the CorDapp to run
+     * @type {number}
+     * @memberof CordappInfo
+     */
+    minimumPlatformVersion: number;
+    /**
+     * The name of the JAR file that defines the CorDapp
+     * @type {string}
+     * @memberof CordappInfo
+     */
+    name: string;
+    /**
+     * The name of the CorDapp
+     * @type {string}
+     * @memberof CordappInfo
+     */
+    shortName: string;
+    /**
+     * The target platform version this CorDapp has been tested against
+     * @type {number}
+     * @memberof CordappInfo
+     */
+    targetPlatformVersion: number;
+    /**
+     * A description of what sort of CorDapp this is - either a contract, workflow, or a combination.
+     * @type {string}
+     * @memberof CordappInfo
+     */
+    type: string;
+    /**
+     * The vendor of this CorDapp
+     * @type {string}
+     * @memberof CordappInfo
+     */
+    vendor: string;
+    /**
+     * The version of this CorDapp
+     * @type {string}
+     * @memberof CordappInfo
+     */
+    version: string;
+}
+/**
  * 
  * @export
  * @interface DeployContractJarsBadRequestV1Response
@@ -106,6 +167,32 @@ export interface DeployContractJarsV1Request {
      * @memberof DeployContractJarsV1Request
      */
     jarFiles: Array<JarFile>;
+}
+/**
+ * 
+ * @export
+ * @interface DiagnoseNodeV1Request
+ */
+export interface DiagnoseNodeV1Request {
+    /**
+     * Optional property specifying which Corda Node should be the one being diagnosed in case the Connector has multiple connections established for different nodes (which is not yet a supported feature, but we want to keep this possibility open for the future).
+     * @type {Array<string>}
+     * @memberof DiagnoseNodeV1Request
+     */
+    nodeIds?: Array<string>;
+}
+/**
+ * 
+ * @export
+ * @interface DiagnoseNodeV1Response
+ */
+export interface DiagnoseNodeV1Response {
+    /**
+     * 
+     * @type {NodeDiagnosticInfo}
+     * @memberof DiagnoseNodeV1Response
+     */
+    nodeDiagnosticInfo: NodeDiagnosticInfo;
 }
 /**
  * Determines which flow starting method will be used on the back-end when invoking the flow. Based on the value here the plugin back-end might invoke the rpc.startFlowDynamic() method or the rpc.startTrackedFlowDynamic() method. Streamed responses are aggregated and returned in a single response to HTTP callers who are not equipped to handle streams like WebSocket/gRPC/etc. do.
@@ -294,6 +381,43 @@ export interface NetworkHostAndPort {
     port: number;
 }
 /**
+ * A NodeDiagnosticInfo holds information about the current node version.
+ * @export
+ * @interface NodeDiagnosticInfo
+ */
+export interface NodeDiagnosticInfo {
+    /**
+     * A list of CorDapps currently installed on this node
+     * @type {Array<CordappInfo>}
+     * @memberof NodeDiagnosticInfo
+     */
+    cordapps: Array<CordappInfo>;
+    /**
+     * The platform version of this node. This number represents a released API version, and should be used to make functionality decisions (e.g. enabling an app feature only if an underlying platform feature exists)
+     * @type {number}
+     * @memberof NodeDiagnosticInfo
+     */
+    platformVersion: number;
+    /**
+     * The git commit hash this node was built from
+     * @type {string}
+     * @memberof NodeDiagnosticInfo
+     */
+    revision: string;
+    /**
+     * The vendor of this node
+     * @type {string}
+     * @memberof NodeDiagnosticInfo
+     */
+    vendor: string;
+    /**
+     * The current node version string, e.g. 4.3, 4.4-SNAPSHOT. Note that this string is effectively freeform, and so should only be used for providing diagnostic information. It should not be used to make functionality decisions (the platformVersion is a better fit for this).
+     * @type {string}
+     * @memberof NodeDiagnosticInfo
+     */
+    version: string;
+}
+/**
  * 
  * @export
  * @interface NodeInfo
@@ -375,6 +499,31 @@ export interface PublicKey {
     encoded: string;
 }
 /**
+ * SHA-256 is part of the SHA-2 hash function family. Generated hash is fixed size, 256-bits (32-bytes).
+ * @export
+ * @interface SHA256
+ */
+export interface SHA256 {
+    /**
+     * 
+     * @type {string}
+     * @memberof SHA256
+     */
+    bytes: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof SHA256
+     */
+    offset: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof SHA256
+     */
+    size: number;
+}
+/**
  * 
  * @export
  * @interface X500Principal
@@ -435,6 +584,46 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
             const needsSerialization = (typeof deployContractJarsV1Request !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
             localVarRequestOptions.data =  needsSerialization ? JSON.stringify(deployContractJarsV1Request !== undefined ? deployContractJarsV1Request : {}) : (deployContractJarsV1Request || "");
+
+            return {
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Responds with diagnostic information about the Corda node
+         * @param {DiagnoseNodeV1Request} [diagnoseNodeV1Request] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        diagnoseNodeV1: async (diagnoseNodeV1Request?: DiagnoseNodeV1Request, options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-corda/diagnose-node`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            const needsSerialization = (typeof diagnoseNodeV1Request !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.data =  needsSerialization ? JSON.stringify(diagnoseNodeV1Request !== undefined ? diagnoseNodeV1Request : {}) : (diagnoseNodeV1Request || "");
 
             return {
                 url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
@@ -586,6 +775,19 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             };
         },
         /**
+         * Responds with diagnostic information about the Corda node
+         * @param {DiagnoseNodeV1Request} [diagnoseNodeV1Request] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async diagnoseNodeV1(diagnoseNodeV1Request?: DiagnoseNodeV1Request, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<DiagnoseNodeV1Response>> {
+            const localVarAxiosArgs = await DefaultApiAxiosParamCreator(configuration).diagnoseNodeV1(diagnoseNodeV1Request, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {...localVarAxiosArgs.options, url: basePath + localVarAxiosArgs.url};
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
          * 
          * @summary Invokes a contract on a Corda ledger (e.g. a flow)
          * @param {InvokeContractV1Request} [invokeContractV1Request] 
@@ -645,6 +847,15 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
             return DefaultApiFp(configuration).deployContractJarsV1(deployContractJarsV1Request, options).then((request) => request(axios, basePath));
         },
         /**
+         * Responds with diagnostic information about the Corda node
+         * @param {DiagnoseNodeV1Request} [diagnoseNodeV1Request] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        diagnoseNodeV1(diagnoseNodeV1Request?: DiagnoseNodeV1Request, options?: any): AxiosPromise<DiagnoseNodeV1Response> {
+            return DefaultApiFp(configuration).diagnoseNodeV1(diagnoseNodeV1Request, options).then((request) => request(axios, basePath));
+        },
+        /**
          * 
          * @summary Invokes a contract on a Corda ledger (e.g. a flow)
          * @param {InvokeContractV1Request} [invokeContractV1Request] 
@@ -692,6 +903,17 @@ export class DefaultApi extends BaseAPI {
      */
     public deployContractJarsV1(deployContractJarsV1Request?: DeployContractJarsV1Request, options?: any) {
         return DefaultApiFp(this.configuration).deployContractJarsV1(deployContractJarsV1Request, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Responds with diagnostic information about the Corda node
+     * @param {DiagnoseNodeV1Request} [diagnoseNodeV1Request] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public diagnoseNodeV1(diagnoseNodeV1Request?: DiagnoseNodeV1Request, options?: any) {
+        return DefaultApiFp(this.configuration).diagnoseNodeV1(diagnoseNodeV1Request, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
@@ -19,7 +19,7 @@ const logLevel: LogLevelDesc = "TRACE";
 
 test("Tests are passing on the JVM side", async (t: Test) => {
   const ledger = new CordaTestLedger({
-    imageName: "petermetz/cactus-corda-4-6-all-in-one-obligation",
+    imageName: "hyperledger/cactus-corda-4-6-all-in-one-obligation",
     imageVersion: "2021-03-04-ac0d32a",
     logLevel,
   });
@@ -56,6 +56,12 @@ test("Tests are passing on the JVM side", async (t: Test) => {
   const internalIp = await internalIpV4();
   t.comment(`Internal IP (based on default gateway): ${internalIp}`);
   const springAppConfig = {
+    logging: {
+      level: {
+        root: "INFO",
+        "org.hyperledger.cactus.plugin.ledger.connector.corda.server": "DEBUG",
+      },
+    },
     cactus: {
       corda: {
         node: { host: internalIp },
@@ -70,8 +76,8 @@ test("Tests are passing on the JVM side", async (t: Test) => {
 
   const connector = new CordaConnectorContainer({
     logLevel,
-    imageName: "petermetz/cactus-connector-corda-server",
-    imageVersion: "2021-03-10-feat-624",
+    imageName: "hyperledger/cactus-connector-corda-server",
+    imageVersion: "2021-03-10-feat-623",
     envVars: [envVarSpringAppJson],
   });
   t.ok(CordaConnectorContainer, "CordaConnectorContainer instantaited OK");
@@ -110,6 +116,21 @@ test("Tests are passing on the JVM side", async (t: Test) => {
   t.ok(flowsRes.data, "flowsRes.data truthy OK");
   t.ok(flowsRes.data.flowNames, "flowsRes.data.flowNames truthy OK");
   t.comment(`apiClient.listFlowsV1() => ${JSON.stringify(flowsRes.data)}`);
+
+  const diagRes = await apiClient.diagnoseNodeV1();
+  t.ok(diagRes.status === 200, "diagRes.status === 200 OK");
+  t.ok(diagRes.data, "diagRes.data truthy OK");
+  t.ok(diagRes.data.nodeDiagnosticInfo, "nodeDiagnosticInfo truthy OK");
+  const ndi = diagRes.data.nodeDiagnosticInfo;
+  t.ok(ndi.cordapps, "ndi.cordapps truthy OK");
+  t.ok(Array.isArray(ndi.cordapps), "ndi.cordapps is Array truthy OK");
+  t.true((ndi.cordapps as []).length > 0, "ndi.cordapps non-empty true OK");
+  t.ok(ndi.vendor, "ndi.vendor truthy OK");
+  t.ok(ndi.version, "ndi.version truthy OK");
+  t.ok(ndi.revision, "ndi.revision truthy OK");
+  t.ok(ndi.platformVersion, "ndi.platformVersion truthy OK");
+
+  t.comment(`apiClient.diagnoseNodeV1() => ${JSON.stringify(diagRes.data)}`);
 
   const depRes = await apiClient.deployContractJarsV1({ jarFiles });
   t.ok(depRes, "Jar deployment response truthy OK");


### PR DESCRIPTION
Depends on #655 

The Corda RPC proxy has a diagnostics method that we
exposed here as an endpoint for our own connector as well.
This will help tremendously in debugging things when
people are working with the corda connector
(speaking from experience here).

Fixes #623

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>