### PR TITLE
fix(fabric): prometheus exporter metrics naming

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/prometheus-exporter/data-fetcher.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/prometheus-exporter/data-fetcher.ts
@@ -1,7 +1,7 @@
 import { Transactions } from "./response.type";
 
-import { totalTxCount } from "./metrics";
+import { totalTxCount, K_CACTUS_FABRIC_TOTAL_TX_COUNT } from "./metrics";
 
 export async function collectMetrics(transactions: Transactions) {
-  totalTxCount.labels("cactus_fabric_total_tx_count").set(transactions.counter);
+  totalTxCount.labels(K_CACTUS_FABRIC_TOTAL_TX_COUNT).set(transactions.counter);
 }

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/prometheus-exporter/metrics.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/prometheus-exporter/metrics.ts
@@ -1,7 +1,9 @@
 import { Gauge } from "prom-client";
 
+export const K_CACTUS_FABRIC_TOTAL_TX_COUNT = "cactus_fabric_total_tx_count";
+
 export const totalTxCount = new Gauge({
-  name: "cactus_fabric_total_tx_count",
+  name: K_CACTUS_FABRIC_TOTAL_TX_COUNT,
   help: "Total transactions executed",
   labelNames: ["type"],
 });

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/prometheus-exporter/prometheus-exporter.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/prometheus-exporter/prometheus-exporter.ts
@@ -1,8 +1,6 @@
 import promClient from "prom-client";
 import { Transactions } from "./response.type";
-import { totalTxCount } from "./metrics";
-
-export const K_CACTUS_FABRIC_TOTAL_TX_COUNT = "cactus_fabric_total_tx_count";
+import { totalTxCount, K_CACTUS_FABRIC_TOTAL_TX_COUNT } from "./metrics";
 
 export interface IPrometheusExporterOptions {
   pollingIntervalInMin?: number;
@@ -28,7 +26,7 @@ export class PrometheusExporter {
 
   public async getPrometheusMetrics(): Promise<string> {
     const result = await promClient.register.getSingleMetricAsString(
-      "cactus_fabric_total_tx_count",
+      K_CACTUS_FABRIC_TOTAL_TX_COUNT,
     );
     return result;
   }

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts
@@ -28,6 +28,7 @@ import {
 
 import { IPluginLedgerConnectorFabricOptions } from "../../../../main/typescript/plugin-ledger-connector-fabric";
 import { DiscoveryOptions } from "fabric-network";
+import { K_CACTUS_FABRIC_TOTAL_TX_COUNT } from "../../../../main/typescript/prometheus-exporter/metrics";
 
 /**
  * Use this to debug issues with the fabric node SDK
@@ -180,9 +181,16 @@ test("runs tx on a Fabric v1.4.8 ledger", async (t: Test) => {
   {
     const res = await apiClient.getPrometheusExporterMetricsV1();
     const promMetricsOutput =
-      "# HELP cactus_fabric_total_tx_count Total transactions executed\n" +
-      "# TYPE cactus_fabric_total_tx_count gauge\n" +
-      'cactus_fabric_total_tx_count{type="cactus_fabric_total_tx_count"} 3';
+      "# HELP " +
+      K_CACTUS_FABRIC_TOTAL_TX_COUNT +
+      " Total transactions executed\n" +
+      "# TYPE " +
+      K_CACTUS_FABRIC_TOTAL_TX_COUNT +
+      " gauge\n" +
+      K_CACTUS_FABRIC_TOTAL_TX_COUNT +
+      '{type="' +
+      K_CACTUS_FABRIC_TOTAL_TX_COUNT +
+      '"} 3';
     t.ok(res);
     t.ok(res.data);
     t.equal(res.status, 200);

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
@@ -29,6 +29,8 @@ import {
   DefaultEventHandlerStrategy,
 } from "../../../../main/typescript/public-api";
 
+import { K_CACTUS_FABRIC_TOTAL_TX_COUNT } from "../../../../main/typescript/prometheus-exporter/metrics";
+
 import { IPluginLedgerConnectorFabricOptions } from "../../../../main/typescript/plugin-ledger-connector-fabric";
 import { DiscoveryOptions } from "fabric-network";
 
@@ -196,9 +198,16 @@ test("runs tx on a Fabric v2.2.0 ledger", async (t: Test) => {
   {
     const res = await apiClient.getPrometheusExporterMetricsV1();
     const promMetricsOutput =
-      "# HELP cactus_fabric_total_tx_count Total transactions executed\n" +
-      "# TYPE cactus_fabric_total_tx_count gauge\n" +
-      'cactus_fabric_total_tx_count{type="cactus_fabric_total_tx_count"} 3';
+      "# HELP " +
+      K_CACTUS_FABRIC_TOTAL_TX_COUNT +
+      " Total transactions executed\n" +
+      "# TYPE " +
+      K_CACTUS_FABRIC_TOTAL_TX_COUNT +
+      " gauge\n" +
+      K_CACTUS_FABRIC_TOTAL_TX_COUNT +
+      '{type="' +
+      K_CACTUS_FABRIC_TOTAL_TX_COUNT +
+      '"} 3';
     t.ok(res);
     t.ok(res.data);
     t.equal(res.status, 200);


### PR DESCRIPTION
# Commit to be reviewed
--------------------------------

fix(fabric): prometheus exporter metrics naming	

	Primary Change
	--------------

	1. Change the cactus_fabric_total_tx_count metric name to be fetched from a variable
	2. Update the same in the test cases

Signed-off-by: Jagpreet Singh Sasan <jagpreet.singh.sasan@accenture.com>