### PR TITLE
fix(tools): prod build fail due to missing dependency ngo #673

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/package-lock.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/package-lock.json
@@ -909,6 +909,16 @@
 				"sha.js": "^2.4.8"
 			}
 		},
+		"cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"requires": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			}
+		},
 		"crypto-browserify": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -1447,6 +1457,37 @@
 				"safe-buffer": "^5.1.1"
 			}
 		},
+		"execa": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+			"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+			"requires": {
+				"cross-spawn": "^7.0.0",
+				"get-stream": "^5.0.0",
+				"human-signals": "^1.1.1",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.0",
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2",
+				"strip-final-newline": "^2.0.0"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"is-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+				}
+			}
+		},
 		"express": {
 			"version": "4.17.1",
 			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -1886,6 +1927,20 @@
 				"min-document": "^2.19.0",
 				"process": "~0.5.1"
 			}
+		},
+		"go-bin": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/go-bin/-/go-bin-1.4.0.tgz",
+			"integrity": "sha512-T+jeJFVboLESIVqi3v8vJMAoHvsauR8XRKBkTwLwE1PUdDWOSAyrIQ9ymWFJ6suaDNEcNNglBCOc6AFbtVkqow==",
+			"requires": {
+				"decompress": "^4.2.1",
+				"mkdirp": "^1.0.4"
+			}
+		},
+		"go-versions": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/go-versions/-/go-versions-1.3.2.tgz",
+			"integrity": "sha512-nKjEKqRT1BUPVGO8WO5EKUWgJ6l1sThfSdYuRi6WwNyiwR4SOfC/FoB7aRRUtfmMHBU3ZJNMG2x8GiE51/tbhg=="
 		},
 		"got": {
 			"version": "9.6.0",
@@ -2440,6 +2495,11 @@
 			"resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.1.4.tgz",
 			"integrity": "sha512-MZVIsLKGVOVE1KEnldppe6Ij+vmemMuApDfjhVSLzyYP+td0bREEYyAoIw9yFePoBXManCuBqmiNP5FqJS5Xkg=="
 		},
+		"human-signals": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+			"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
+		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -2565,6 +2625,11 @@
 			"requires": {
 				"punycode": "2.x.x"
 			}
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -2774,6 +2839,11 @@
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
 			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
 		},
+		"merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+		},
 		"methods": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -2805,6 +2875,11 @@
 			"requires": {
 				"mime-db": "1.44.0"
 			}
+		},
+		"mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
 		},
 		"mimic-response": {
 			"version": "1.0.1",
@@ -2957,6 +3032,16 @@
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
 			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
 		},
+		"ngo": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/ngo/-/ngo-2.6.2.tgz",
+			"integrity": "sha512-fOAX8YlMFUHvJUBp0uNOqYMS/OqK05iV9lPzLVhn9sFJR0n4wFIfz9Y59Kg0v9mtrxZizN8L0mkimn7ikyIbbA==",
+			"requires": {
+				"execa": "^4.0.0",
+				"go-bin": "^1.4.0",
+				"go-versions": "^1.3.2"
+			}
+		},
 		"node-addon-api": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
@@ -2993,6 +3078,14 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
 			"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
+		},
+		"npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"requires": {
+				"path-key": "^3.0.0"
+			}
 		},
 		"number-is-nan": {
 			"version": "1.0.1",
@@ -3047,6 +3140,14 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
 				"wrappy": "1"
+			}
+		},
+		"onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"requires": {
+				"mimic-fn": "^2.1.0"
 			}
 		},
 		"ono": {
@@ -3119,6 +3220,11 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -3529,10 +3635,28 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"requires": {
+				"shebang-regex": "^3.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+		},
 		"shell-escape": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/shell-escape/-/shell-escape-0.2.0.tgz",
 			"integrity": "sha1-aP0CXrBJC09WegJ/C/IkgLX4QTM="
+		},
+		"signal-exit": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
 		},
 		"simple-concat": {
 			"version": "1.0.1",
@@ -3653,6 +3777,11 @@
 			"requires": {
 				"is-natural-number": "^4.0.1"
 			}
+		},
+		"strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
 		},
 		"strip-hex-prefix": {
 			"version": "1.0.0",
@@ -4841,6 +4970,14 @@
 						"xhr-request-promise": "^0.1.2"
 					}
 				}
+			}
+		},
+		"which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"requires": {
+				"isexe": "^2.0.0"
 			}
 		},
 		"window-size": {

--- a/packages/cactus-plugin-ledger-connector-fabric/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/package.json
@@ -96,6 +96,7 @@
     "http-status-codes": "2.1.4",
     "joi": "14.3.1",
     "multer": "1.4.2",
+    "ngo": "2.6.2",
     "node-ssh": "11.0.0",
     "openapi-types": "7.0.1",
     "prom-client": "13.0.0",


### PR DESCRIPTION
The dependency was removed accidentally during a refactor
where we deprecated the chain code compiler component
in its current form (ngo is a depenency of that). Later on
they are both scheduled to depart from the codebase (ngo
and the chain code compiler) but that will be part of a larger
refactor so for now I just added the missing dependency back
to ensure that the `./tools/ci.sh` script doesn't crash when
it runs the production build (the one that bundles with
webpack and minifies it as well)

Fixes #673

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>