### PR TITLE
feat(consortium-manual): add prometheus exporter

### DIFF
--- a/packages/cactus-plugin-consortium-manual/README.md
+++ b/packages/cactus-plugin-consortium-manual/README.md
@@ -1,0 +1,39 @@
+# `@hyperledger/cactus-plugin-consortium-manual`
+
+## Prometheus Exporter
+This class creates a prometheus exporter, which scrapes the total Cactus node count.
+
+### Usage Prometheus
+The prometheus exporter object is initialized in the `PluginConsortiumManual` class constructor itself, so instantiating the object of the `PluginConsortiumManual` class, gives access to the exporter object.
+You can also initialize the prometheus exporter object seperately and then pass it to the `IPluginConsortiumManualOptions` interface for `PluginConsortiumManual` constructor.
+
+`getPrometheusExporterMetricsV1` function returns the prometheus exporter metrics, currently displaying the total cactus node count, which currently refreshes to match the node count in the consortium, everytime `updateMetricNodeCount` method of the `PluginConsortiumManual` class is called.
+
+### Prometheus Integration
+To use Prometheus with this exporter make sure to install [Prometheus main component](https://prometheus.io/download/).
+Once Prometheus is setup, the corresponding scrape_config needs to be added to the prometheus.yml
+
+```(yaml)
+- job_name: 'consortium_manual_exporter'
+  metrics_path: api/v1/plugins/@hyperledger/cactus-plugin-consortium-manual/get-prometheus-exporter-metrics
+  scrape_interval: 5s
+  static_configs:
+    - targets: ['{host}:{port}']
+```
+
+Here the `host:port` is where the prometheus exporter metrics are exposed. The test cases (For example, packages/cactus-plugin-consortium-manual/src/test/typescript/unit/consortium/get-node-jws-endpoint-v1.test.ts) exposes it over `0.0.0.0` and a random port(). The random port can be found in the running logs of the test case and looks like (42379 in the below mentioned URL)
+`Metrics URL: http://0.0.0.0:42379/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-fabric/get-prometheus-exporter-metrics`
+
+Once edited, you can start the prometheus service by referencing the above edited prometheus.yml file.
+On the prometheus graphical interface (defaulted to http://localhost:9090), choose **Graph** from the menu bar, then select the **Console** tab. From the **Insert metric at cursor** drop down, select **cactus_consortium_manual_total_node_count** and click **execute**
+
+### Helper code
+
+###### response.type.ts
+This file contains the various responses of the metrics.
+
+###### data-fetcher.ts
+This file contains functions encasing the logic to process the data points.
+
+###### metrics.ts
+This file lists all the prometheus metrics and what they are used for.

--- a/packages/cactus-plugin-consortium-manual/package-lock.json
+++ b/packages/cactus-plugin-consortium-manual/package-lock.json
@@ -119,6 +119,11 @@
 				"follow-redirects": "^1.10.0"
 			}
 		},
+		"bintrees": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+			"integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+		},
 		"body-parser": {
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -380,6 +385,14 @@
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
 			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
+		"prom-client": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.0.0.tgz",
+			"integrity": "sha512-M7ZNjIO6x+2R/vjSD13yjJPjpoZA8eEwH2Bp2Re0/PvzozD7azikv+SaBtZes4Q1ca/xHjZ4RSCuTag3YZLg1A==",
+			"requires": {
+				"tdigest": "^0.1.1"
+			}
+		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -467,6 +480,14 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
 			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+		},
+		"tdigest": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+			"integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+			"requires": {
+				"bintrees": "1.0.1"
+			}
 		},
 		"toidentifier": {
 			"version": "1.0.0",

--- a/packages/cactus-plugin-consortium-manual/package.json
+++ b/packages/cactus-plugin-consortium-manual/package.json
@@ -83,6 +83,7 @@
     "axios": "0.21.1",
     "body-parser": "1.19.0",
     "express": "4.17.1",
+    "prom-client": "13.0.0",
     "jose": "1.27.2",
     "json-stable-stringify": "1.0.1",
     "typescript-optional": "2.0.1",

--- a/packages/cactus-plugin-consortium-manual/src/main/json/openapi.json
+++ b/packages/cactus-plugin-consortium-manual/src/main/json/openapi.json
@@ -57,6 +57,10 @@
                         "format": "The general format which is a JSON object, not a string."
                     }
                 }
+            },
+            "PrometheusExporterMetricsResponse": {
+                "type": "string",
+                "nullable": false
             }
         }
     },
@@ -105,6 +109,31 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/GetNodeJwsResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/plugins/@hyperledger/cactus-plugin-consortium-manual/get-prometheus-exporter-metrics": {
+            "get": {
+                "x-hyperledger-cactus": {
+                    "http": {
+                        "verbLowerCase": "get",
+                        "path": "/api/v1/plugins/@hyperledger/cactus-plugin-consortium-manual/get-prometheus-exporter-metrics"
+                    }
+                },
+                "operationId": "getPrometheusExporterMetricsV1",
+                "summary": "Get the Prometheus Metrics",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PrometheusExporterMetricsResponse"
                                 }
                             }
                         }

--- a/packages/cactus-plugin-consortium-manual/src/main/typescript/consortium/get-node-jws-endpoint-v1.ts
+++ b/packages/cactus-plugin-consortium-manual/src/main/typescript/consortium/get-node-jws-endpoint-v1.ts
@@ -24,8 +24,10 @@ import {
 } from "@hyperledger/cactus-core";
 
 import OAS from "../../json/openapi.json";
+import { PluginConsortiumManual } from "../plugin-consortium-manual";
 
 export interface IGetNodeJwsEndpointOptions {
+  plugin: PluginConsortiumManual;
   keyPairPem: string;
   consortiumRepo: ConsortiumRepository;
   logLevel?: LogLevelDesc;
@@ -33,6 +35,7 @@ export interface IGetNodeJwsEndpointOptions {
 
 export class GetNodeJwsEndpoint implements IWebServiceEndpoint {
   private readonly log: Logger;
+  private readonly plugin: PluginConsortiumManual;
 
   constructor(public readonly options: IGetNodeJwsEndpointOptions) {
     const fnTag = "GetNodeJwsEndpoint#constructor()";
@@ -43,6 +46,12 @@ export class GetNodeJwsEndpoint implements IWebServiceEndpoint {
       throw new Error(`${fnTag} options.keyPairPem falsy.`);
     }
     Checks.truthy(options.consortiumRepo, `${fnTag} options.consortiumRepo`);
+    Checks.truthy(options.plugin, `${fnTag} options.plugin`);
+    Checks.truthy(
+      options.plugin instanceof PluginConsortiumManual,
+      `${fnTag} options.plugin instanceof PluginConsortiumManual`,
+    );
+    this.plugin = options.plugin;
 
     const level = options.logLevel || "INFO";
     const label = "get-node-jws-endpoint-v1";
@@ -95,6 +104,11 @@ export class GetNodeJwsEndpoint implements IWebServiceEndpoint {
     const fnTag = "GetNodeJwsEndpoint#createJws()";
     const { keyPairPem, consortiumRepo: repo } = this.options;
     try {
+      // TODO: move this logic here entirely to the plugin itself. We already
+      // have an issue open for it on GH most likely, someone may already be
+      // working on this very thing actually so please do double check prior
+      // to diving in and working on it to avoid redundant effort.
+      this.plugin.updateMetricNodeCount();
       const keyPair = JWK.asKey(keyPairPem);
       const payloadObject = { consortiumDatabase: repo.consortiumDatabase };
       const payloadJson = jsonStableStringify(payloadObject);

--- a/packages/cactus-plugin-consortium-manual/src/main/typescript/consortium/get-prometheus-exporter-metrics-endpoint-v1.ts
+++ b/packages/cactus-plugin-consortium-manual/src/main/typescript/consortium/get-prometheus-exporter-metrics-endpoint-v1.ts
@@ -1,0 +1,81 @@
+import { Express, Request, Response } from "express";
+
+import {
+  Logger,
+  LoggerProvider,
+  LogLevelDesc,
+  Checks,
+} from "@hyperledger/cactus-common";
+
+import {
+  IWebServiceEndpoint,
+  IExpressRequestHandler,
+} from "@hyperledger/cactus-core-api";
+
+import OAS from "../../json/openapi.json";
+
+import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";
+
+import { PluginConsortiumManual } from "../plugin-consortium-manual";
+
+export interface IGetPrometheusExporterMetricsEndpointV1Options {
+  logLevel?: LogLevelDesc;
+  plugin: PluginConsortiumManual;
+}
+
+export class GetPrometheusExporterMetricsEndpointV1
+  implements IWebServiceEndpoint {
+  private readonly log: Logger;
+
+  constructor(
+    public readonly opts: IGetPrometheusExporterMetricsEndpointV1Options,
+  ) {
+    const fnTag = "GetPrometheusExporterMetricsEndpointV1#constructor()";
+
+    Checks.truthy(opts, `${fnTag} options`);
+    Checks.truthy(opts.plugin, `${fnTag} options.plugin`);
+
+    this.log = LoggerProvider.getOrCreate({
+      label: "get-prometheus-exporter-metrics-v1",
+      level: opts.logLevel || "INFO",
+    });
+  }
+
+  public getExpressRequestHandler(): IExpressRequestHandler {
+    return this.handleRequest.bind(this);
+  }
+
+  public getPath(): string {
+    return OAS.paths[
+      "/api/v1/plugins/@hyperledger/cactus-plugin-consortium-manual/get-prometheus-exporter-metrics"
+    ].get["x-hyperledger-cactus"].http.path;
+  }
+
+  public getVerbLowerCase(): string {
+    return OAS.paths[
+      "/api/v1/plugins/@hyperledger/cactus-plugin-consortium-manual/get-prometheus-exporter-metrics"
+    ].get["x-hyperledger-cactus"].http.verbLowerCase;
+  }
+
+  public registerExpress(app: Express): IWebServiceEndpoint {
+    registerWebServiceEndpoint(app, this);
+    return this;
+  }
+
+  async handleRequest(req: Request, res: Response): Promise<void> {
+    const fnTag = "GetPrometheusExporterMetrics#handleRequest()";
+    const verbUpper = this.getVerbLowerCase().toUpperCase();
+    this.log.debug(`${verbUpper} ${this.getPath()}`);
+
+    try {
+      const resBody = await this.opts.plugin.getPrometheusExporterMetrics();
+      res.status(200);
+      res.send(resBody);
+    } catch (ex) {
+      this.log.error(`${fnTag} failed to serve request`, ex);
+      res.status(500);
+      res.statusMessage = ex.message;
+      res.json({ error: ex.stack });
+    }
+  }
+}

--- a/packages/cactus-plugin-consortium-manual/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-consortium-manual/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -168,6 +168,42 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * 
+         * @summary Get the Prometheus Metrics
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getPrometheusExporterMetricsV1: async (options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/plugins/@hyperledger/cactus-plugin-consortium-manual/get-prometheus-exporter-metrics`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
+                options: localVarRequestOptions,
+            };
+        },
     }
 };
 
@@ -203,6 +239,19 @@ export const DefaultApiFp = function(configuration?: Configuration) {
                 return axios.request(axiosRequestArgs);
             };
         },
+        /**
+         * 
+         * @summary Get the Prometheus Metrics
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getPrometheusExporterMetricsV1(options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await DefaultApiAxiosParamCreator(configuration).getPrometheusExporterMetricsV1(options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {...localVarAxiosArgs.options, url: basePath + localVarAxiosArgs.url};
+                return axios.request(axiosRequestArgs);
+            };
+        },
     }
 };
 
@@ -229,6 +278,15 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          */
         getNodeJws(options?: any): AxiosPromise<GetNodeJwsResponse> {
             return DefaultApiFp(configuration).getNodeJws(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Get the Prometheus Metrics
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getPrometheusExporterMetricsV1(options?: any): AxiosPromise<string> {
+            return DefaultApiFp(configuration).getPrometheusExporterMetricsV1(options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -260,6 +318,17 @@ export class DefaultApi extends BaseAPI {
      */
     public getNodeJws(options?: any) {
         return DefaultApiFp(this.configuration).getNodeJws(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Get the Prometheus Metrics
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public getPrometheusExporterMetricsV1(options?: any) {
+        return DefaultApiFp(this.configuration).getPrometheusExporterMetricsV1(options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/packages/cactus-plugin-consortium-manual/src/main/typescript/prometheus-exporter/data-fetcher.ts
+++ b/packages/cactus-plugin-consortium-manual/src/main/typescript/prometheus-exporter/data-fetcher.ts
@@ -1,0 +1,12 @@
+import { NodeCount } from "./response.type";
+
+import {
+  totalTxCount,
+  K_CACTUS_CONSORTIUM_MANUAL_TOTAL_NODE_COUNT,
+} from "./metrics";
+
+export async function collectMetrics(nodeCount: NodeCount) {
+  totalTxCount
+    .labels(K_CACTUS_CONSORTIUM_MANUAL_TOTAL_NODE_COUNT)
+    .set(nodeCount.counter);
+}

--- a/packages/cactus-plugin-consortium-manual/src/main/typescript/prometheus-exporter/metrics.ts
+++ b/packages/cactus-plugin-consortium-manual/src/main/typescript/prometheus-exporter/metrics.ts
@@ -1,0 +1,10 @@
+import { Gauge } from "prom-client";
+
+export const K_CACTUS_CONSORTIUM_MANUAL_TOTAL_NODE_COUNT =
+  "cactus_consortium_manual_total_node_count";
+
+export const totalTxCount = new Gauge({
+  name: K_CACTUS_CONSORTIUM_MANUAL_TOTAL_NODE_COUNT,
+  help: "Total cactus node count",
+  labelNames: ["type"],
+});

--- a/packages/cactus-plugin-consortium-manual/src/main/typescript/prometheus-exporter/prometheus-exporter.ts
+++ b/packages/cactus-plugin-consortium-manual/src/main/typescript/prometheus-exporter/prometheus-exporter.ts
@@ -1,0 +1,42 @@
+import promClient from "prom-client";
+import { NodeCount } from "./response.type";
+import {
+  totalTxCount,
+  K_CACTUS_CONSORTIUM_MANUAL_TOTAL_NODE_COUNT,
+} from "./metrics";
+
+export interface IPrometheusExporterOptions {
+  pollingIntervalInMin?: number;
+}
+
+export class PrometheusExporter {
+  public readonly metricsPollingIntervalInMin: number;
+  public readonly nodeCount: NodeCount = { counter: 0 };
+
+  constructor(
+    public readonly prometheusExporterOptions: IPrometheusExporterOptions,
+  ) {
+    this.metricsPollingIntervalInMin =
+      prometheusExporterOptions.pollingIntervalInMin || 1;
+  }
+
+  public setNodeCount(nodeCount: number): void {
+    this.nodeCount.counter = nodeCount;
+    totalTxCount
+      .labels(K_CACTUS_CONSORTIUM_MANUAL_TOTAL_NODE_COUNT)
+      .set(this.nodeCount.counter);
+  }
+
+  public async getPrometheusMetrics(): Promise<string> {
+    const result = await promClient.register.getSingleMetricAsString(
+      K_CACTUS_CONSORTIUM_MANUAL_TOTAL_NODE_COUNT,
+    );
+    return result;
+  }
+
+  public startMetricsCollection(): void {
+    const Registry = promClient.Registry;
+    const register = new Registry();
+    promClient.collectDefaultMetrics({ register });
+  }
+}

--- a/packages/cactus-plugin-consortium-manual/src/main/typescript/prometheus-exporter/response.type.ts
+++ b/packages/cactus-plugin-consortium-manual/src/main/typescript/prometheus-exporter/response.type.ts
@@ -1,0 +1,3 @@
+export type NodeCount = {
+  counter: number;
+};

--- a/packages/cactus-plugin-consortium-manual/src/test/typescript/unit/consortium/get-node-jws-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-consortium-manual/src/test/typescript/unit/consortium/get-node-jws-endpoint-v1.test.ts
@@ -1,14 +1,31 @@
 import test, { Test } from "tape";
 import { JWS, JWK } from "jose";
+import express from "express";
+import bodyParser from "body-parser";
+import http from "http";
+import { AddressInfo } from "net";
 
-import { ConsortiumDatabase } from "@hyperledger/cactus-core-api";
+import { IListenOptions, Servers } from "@hyperledger/cactus-common";
+
+import { ConsortiumDatabase, CactusNode } from "@hyperledger/cactus-core-api";
 
 import { ConsortiumRepository } from "@hyperledger/cactus-core";
+
+import {
+  PluginConsortiumManual,
+  IPluginConsortiumManualOptions,
+} from "../../../../main/typescript/plugin-consortium-manual";
 
 import {
   GetNodeJwsEndpoint,
   IGetNodeJwsEndpointOptions,
 } from "../../../../main/typescript/public-api";
+
+import { v4 as uuidv4 } from "uuid";
+
+import { DefaultApi as ConsortiumManualApi } from "../../../../main/typescript/public-api";
+
+import { K_CACTUS_CONSORTIUM_MANUAL_TOTAL_NODE_COUNT } from "../../../../main/typescript/prometheus-exporter/metrics";
 
 test("Can provide JWS", async (t: Test) => {
   t.ok(GetNodeJwsEndpoint);
@@ -25,7 +42,40 @@ test("Can provide JWS", async (t: Test) => {
   };
   const consortiumRepo = new ConsortiumRepository({ db });
 
+  // Creating the PluginConsortiumManual object to observe the prometheus metrics.
+  const options: IPluginConsortiumManualOptions = {
+    instanceId: uuidv4(),
+    keyPairPem: keyPairPem,
+    consortiumDatabase: db,
+  };
+
+  const pluginConsortiumManual: PluginConsortiumManual = new PluginConsortiumManual(
+    options,
+  );
+
+  // Setting up of the api-server for hosting the endpoints defined in the openapi specs
+  // of the plugin
+  const expressApp = express();
+  expressApp.use(bodyParser.json({ limit: "250mb" }));
+  const server = http.createServer(expressApp);
+  const listenOptions: IListenOptions = {
+    hostname: "0.0.0.0",
+    port: 0,
+    server,
+  };
+  const addressInfo = (await Servers.listen(listenOptions)) as AddressInfo;
+  test.onFinish(async () => await Servers.shutdown(server));
+  const { address, port } = addressInfo;
+  const apiHost = `http://${address}:${port}`;
+  t.comment(
+    `Metrics URL: ${apiHost}/api/v1/plugins/@hyperledger/cactus-plugin-consortium-manual/get-prometheus-exporter-metrics`,
+  );
+  const apiClient = new ConsortiumManualApi({ basePath: apiHost });
+
+  await pluginConsortiumManual.installWebServices(expressApp);
+
   const epOpts: IGetNodeJwsEndpointOptions = {
+    plugin: pluginConsortiumManual,
     consortiumRepo,
     keyPairPem,
   };
@@ -48,6 +98,73 @@ test("Can provide JWS", async (t: Test) => {
     t.fail(`JWS Verification result: ${payload}`);
   } else {
     t.ok(payload.consortiumDatabase, "JWS payload.consortiumDatabase truthy");
+  }
+
+  {
+    // The first check shall observe the cactus_consortium_manual_total_node_count metrics
+    // to be valued at zero, as the ConsortiumRepo object is initialized with an empty array of
+    // Cactus nodes.
+    const res = await apiClient.getPrometheusExporterMetricsV1();
+    const promMetricsOutput =
+      "# HELP " +
+      K_CACTUS_CONSORTIUM_MANUAL_TOTAL_NODE_COUNT +
+      " Total cactus node count\n" +
+      "# TYPE " +
+      K_CACTUS_CONSORTIUM_MANUAL_TOTAL_NODE_COUNT +
+      " gauge\n" +
+      K_CACTUS_CONSORTIUM_MANUAL_TOTAL_NODE_COUNT +
+      '{type="' +
+      K_CACTUS_CONSORTIUM_MANUAL_TOTAL_NODE_COUNT +
+      '"} 0';
+    t.ok(res);
+    t.ok(res.data);
+    t.equal(res.status, 200);
+    t.true(
+      res.data.includes(promMetricsOutput),
+      "Total Cactus Node Count of 0 recorded as expected. RESULT OK",
+    );
+  }
+
+  // Creating a dummy cactus node for adding it to the cactus node array
+  // and thus observing the change in prometheus exporter metrics (should increment by 1)
+  const dummyCactusNode: CactusNode = {
+    consortiumId: "",
+    id: "",
+    ledgerIds: [],
+    memberId: "",
+    nodeApiHost: "",
+    pluginInstanceIds: [],
+    publicKeyPem: "",
+  };
+
+  consortiumRepo.consortiumDatabase.cactusNode.push(dummyCactusNode);
+  // The invocation of the node JWS endpoint internally triggers the update
+  // of the metrics so after it has executed we can expect the metrics to
+  // show the new values for our assertions below
+  await apiClient.getNodeJws();
+
+  {
+    // The second check shall observe the cactus_consortium_manual_total_node_count metrics
+    // to be valued at One, as the Cactus node array is pushed with a dummy cactus node.
+    const res = await apiClient.getPrometheusExporterMetricsV1();
+    const promMetricsOutput =
+      "# HELP " +
+      K_CACTUS_CONSORTIUM_MANUAL_TOTAL_NODE_COUNT +
+      " Total cactus node count\n" +
+      "# TYPE " +
+      K_CACTUS_CONSORTIUM_MANUAL_TOTAL_NODE_COUNT +
+      " gauge\n" +
+      K_CACTUS_CONSORTIUM_MANUAL_TOTAL_NODE_COUNT +
+      '{type="' +
+      K_CACTUS_CONSORTIUM_MANUAL_TOTAL_NODE_COUNT +
+      '"} 1';
+    t.ok(res);
+    t.ok(res.data);
+    t.equal(res.status, 200);
+    t.true(
+      res.data.includes(promMetricsOutput),
+      "Total Cactus Node Count of 1 recorded as expected. RESULT OK",
+    );
   }
 
   t.end();


### PR DESCRIPTION
# Commit to be reviewed
---------------------------------
feat(consortium-manual): add prometheus exporter

	Primary Change
	--------------
	1. The consortium-manual plugin now includes the prometheus metrics exporter integration
	2. OpenAPI spec now has api endpoint for the getting the prometheus metrics

	Refactorings that were also necessary to accomodate 1) and 2)
	------------------------------------------------------------

	3. GetPrometheusMetricsV1 class is created to handle the corresponding api endpoint
	4. IPluginConsortiumManualOptions interface in PluginConsortiumManual class now has a prometheusExporter optional field
	5. The PluginConsortiumManual class has relevant functions and codes to incorporate prometheus exporter
	6. get-node-jws-endpoint-v1.test.ts is changed to incorporate the prometheus exporter
	7. Added Readme.md on the prometheus exporter usage

Resolve #538

Signed-off-by: Jagpreet Singh Sasan <jagpreet.singh.sasan@accenture.com>