### PR TITLE
feat(test-tooling): add corda AIO emitContainerLogs option

### DIFF
--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
@@ -36,21 +36,8 @@ test(testCase, async (t: Test) => {
   t.ok(ledger, "CordaTestLedger instantaited OK");
 
   test.onFinish(async () => {
-    try {
-      const logBuffer = ((await ledgerContainer.logs({
-        follow: false,
-        stdout: true,
-        stderr: true,
-      })) as unknown) as Buffer;
-      const logs = logBuffer.toString("utf-8");
-      t.comment(`[CordaAllInOne] ${logs}`);
-    } finally {
-      try {
-        await ledger.stop();
-      } finally {
-        await ledger.destroy();
-      }
-    }
+    await ledger.stop();
+    await ledger.destroy();
   });
   const ledgerContainer = await ledger.start();
   t.ok(ledgerContainer, "CordaTestLedger container truthy post-start() OK");

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
@@ -90,7 +90,7 @@ test(testCase, async (t: Test) => {
     imageVersion: "2021-03-10-feat-623",
     envVars: [envVarSpringAppJson],
   });
-  t.ok(CordaConnectorContainer, "CordaConnectorContainer instantaited OK");
+  t.ok(CordaConnectorContainer, "CordaConnectorContainer instantiated OK");
 
   test.onFinish(async () => {
     try {


### PR DESCRIPTION
## Dependencies (need to be reviewed and merged first)

Depends on #657
Depends on #687
Depends on #656 

## Commit to be reviewed

feat(test-tooling): add corda AIO emitContainerLogs option

This is the same thing that we added to the Fabric
AIO image earlier:
Setting the flag controls whether the CordaTestLedger
class will automatically pipe the container's own logs onto the logger object of the
class instance (CordaTestLedger) or not.
By default it does pipe the logs but if it gets spammy
developers can turn it off via the flag to avoid
having to scroll through thousands of lines of
logs that may or may not be useful to them.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>
