### PR TITLE
fix(test-tooling): uncomment code that was forgotten

### DIFF
--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
@@ -36,21 +36,8 @@ test(testCase, async (t: Test) => {
   t.ok(ledger, "CordaTestLedger instantaited OK");
 
   test.onFinish(async () => {
-    try {
-      const logBuffer = ((await ledgerContainer.logs({
-        follow: false,
-        stdout: true,
-        stderr: true,
-      })) as unknown) as Buffer;
-      const logs = logBuffer.toString("utf-8");
-      t.comment(`[CordaAllInOne] ${logs}`);
-    } finally {
-      try {
-        await ledger.stop();
-      } finally {
-        await ledger.destroy();
-      }
-    }
+    await ledger.stop();
+    await ledger.destroy();
   });
   const ledgerContainer = await ledger.start();
   t.ok(ledgerContainer, "CordaTestLedger container truthy post-start() OK");

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
@@ -90,7 +90,7 @@ test(testCase, async (t: Test) => {
     imageVersion: "2021-03-10-feat-623",
     envVars: [envVarSpringAppJson],
   });
-  t.ok(CordaConnectorContainer, "CordaConnectorContainer instantaited OK");
+  t.ok(CordaConnectorContainer, "CordaConnectorContainer instantiated OK");
 
   test.onFinish(async () => {
     try {

--- a/packages/cactus-test-tooling/src/main/typescript/corda/corda-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/corda/corda-test-ledger.ts
@@ -250,8 +250,7 @@ export class CordaTestLedger implements ITestLedger {
   ): Promise<Base64File[]> {
     const fnTag = `${this.className}.pullCordappJars()`;
     Checks.truthy(sampleCordapp, `${fnTag}:sampleCordapp`);
-    // FIXME: uncomment this when done testing
-    // await this.buildCordapp(sampleCordapp);
+    await this.buildCordapp(sampleCordapp);
     const container = this.getContainer();
     const cordappRootDir = SAMPLE_CORDAPP_ROOT_DIRS[sampleCordapp];
 


### PR DESCRIPTION
## Dependencies (need to be reviewed and merged first)

Depends on #657
Depends on #687
Depends on #688
Depends on #656 

## Commit to be reviewed

fix(test-tooling): uncomment code that was forgotten

During testing it was easier and faster to have the
cordapp building process commented out because
the obligation cordapp is pre-built within the
container image of AIO Corda, then it was forgotten
like that which is not good because the rest of the examples
are not pre-built and therefore don't actually work
without this line being uncommented.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>
