### PR TITLE
feat(tools): add standalone shell CLI tool to corda AIO image

### DIFF
--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
@@ -36,21 +36,8 @@ test(testCase, async (t: Test) => {
   t.ok(ledger, "CordaTestLedger instantaited OK");
 
   test.onFinish(async () => {
-    try {
-      const logBuffer = ((await ledgerContainer.logs({
-        follow: false,
-        stdout: true,
-        stderr: true,
-      })) as unknown) as Buffer;
-      const logs = logBuffer.toString("utf-8");
-      t.comment(`[CordaAllInOne] ${logs}`);
-    } finally {
-      try {
-        await ledger.stop();
-      } finally {
-        await ledger.destroy();
-      }
-    }
+    await ledger.stop();
+    await ledger.destroy();
   });
   const ledgerContainer = await ledger.start();
   t.ok(ledgerContainer, "CordaTestLedger container truthy post-start() OK");

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
@@ -90,7 +90,7 @@ test(testCase, async (t: Test) => {
     imageVersion: "2021-03-10-feat-623",
     envVars: [envVarSpringAppJson],
   });
-  t.ok(CordaConnectorContainer, "CordaConnectorContainer instantaited OK");
+  t.ok(CordaConnectorContainer, "CordaConnectorContainer instantiated OK");
 
   test.onFinish(async () => {
     try {

--- a/packages/cactus-test-tooling/src/main/typescript/corda/corda-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/corda/corda-test-ledger.ts
@@ -250,8 +250,7 @@ export class CordaTestLedger implements ITestLedger {
   ): Promise<Base64File[]> {
     const fnTag = `${this.className}.pullCordappJars()`;
     Checks.truthy(sampleCordapp, `${fnTag}:sampleCordapp`);
-    // FIXME: uncomment this when done testing
-    // await this.buildCordapp(sampleCordapp);
+    await this.buildCordapp(sampleCordapp);
     const container = this.getContainer();
     const cordappRootDir = SAMPLE_CORDAPP_ROOT_DIRS[sampleCordapp];
 

--- a/tools/docker/corda-all-in-one/Dockerfile
+++ b/tools/docker/corda-all-in-one/Dockerfile
@@ -2,6 +2,7 @@ FROM docker:20.10.2-dind
 
 ARG SAMPLES_KOTLIN_SHA=c6d386057957ae1a717751abe61f82e7aef4e035
 ARG SAMPLES_KOTLIN_CORDAPP_SUB_DIR_PATH="./Advanced/obligation-cordapp/"
+ARG CORDA_TOOLS_SHELL_CLI_VERSION=4.5
 
 WORKDIR /
 
@@ -57,6 +58,10 @@ RUN cp $CACTUS_CFG_PATH/corda-aio-image.pub ~/.ssh/authorized_keys
 # RUN tr -dc A-Za-z0-9 </dev/urandom | head -c 20 > /root-password.txt
 # RUN cat /root-password.txt | chpasswd
 RUN echo "root:root" | chpasswd
+
+RUN curl https://software.r3.com/artifactory/corda-releases/net/corda/corda-tools-shell-cli/${CORDA_TOOLS_SHELL_CLI_VERSION}/corda-tools-shell-cli-${CORDA_TOOLS_SHELL_CLI_VERSION}-all.jar --output /corda-tools-shell-cli-all.jar
+# This is what makes the "corda-shell" alias avaialble on the terminal
+RUN java -jar /corda-tools-shell-cli-all.jar install-shell-extensions
 
 RUN git clone https://github.com/corda/samples-kotlin.git
 WORKDIR /samples-kotlin

--- a/tools/docker/corda-all-in-one/supervisord.conf
+++ b/tools/docker/corda-all-in-one/supervisord.conf
@@ -4,6 +4,12 @@ logfile_maxbytes = 50MB
 logfile_backups=10
 loglevel = info
 
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=http://127.0.0.1:9001
+
 [program:sshd]
 command=/usr/sbin/sshd -D -ddd
 autostart=true


### PR DESCRIPTION
## Dependencies (need to be reviewed and merged first)

Depends on #657
Depends on #687
Depends on #688
Depends on #689
Depends on #690
Depends on #656 

## Commit to be reviewed

Author: Peter Somogyvari <peter.somogyvari@accenture.com>
Author Date: 2021-03-14 17:17:35 -0700
Committer: Peter Somogyvari <peter.somogyvari@accenture.com>
Committer Date: 2021-03-14 18:51:05 -0700 

feat(tools): add standalone shell CLI tool to corda AIO image

The corda AIO docker image now downloads
the CLI tools jar for the standalone shell at
build time.
By default it downloads the 4.5 version of the
jar but this can be altered to any other version
through a dedicated build argument of the
container image definition.

The image built from this commit is also tagged
(on top of the automatic tagging script) as
hyperledger/cactus-corda-4-6-all-in-one-obligation:2021-03-14-standalone-corda-shell

See more details here for what a standalone
shell is and how it can be used to execute
commands (some which are not available on
the RPC proxy so this tool is a must have for
certain operations such as gracefully stopping
nodes)
https://docs.corda.net/docs/corda-os/4.5/shell.html#standalone-shell

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>
