### PR TITLE
feat(test-tooling): pruneDockerResources() observability #694

### DIFF
--- a/packages/cactus-test-tooling/src/main/typescript/public-api.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/public-api.ts
@@ -23,7 +23,11 @@ export {
 } from "./corda/corda-test-ledger";
 
 export * from "./quorum/i-quorum-genesis-options";
-export { Containers } from "./common/containers";
+export {
+  Containers,
+  IPruneDockerResourcesRequest,
+  IPruneDockerResourcesResponse,
+} from "./common/containers";
 
 export {
   HttpEchoContainer,


### PR DESCRIPTION
Primary change
-----------------------

Adds request and response definitions to
the pruneDockerResources() method to
allow callers to control the log levels
and also to get a complete report of the
pruning processes' outcome from the
returned object instead of just returning
with `void`.

Miscellaneous changes
----------------------------------

Significantly improved the documentation
for the utility method in question.

Fixes #694

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>