### PR TITLE
feat(test-tooling): utility function docker prune in GH action #696

### DIFF
--- a/packages/cactus-test-tooling/src/main/typescript/github-actions/is-running-in-github-action.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/github-actions/is-running-in-github-action.ts
@@ -1,0 +1,27 @@
+import { Checks } from "@hyperledger/cactus-common";
+
+/**
+ * Utility/helper function that examines if the current code is running on Github Actions
+ * or not.
+ *
+ * Important note: Do not use this in production code it is meant to be used for tests
+ * only. Do not depend on this function in your code outside of the test cases.
+ *
+ * Uses the environment variable `GITHUB_ACTIONS` to determine its output which is always
+ * set to `"true"` when GitHub Actions is running the workflow.
+ * You can use this variable to differentiate when tests are being run locally or by GitHub Actions.
+ *
+ * @see https://docs.github.com/en/actions/reference/environment-variables
+ *
+ * @param env The process environment variables object to look into when attempting to
+ * determine if the current execution environment appears to be a GitHub Action VM or
+ * not.
+ * @returns
+ */
+export function isRunningInGithubAction(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  Checks.truthy(env, "isRunningInGithubAction():env");
+
+  return env.GITHUB_ACTIONS === "true";
+}

--- a/packages/cactus-test-tooling/src/main/typescript/github-actions/prune-docker-all-if-github-action.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/github-actions/prune-docker-all-if-github-action.ts
@@ -1,0 +1,27 @@
+import { Optional } from "typescript-optional";
+import {
+  Containers,
+  IPruneDockerResourcesRequest,
+  IPruneDockerResourcesResponse,
+} from "../common/containers";
+import { isRunningInGithubAction } from "./is-running-in-github-action";
+
+/**
+ * Github Actions started to run out of disk space recently (as of March, 2021) so we have this
+ * hack here to attempt to free up disk space when running inside a VM of the CI system.
+ * The idea is that tests can call this function before and after their execution so that
+ * their container images/volumes get freed up.
+ */
+export async function pruneDockerAllIfGithubAction(
+  req?: IPruneDockerResourcesRequest,
+): Promise<Optional<IPruneDockerResourcesResponse>> {
+  if (!isRunningInGithubAction()) {
+    return Optional.empty();
+  }
+  console.log(
+    "Detected current process to be running " +
+      "inside a Github Action. Pruning all docker resources...",
+  );
+  const res = await Containers.pruneDockerResources(req);
+  return Optional.of(res);
+}

--- a/packages/cactus-test-tooling/src/main/typescript/public-api.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/public-api.ts
@@ -23,7 +23,11 @@ export {
 } from "./corda/corda-test-ledger";
 
 export * from "./quorum/i-quorum-genesis-options";
-export { Containers } from "./common/containers";
+export {
+  Containers,
+  IPruneDockerResourcesRequest,
+  IPruneDockerResourcesResponse,
+} from "./common/containers";
 
 export {
   HttpEchoContainer,

--- a/packages/cactus-test-tooling/src/main/typescript/public-api.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/public-api.ts
@@ -73,3 +73,6 @@ export {
 } from "./corda/sample-cordapp-enum";
 
 export { Streams } from "./common/streams";
+
+export { isRunningInGithubAction } from "./github-actions/is-running-in-github-action";
+export { pruneDockerAllIfGithubAction } from "./github-actions/prune-docker-all-if-github-action";


### PR DESCRIPTION
## Dependencies

Depends on #695 

## Commit to be reviewed

feat(test-tooling): utility function docker prune in GH action #696

Primary change
--------------

Added a convenience function that tests can call in order to easily
get rid of dangling docker resources that could be eating up the
file system's available space on disk (which is an issue that we've
started hitting more and more as we kept increasing the number
of test cases that use containers for end to end testing).
A good problem to have but nevertheless it is a problem that we
need to be vigilant about cleaning up after our test cases to avoid
overusing the resources of the CI runner.

Miscellaneous change(s)
-----------------------

Also added another utility function to determine if the current code
is being executed in a GitHub Action Workflow runner or not.
The presence and value of an environment variable is used to
achieve this feat so it definitely is not bullet proof but the trade-
off seemed fair given that these utility functions are only meant to
be used by the test code anyway.

Fixes #696 

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>