### PR TITLE
fix(common): servers#startOnPreferredPort no graceful fallback #683

### DIFF
--- a/packages/cactus-common/src/main/typescript/servers.ts
+++ b/packages/cactus-common/src/main/typescript/servers.ts
@@ -86,7 +86,8 @@ export class Servers {
   ): Promise<Server> {
     if (preferredPort) {
       try {
-        return Servers.startOnPort(preferredPort, host);
+        const server = await Servers.startOnPort(preferredPort, host);
+        return server;
       } catch (ex) {
         // if something else went wrong we still want to just give up
         if (!ex.message.includes("EADDRINUSE")) {


### PR DESCRIPTION
## Dependencies

Depends on #656 

## Commit to be reviewed

fix(common): servers#startOnPreferredPort no graceful fallback #683

The code of the method was not waiting for a promise to resolve
which was masking the underlying exception that the code
was supposed to catch and examine in order to determine if
it should perform a fallback of binding to port zero or not.
Fixed it by making sure the initial try of the preferred port
allocation is awaited for so that the exception is thrown
where it is expected by the algorithm.

Fixes #683

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>
