### PR TITLE
feat(connector-besu): request param: wait for ledger tx receipt #685

### DIFF
--- a/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json
@@ -31,6 +31,33 @@
     ],
     "components": {
         "schemas": {
+            "ReceiptType": {
+                "description": "Enumerates the possible types of receipts that can be waited for by someone or something that has requested the execution of a transaction on a ledger.",
+                "type": "string",
+                "enum": [
+                    "NODE_TX_POOL_ACK", 
+                    "LEDGER_BLOCK_ACK"
+                ]
+            },
+            "ConsistencyStrategy": {
+                "type": "object",
+                "required": ["receiptType", "blockConfirmations"],
+                "properties": {
+                    "receiptType": {
+                        "$ref": "#/components/schemas/ReceiptType"
+                    },
+                    "timeoutMs": {
+                        "type": "integer",
+                        "description": "The amount of milliseconds to wait for the receipt to arrive to the connector. Defaults to 0 which means to wait for an unlimited amount of time. Note that this wait may be interrupted still by other parts of the infrastructure such as load balancers cutting of HTTP requests after some time even if they are the type that is supposed to be kept alive. The question of re-entrancy is a broader topic not in scope to discuss here, but it is important to mention it.",
+                        "minimum": 0
+                    },
+                    "blockConfirmations": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "The number of blocks to wait to be confirmed in addition to the block containing the transaction in question. Note that if the receipt type is set to only wait for node transaction pool ACK and this parameter is set to anything, but zero then the API will not accept the request due to conflicting parameters."
+                    }
+                }
+            },
             "Web3SigningCredential": {
                 "type": "object",
                 "required": [
@@ -343,7 +370,8 @@
                 "type": "object",
                 "required": [
                     "web3SigningCredential",
-                    "transactionConfig"
+                    "transactionConfig",
+                    "consistencyStrategy"
                 ],
                 "properties": {
                     "web3SigningCredential": {
@@ -354,12 +382,8 @@
                         "$ref": "#/components/schemas/BesuTransactionConfig",
                         "nullable": false
                     },
-                    "timeoutMs": {
-                        "type": "number",
-                        "description": "The amount of milliseconds to wait for a transaction receipt with thehash of the transaction(which indicates successful execution) beforegiving up and crashing.",
-                        "minimum": 0,
-                        "default": 60000,
-                        "nullable": false
+                    "consistencyStrategy": {
+                        "$ref": "#/components/schemas/ConsistencyStrategy"
                     }
                 }
             },

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -79,6 +79,31 @@ export interface BesuTransactionConfig {
 /**
  * 
  * @export
+ * @interface ConsistencyStrategy
+ */
+export interface ConsistencyStrategy {
+    /**
+     * 
+     * @type {ReceiptType}
+     * @memberof ConsistencyStrategy
+     */
+    receiptType: ReceiptType;
+    /**
+     * The amount of milliseconds to wait for the receipt to arrive to the connector. Defaults to 0 which means to wait for an unlimited amount of time. Note that this wait may be interrupted still by other parts of the infrastructure such as load balancers cutting of HTTP requests after some time even if they are the type that is supposed to be kept alive. The question of re-entrancy is a broader topic not in scope to discuss here, but it is important to mention it.
+     * @type {number}
+     * @memberof ConsistencyStrategy
+     */
+    timeoutMs?: number;
+    /**
+     * The number of blocks to wait to be confirmed in addition to the block containing the transaction in question. Note that if the receipt type is set to only wait for node transaction pool ACK and this parameter is set to anything, but zero then the API will not accept the request due to conflicting parameters.
+     * @type {number}
+     * @memberof ConsistencyStrategy
+     */
+    blockConfirmations: number;
+}
+/**
+ * 
+ * @export
  * @interface DeployContractSolidityBytecodeV1Request
  */
 export interface DeployContractSolidityBytecodeV1Request {
@@ -321,6 +346,16 @@ export interface InvokeContractV2Response {
     success: boolean;
 }
 /**
+ * Enumerates the possible types of receipts that can be waited for by someone or something that has requested the execution of a transaction on a ledger.
+ * @export
+ * @enum {string}
+ */
+export enum ReceiptType {
+    NODETXPOOLACK = 'NODE_TX_POOL_ACK',
+    LEDGERBLOCKACK = 'LEDGER_BLOCK_ACK'
+}
+
+/**
  * 
  * @export
  * @interface RunTransactionRequest
@@ -339,11 +374,11 @@ export interface RunTransactionRequest {
      */
     transactionConfig: BesuTransactionConfig;
     /**
-     * The amount of milliseconds to wait for a transaction receipt with thehash of the transaction(which indicates successful execution) beforegiving up and crashing.
-     * @type {number}
+     * 
+     * @type {ConsistencyStrategy}
      * @memberof RunTransactionRequest
      */
-    timeoutMs?: number;
+    consistencyStrategy: ConsistencyStrategy;
 }
 /**
  * 

--- a/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/deploy-contract-from-json.test.ts
@@ -7,6 +7,7 @@ import {
   PluginLedgerConnectorBesu,
   PluginFactoryLedgerConnector,
   Web3SigningCredentialCactusKeychainRef,
+  ReceiptType,
 } from "../../../../../main/typescript/public-api";
 import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory";
 import {
@@ -69,6 +70,7 @@ test(testCase, async (t: Test) => {
   });
   const connector: PluginLedgerConnectorBesu = await factory.create({
     rpcApiHttpHost,
+    logLevel,
     instanceId: uuidv4(),
     pluginRegistry: new PluginRegistry({ plugins: [keychainPlugin] }),
   });
@@ -84,6 +86,11 @@ test(testCase, async (t: Test) => {
       to: testEthAccount.address,
       value: 10e9,
       gas: 1000000,
+    },
+    consistencyStrategy: {
+      blockConfirmations: 0,
+      receiptType: ReceiptType.NODETXPOOLACK,
+      timeoutMs: 60000,
     },
   });
 
@@ -157,6 +164,11 @@ test(testCase, async (t: Test) => {
       },
       transactionConfig: {
         rawTransaction,
+      },
+      consistencyStrategy: {
+        blockConfirmations: 0,
+        receiptType: ReceiptType.NODETXPOOLACK,
+        timeoutMs: 60000,
       },
     });
 

--- a/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/invoke-contract-v2.test.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/invoke-contract-v2.test.ts
@@ -8,6 +8,7 @@ import {
   PluginLedgerConnectorBesu,
   PluginFactoryLedgerConnector,
   Web3SigningCredentialCactusKeychainRef,
+  ReceiptType,
 } from "../../../../../main/typescript/public-api";
 import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory";
 import { BesuTestLedger } from "@hyperledger/cactus-test-tooling";
@@ -74,6 +75,10 @@ test("deploys contract via .json file", async (t: Test) => {
       ethAccount: firstHighNetWorthAccount,
       secret: besuKeyPair.privateKey,
       type: Web3SigningCredentialType.PRIVATEKEYHEX,
+    },
+    consistencyStrategy: {
+      blockConfirmations: 0,
+      receiptType: ReceiptType.NODETXPOOLACK,
     },
     transactionConfig: {
       from: firstHighNetWorthAccount,
@@ -149,6 +154,10 @@ test("deploys contract via .json file", async (t: Test) => {
     await connector.transact({
       web3SigningCredential: {
         type: Web3SigningCredentialType.NONE,
+      },
+      consistencyStrategy: {
+        blockConfirmations: 0,
+        receiptType: ReceiptType.NODETXPOOLACK,
       },
       transactionConfig: {
         rawTransaction,


### PR DESCRIPTION
Adds new parameters to the run transaction endpoint's request object
that allow the caller to specify a the consistency strategy
parameters that can define if the connector should wait for either:
1. the transaction to be confirmed only by the node's transaction pool
2. if at least the block containing the transaction should be mined
by the ledger
3. an N number of additional blocks should be confirmed by the ledger
in **addition** to the block that contained the transaction.

The parameters also allow to specify a timeout in milliseconds that
if unspecified defaults to the maximum safe integer that Javascript
can represent which for practical purposes we consider to be the
same as waiting until the heat death of the universe or infinity.

Fixes #685

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>