### PR TITLE
ci: use tools/ci.sh in Github Actions #497

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,18 +56,4 @@ jobs:
 
     - uses: actions/checkout@v2.3.4
 
-    # https://stackoverflow.com/a/61789467
-    - run: npm config list
-    - run: npm config delete proxy
-    - run: npm config delete http-proxy
-    - run: npm config delete https-proxy
-
-    # https://stackoverflow.com/a/15483897
-    - run: npm cache verify
-    - run: npm cache clean --force
-    - run: npm cache verify
-
-    - run: npm ci
-    - run: ./node_modules/.bin/lerna bootstrap
-    - run: npm run build:dev:backend
-    - run: npm run test:all -- --bail
+    - run: ./tools/ci.sh


### PR DESCRIPTION
## Dependencies

Depends on #656 
Depends on #674

## Commit to review

ci: use tools/ci.sh in Github Actions #497

While we were getting to know the GitHub Actions CI runner
we temporarily stopped using the tools/ci.sh script
to run the tests, but now that we are properly
familiarized with GHA and it's quirks, it is time to
go back to the good old script we've been using before migrating
over to GHA for CI.

Fixes #497

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

