### PR TITLE
fix(tools): ci.sh wsl2 lsmem does not support memory blocks #556

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -19,19 +19,19 @@ function mainTask()
   if ! [ -x "$(command -v lscpu)" ]; then
     echo 'lscpu is not installed, skipping...'
   else
-    lscpu
+    lscpu || true
   fi
 
   if ! [ -x "$(command -v lsmem)" ]; then
     echo 'lsmem is not installed, skipping...'
   else
-    lsmem
+    lsmem || true
   fi
 
   if ! [ -x "$(command -v smem)" ]; then
     echo 'smem is not installed, skipping...'
   else
-    smem --abbreviate --totals --system
+    smem --abbreviate --totals --system || true
   fi
 
   # Travis does not have (nor need) nvm but CircleCI does have nvm and also


### PR DESCRIPTION
## Dependencies

Depends on #713
Depends on #674 

## Commit to review

Author: Peter Somogyvari <peter.somogyvari@accenture.com>
Author Date: 2021-03-24 15:19:59 -0700
Committer: Peter Somogyvari <peter.somogyvari@accenture.com>
Committer Date: 2021-03-24 17:42:51 -0700 

fix(tools): ci.sh wsl2 lsmem does not support memory blocks #556

Added a fallback || true suffix to the lsmem, lscpu and smem commands
which are used by the ci.sh script to dump diagnostic information about
the hardware of the CI runner prior to actually proceeding with the
execution of the full build+test suite.

The existing guards examining the presence of the lsmem binary were
not enough because the lsmem binary is indeed present on WSL 2
Ubuntu, it just does not work as intended (exit code is non-zero which
crashes the ci.sh script by design)

Fixes #556

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>
