### PR TITLE
feat(corda-connector): params factory pattern support #620

### DIFF
--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/impl/JsonJvmObjectDeserializer.kt
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/impl/JsonJvmObjectDeserializer.kt
@@ -1,0 +1,174 @@
+package org.hyperledger.cactus.plugin.ledger.connector.corda.server.impl
+
+import net.corda.core.utilities.loggerFor
+import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.JvmObject
+import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.JvmTypeKind
+import org.xeustechnologies.jcl.JarClassLoader
+import java.lang.Exception
+import java.lang.IllegalStateException
+import java.lang.RuntimeException
+import java.lang.reflect.Constructor
+import java.lang.reflect.Method
+import java.util.*
+
+// FIXME: Make it so that this has a memory, remembering the .jar files that were added before (file-system?) or
+// maybe use the keychain to save it there and then it can pre-populate at boot?
+class JsonJvmObjectDeserializer(
+    val jcl: JarClassLoader = JarClassLoader(JsonJvmObjectDeserializer::class.java.classLoader)
+) {
+
+    companion object {
+        val logger = loggerFor<JsonJvmObjectDeserializer>()
+
+        // If something is missing from here that's because they also missed at in the documentation:
+        // https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html
+        val exoticTypes: Map<String, Class<*>> = mapOf(
+
+            "byte" to Byte::class.java,
+            "char" to Char::class.java,
+            "int" to Int::class.java,
+            "short" to Short::class.java,
+            "long" to Long::class.java,
+            "float" to Float::class.java,
+            "double" to Double::class.java,
+            "boolean" to Boolean::class.java,
+
+            "byte[]" to ByteArray::class.java,
+            "char[]" to CharArray::class.java,
+            "int[]" to IntArray::class.java,
+            "short[]" to ShortArray::class.java,
+            "long[]" to LongArray::class.java,
+            "float[]" to FloatArray::class.java,
+            "double[]" to DoubleArray::class.java,
+            "boolean[]" to BooleanArray::class.java
+        )
+    }
+
+    fun getOrInferType(fqClassName: String): Class<*> {
+        Objects.requireNonNull(fqClassName, "fqClassName must not be null for its type to be inferred.")
+
+        return if (exoticTypes.containsKey(fqClassName)) {
+            exoticTypes.getOrElse(
+                fqClassName,
+                { throw IllegalStateException("Could not locate Class<*> for $fqClassName Exotic JVM types map must have been modified on a concurrent threat.") })
+        } else {
+            try {
+                jcl.loadClass(fqClassName, true)
+            } catch (ex: ClassNotFoundException) {
+                Class.forName(fqClassName)
+            }
+        }
+    }
+
+    fun instantiate(jvmObject: JvmObject): Any? {
+        logger.info("Instantiating ... JvmObject={}", jvmObject)
+
+        val clazz = getOrInferType(jvmObject.jvmType.fqClassName)
+
+        when (jvmObject.jvmTypeKind) {
+            JvmTypeKind.REFERENCE -> {
+                if (jvmObject.jvmCtorArgs == null) {
+                    throw IllegalArgumentException("jvmObject.jvmCtorArgs cannot be null when jvmObject.jvmTypeKind == JvmTypeKind.REFERENCE")
+                }
+                val constructorArgs: Array<Any?> = jvmObject.jvmCtorArgs.map { x -> instantiate(x) }.toTypedArray()
+
+                when {
+                    List::class.java.isAssignableFrom(clazz) -> {
+                        return listOf(*constructorArgs)
+                    }
+                    Array<Any>::class.java.isAssignableFrom(clazz) -> {
+                        // TODO verify that this actually works and also
+                        // if we need it at all since we already have lists covered
+                        return arrayOf(*constructorArgs)
+                    }
+                    jvmObject.jvmType.constructorName != null -> {
+                        val methodArgTypes: List<Class<*>> =
+                            jvmObject.jvmCtorArgs.map { x -> getOrInferType(x.jvmType.fqClassName) }
+                        val factoryMethod: Method
+                        try {
+                            factoryMethod = clazz.methods
+                                .filter { c -> c.name == jvmObject.jvmType.constructorName }
+                                .filter { c -> c.parameterCount == methodArgTypes.size }
+                                .single { c ->
+                                    c.parameterTypes
+                                        .mapIndexed { index, clazz -> clazz.isAssignableFrom(methodArgTypes[index]) }
+                                        .all { x -> x }
+                                }
+                        } catch (ex: NoSuchElementException) {
+                            val argTypes = jvmObject.jvmCtorArgs.joinToString(",") { x -> x.jvmType.fqClassName }
+                            val className = jvmObject.jvmType.fqClassName
+                            val methodsAsStrings = clazz.constructors
+                                .mapIndexed { i, c -> "$className->Method#${i + 1}(${c.parameterTypes.joinToString { p -> p.name }})" }
+                                .joinToString(" ;; ")
+                            val targetMethod = "Cannot find matching method for ${className}(${argTypes})"
+                            val availableMethods =
+                                "Searched among the ${clazz.constructors.size} available methods: $methodsAsStrings"
+                            throw RuntimeException("$targetMethod --- $availableMethods")
+                        }
+
+                        logger.info("Constructor=${factoryMethod}")
+                        constructorArgs.forEachIndexed { index, it -> logger.info("Constructor ARGS: #${index} -> $it") }
+
+                        var invocationTarget: Any? = null
+                        if (jvmObject.jvmType.invocationTarget != null) {
+                            try {
+                                logger.debug("Instantiating InvocationTarget: ${jvmObject.jvmType.invocationTarget}")
+                                invocationTarget = instantiate(jvmObject.jvmType.invocationTarget)
+                                logger.debug("Instantiated OK InvocationTarget: ${jvmObject.jvmType.invocationTarget}")
+                            } catch (ex: Exception) {
+                                val argTypes = jvmObject.jvmCtorArgs.joinToString(",") { x -> x.jvmType.fqClassName }
+                                val className = jvmObject.jvmType.fqClassName
+                                val constructorName = jvmObject.jvmType.constructorName
+                                val message = "Failed to instantiate invocation target for " +
+                                        "JvmType:${className}${constructorName}(${argTypes}) with an " +
+                                        "InvocationTarget: ${jvmObject.jvmType.invocationTarget}"
+                                throw RuntimeException(message, ex)
+                            }
+                        }
+                        val instance = factoryMethod.invoke(invocationTarget, *constructorArgs)
+                        logger.info("Instantiated REFERENCE OK {}", instance)
+                        return instance
+                    }
+                    else -> {
+                        val constructorArgTypes: List<Class<*>> =
+                            jvmObject.jvmCtorArgs.map { x -> getOrInferType(x.jvmType.fqClassName) }
+                        val constructor: Constructor<*>
+                        try {
+                            constructor = clazz.constructors
+                                .filter { c -> c.parameterCount == constructorArgTypes.size }
+                                .single { c ->
+                                    c.parameterTypes
+                                        .mapIndexed { index, clazz -> clazz.isAssignableFrom(constructorArgTypes[index]) }
+                                        .all { x -> x }
+                                }
+                        } catch (ex: NoSuchElementException) {
+                            val argTypes = jvmObject.jvmCtorArgs.joinToString(",") { x -> x.jvmType.fqClassName }
+                            val className = jvmObject.jvmType.fqClassName
+                            val constructorsAsStrings = clazz.constructors
+                                .mapIndexed { i, c -> "$className->Constructor#${i + 1}(${c.parameterTypes.joinToString { p -> p.name }})" }
+                                .joinToString(" ;; ")
+                            val targetConstructor = "Cannot find matching constructor for ${className}(${argTypes})"
+                            val availableConstructors =
+                                "Searched among the ${clazz.constructors.size} available constructors: $constructorsAsStrings"
+                            throw RuntimeException("$targetConstructor --- $availableConstructors")
+                        }
+
+                        logger.info("Constructor=${constructor}")
+                        constructorArgs.forEachIndexed { index, it -> logger.info("Constructor ARGS: #${index} -> $it") }
+                        val instance = constructor.newInstance(*constructorArgs)
+                        logger.info("Instantiated REFERENCE OK {}", instance)
+                        return instance
+                    }
+                }
+
+            }
+            JvmTypeKind.PRIMITIVE -> {
+                logger.info("Instantiated PRIMITIVE OK {}", jvmObject.primitiveValue)
+                return jvmObject.primitiveValue
+            }
+            else -> {
+                throw IllegalArgumentException("Unknown jvmObject.jvmTypeKind (${jvmObject.jvmTypeKind})")
+            }
+        }
+    }
+}

--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/impl/NodeRPCConnection.kt
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/impl/NodeRPCConnection.kt
@@ -69,7 +69,24 @@ open class NodeRPCConnection(
             maxAttempts = 30
         )
 
-        rpcConnection = rpcClient.start(username, password, gracefulReconnect = gracefulReconnect)
+        // this workaround here is due to the Graceful Reconnect above not actually doing what it's supposed to
+        // either because it has a bug or because I misread the documentation.
+        // So this manual retry on top of the graceful reconnects is to make it resilient
+        var numberOfTriesRemaining = 5
+        while (numberOfTriesRemaining > 0) {
+            numberOfTriesRemaining--
+            try {
+                logger.info("Trying to connect to RPC numberOfTriesRemaining=$numberOfTriesRemaining")
+                rpcConnection = rpcClient.start(username, password, gracefulReconnect = gracefulReconnect)
+                break;
+            } catch (ex: net.corda.client.rpc.RPCException) {
+                logger.info("ManualReconnect:numberOfTriesRemaining=$numberOfTriesRemaining")
+                if (numberOfTriesRemaining <= 0) {
+                    throw ex
+                }
+            }
+        }
+
         proxy = rpcConnection.proxy
     }
 

--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/DeployContractJarsV1Request.kt
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/DeployContractJarsV1Request.kt
@@ -22,7 +22,7 @@ data class DeployContractJarsV1Request(
 
     @get:NotNull  
     @field:Valid
-    @get:Size(min=1,max=1024)
+    @get:Size(min=0,max=1024)
     @field:JsonProperty("cordappDeploymentConfigs") val cordappDeploymentConfigs: kotlin.collections.List<CordappDeploymentConfig>,
 
     @get:NotNull  

--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/JvmType.kt
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/JvmType.kt
@@ -2,6 +2,7 @@ package org.hyperledger.cactus.plugin.ledger.connector.corda.server.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.JvmObject
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Max
@@ -14,12 +15,20 @@ import javax.validation.Valid
 /**
  * Represents a reference to a JVM type (such as a Java class)
  * @param fqClassName 
+ * @param constructorName This parameter is used to specify that the function used to construct this JvmType is not a constructor function but instead is a factory function. Setting this parameter will cause the plugin to look up methods of the class denoted by fqClassName instead of its constructors.
+ * @param invocationTarget 
  */
 data class JvmType(
 
     @get:NotNull  
     @get:Size(min=1,max=65535)
-    @field:JsonProperty("fqClassName") val fqClassName: kotlin.String
+    @field:JsonProperty("fqClassName") val fqClassName: kotlin.String,
+
+    @get:Size(min=1,max=65535)
+    @field:JsonProperty("constructorName") val constructorName: kotlin.String? = null,
+
+    @field:Valid
+    @field:JsonProperty("invocationTarget") val invocationTarget: JvmObject? = null
 ) {
 
 }

--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/start-app.sh
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/start-app.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-java -jar ${APP}/kotlin-spring/build/libs/cactus-connector-corda-server-0.3.0.jar
+for i in 1 2 3 4 5; do java -jar ${APP}/kotlin-spring/build/libs/cactus-connector-corda-server-0.3.0.jar && break || sleep 15; done

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/json/openapi.json
@@ -209,6 +209,16 @@
                         "nullable": false,
                         "minLength": 1,
                         "maxLength": 65535
+                    },
+                    "constructorName": {
+                        "type": "string",
+                        "nullable": false,
+                        "description": "This parameter is used to specify that the function used to construct this JvmType is not a constructor function but instead is a factory function. Setting this parameter will cause the plugin to look up methods of the class denoted by fqClassName instead of its constructors.",
+                        "minLength": 1,
+                        "maxLength": 65535
+                    },
+                    "invocationTarget": {
+                        "$ref": "#/components/schemas/JvmObject"
                     }
                 }
             },
@@ -368,8 +378,9 @@
                     "cordappDeploymentConfigs": {
                         "type": "array",
                         "description": "The list of deployment configurations pointing to the nodes where the provided cordapp jar files are to be deployed .",
-                        "minLength": 1,
+                        "minLength": 0,
                         "maxLength": 1024,
+                        "default": [],
                         "items": {
                             "$ref": "#/components/schemas/CordappDeploymentConfig"
                         }

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -447,6 +447,18 @@ export interface JvmType {
      * @memberof JvmType
      */
     fqClassName: string;
+    /**
+     * This parameter is used to specify that the function used to construct this JvmType is not a constructor function but instead is a factory function. Setting this parameter will cause the plugin to look up methods of the class denoted by fqClassName instead of its constructors.
+     * @type {string}
+     * @memberof JvmType
+     */
+    constructorName?: string;
+    /**
+     * 
+     * @type {JvmObject}
+     * @memberof JvmType
+     */
+    invocationTarget?: JvmObject;
 }
 /**
  * 

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes.test.ts
@@ -86,33 +86,21 @@ test("Tests are passing on the JVM side", async (t: Test) => {
   const connector = new CordaConnectorContainer({
     logLevel,
     imageName: "hyperledger/cactus-connector-corda-server",
-    imageVersion: "2021-03-16-feat-621",
+    imageVersion: "2021-03-24-feat-620",
+    // imageName: "cccs",
+    // imageVersion: "latest",
     envVars: [envVarSpringAppJson],
   });
   t.ok(CordaConnectorContainer, "CordaConnectorContainer instantiated OK");
 
   test.onFinish(async () => {
     try {
-      const logBuffer = ((await connectorContainer.logs({
-        follow: false,
-        stdout: true,
-        stderr: true,
-      })) as unknown) as Buffer;
-      const logs = logBuffer.toString("utf-8");
-      t.comment(`[CordaConnectorServer] ${logs}`);
+      await connector.stop();
     } finally {
-      try {
-        await connector.stop();
-      } finally {
-        await connector.destroy();
-      }
+      await connector.destroy();
     }
   });
 
-  // FIXME health checks with JMX appear to be working but this wait still seems
-  // to be necessary in order to make it work on the CI server (locally it
-  // works just fine without this as well...)
-  // await new Promise((r) => setTimeout(r, 120000));
   const connectorContainer = await connector.start();
   t.ok(connectorContainer, "CordaConnectorContainer started OK");
 


### PR DESCRIPTION
## Dependencies

Depends on #666 

## Commit

Author: Peter Somogyvari <peter.somogyvari@accenture.com>
Committer: Peter Somogyvari <peter.somogyvari@accenture.com>
Date: 2021-03-24 22:33:40 -0700 

feat(corda-connector): params factory pattern support #620

Primary change
============

Added support in the Corda ledger connector plugin's JVM backend to
have the JSON DSL be able to express static and non-static factory
functions.
For the non-static factory functions, the invocation target can be any
constructable object that the DLS can express via the JvmObject type.

The method lookups are performed the same way as when looking up
constructors but with the additional constraint that the name of the
method has to also match not just the parameter types/count.

Miscellaneous changes
==================

Refactored ApiPluginLedgerConnectorCordaServiceImpl.kt so that it
does not include the JSON DSL deserialization logic within itself but
instead outsources all of that to a separate class that was newly added
just for this: JsonJvmObjectDeserializer.kt

Updated the tests to specify the new invocation parameters accordingly:
The Currency class is now instantiated through the JSON DLS thanks to
the static factory method support we just added.

Published the container image to the DockerHub registry with the updated
JVM corda connector plugin under the tag:
hyperledger/cactus-connector-corda-server:2021-03-24-feat-620
(which is now used by both of the integration tests that we
currently have for corda)

The contract deployment request object will now allow a minimum of
zero items in the deployment configuration array parameter which
we needed to cover the case when a jar only needs to be deployed
to the classpath of the connector plugin because it is already present
on the Corda node's cordapps directory (meaning that adding it there
again would make it impossible to start back up the corda node)

Fixes #620

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>