### PR TITLE
feat(api-server): add prometheus exporter

### DIFF
--- a/packages/cactus-cmd-api-server/README.md
+++ b/packages/cactus-cmd-api-server/README.md
@@ -8,6 +8,10 @@
 - [Deployment Scenarios](#deployment-scenarios)
   - [Production Deployment Example](#production-deployment-example)
   - [Low Resource Deployment Example](#low-resource-deployment-example)
+- [Prometheus Exporter](#prometheus-exporter)
+  - [Usage Prometheus](#usage-prometheus)
+  - [Prometheus Integration](#prometheus-integration)
+  - [Helper Code](#helper-code)
 - [FAQ](#faq)
   - [What is the difference between a Cactus Node and a Cactus API Server?](#what-is-the-difference-between-a-cactus-node-and-a-cactus-api-server)
   - [Is the API server horizontally scalable?](#is-the-api-server-horizontally-scalable)
@@ -195,6 +199,47 @@ The individual nodes/API servers are isolated by listening on seperate TCP ports
 of the machine they are hosted on:
 
 ![deployment-low-resource-example.png](https://github.com/hyperledger/cactus/raw/4a337be719a9d2e2ccb877edccd7849f4be477ec/whitepaper/deployment-low-resource-example.png)
+
+## Prometheus Exporter
+This class creates a prometheus exporter, which scrapes the total Cactus node count.
+
+### Usage Prometheus
+The prometheus exporter object is initialized in the `ApiServer` class constructor itself, so instantiating the object of the `ApiServer` class, gives access to the exporter object.
+You can also initialize the prometheus exporter object seperately and then pass it to the `IApiServerConstructorOptions` interface for `ApiServer` constructor.
+
+`getPrometheusExporterMetricsV1` function returns the prometheus exporter metrics, currently displaying the total plugins imported, which currently refreshes to match the plugin count, everytime `setTotalPluginImports` method is called.
+
+### Prometheus Integration
+To use Prometheus with this exporter make sure to install [Prometheus main component](https://prometheus.io/download/).
+Once Prometheus is setup, the corresponding scrape_config needs to be added to the prometheus.yml
+
+```(yaml)
+- job_name: 'consortium_manual_exporter'
+  metrics_path: /api/v1/api-server/get-prometheus-exporter-metrics
+  scrape_interval: 5s
+  static_configs:
+    - targets: ['{host}:{port}']
+```
+
+Here the `host:port` is where the prometheus exporter metrics are exposed. The test cases (For example, packages/cactus-plugin-consortium-manual/src/test/typescript/unit/consortium/get-node-jws-endpoint-v1.test.ts) exposes it over `0.0.0.0` and a random port(). The random port can be found in the running logs of the test case and looks like (42379 in the below mentioned URL)
+`Metrics URL: http://0.0.0.0:42379/api/v1/api-server/get-prometheus-exporter-metrics/get-prometheus-exporter-metrics`
+
+Once edited, you can start the prometheus service by referencing the above edited prometheus.yml file.
+On the prometheus graphical interface (defaulted to http://localhost:9090), choose **Graph** from the menu bar, then select the **Console** tab. From the **Insert metric at cursor** drop down, select **cactus_api_server_total_plugin_imports** and click **execute**
+
+### Helper code
+
+###### response.type.ts
+This file contains the various responses of the metrics.
+
+###### data-fetcher.ts
+This file contains functions encasing the logic to process the data points.
+
+###### metrics.ts
+This file lists all the prometheus metrics and what they are used for.
+
+
+
 
 
 ## FAQ

--- a/packages/cactus-cmd-api-server/package-lock.json
+++ b/packages/cactus-cmd-api-server/package-lock.json
@@ -224,6 +224,11 @@
 				"file-uri-to-path": "1.0.0"
 			}
 		},
+		"bintrees": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+			"integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+		},
 		"body-parser": {
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -811,6 +816,14 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
+		"prom-client": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.1.0.tgz",
+			"integrity": "sha512-jT9VccZCWrJWXdyEtQddCDszYsiuWj5T0ekrPszi/WEegj3IZy6Mm09iOOVM86A4IKMWq8hZkT2dD9MaSe+sng==",
+			"requires": {
+				"tdigest": "^0.1.1"
+			}
+		},
 		"proxy-addr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -934,6 +947,14 @@
 			"version": "0.10.31",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+		},
+		"tdigest": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+			"integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+			"requires": {
+				"bintrees": "1.0.1"
+			}
 		},
 		"toidentifier": {
 			"version": "1.0.0",

--- a/packages/cactus-cmd-api-server/package.json
+++ b/packages/cactus-cmd-api-server/package.json
@@ -101,6 +101,7 @@
     "express-openapi-validator": "3.10.0",
     "jose": "1.27.2",
     "node-forge": "0.10.0",
+    "prom-client": "13.1.0",
     "semver": "7.3.2",
     "uuid": "7.0.2"
   },

--- a/packages/cactus-cmd-api-server/src/main/json/openapi.json
+++ b/packages/cactus-cmd-api-server/src/main/json/openapi.json
@@ -73,6 +73,10 @@
                     "createdAt",
                     "memoryUsage"
                 ]
+            },
+            "PrometheusExporterMetricsResponse": {
+                "type": "string",
+                "nullable": false
             }
         }
     },
@@ -96,6 +100,31 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/HealthCheckResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/api-server/get-prometheus-exporter-metrics": {
+            "get": {
+                "x-hyperledger-cactus": {
+                    "http": {
+                        "verbLowerCase": "get",
+                        "path": "/api/v1/api-server/get-prometheus-exporter-metrics"
+                    }
+                },
+                "operationId": "getPrometheusExporterMetricsV1",
+                "summary": "Get the Prometheus Metrics",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PrometheusExporterMetricsResponse"
                                 }
                             }
                         }

--- a/packages/cactus-cmd-api-server/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -124,6 +124,42 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * 
+         * @summary Get the Prometheus Metrics
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getPrometheusExporterMetricsV1: async (options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/api-server/get-prometheus-exporter-metrics`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
+                options: localVarRequestOptions,
+            };
+        },
     }
 };
 
@@ -141,6 +177,19 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          */
         async getHealthCheck(options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<HealthCheckResponse>> {
             const localVarAxiosArgs = await DefaultApiAxiosParamCreator(configuration).getHealthCheck(options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {...localVarAxiosArgs.options, url: basePath + localVarAxiosArgs.url};
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         * 
+         * @summary Get the Prometheus Metrics
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getPrometheusExporterMetricsV1(options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await DefaultApiAxiosParamCreator(configuration).getPrometheusExporterMetricsV1(options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {...localVarAxiosArgs.options, url: basePath + localVarAxiosArgs.url};
                 return axios.request(axiosRequestArgs);
@@ -164,6 +213,15 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         getHealthCheck(options?: any): AxiosPromise<HealthCheckResponse> {
             return DefaultApiFp(configuration).getHealthCheck(options).then((request) => request(axios, basePath));
         },
+        /**
+         * 
+         * @summary Get the Prometheus Metrics
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getPrometheusExporterMetricsV1(options?: any): AxiosPromise<string> {
+            return DefaultApiFp(configuration).getPrometheusExporterMetricsV1(options).then((request) => request(axios, basePath));
+        },
     };
 };
 
@@ -183,6 +241,17 @@ export class DefaultApi extends BaseAPI {
      */
     public getHealthCheck(options?: any) {
         return DefaultApiFp(this.configuration).getHealthCheck(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Get the Prometheus Metrics
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public getPrometheusExporterMetricsV1(options?: any) {
+        return DefaultApiFp(this.configuration).getPrometheusExporterMetricsV1(options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/packages/cactus-cmd-api-server/src/main/typescript/prometheus-exporter/data-fetcher.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/prometheus-exporter/data-fetcher.ts
@@ -1,0 +1,12 @@
+import { TotalPluginImports } from "./response.type";
+
+import {
+  totalTxCount,
+  K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS,
+} from "./metrics";
+
+export async function collectMetrics(totalPluginImports: TotalPluginImports) {
+  totalTxCount
+    .labels(K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS)
+    .set(totalPluginImports.counter);
+}

--- a/packages/cactus-cmd-api-server/src/main/typescript/prometheus-exporter/metrics.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/prometheus-exporter/metrics.ts
@@ -1,0 +1,10 @@
+import { Gauge } from "prom-client";
+
+export const K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS =
+  "cactus_api_server_total_plugin_imports";
+
+export const totalTxCount = new Gauge({
+  name: K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS,
+  help: "Total number of plugins imported",
+  labelNames: ["type"],
+});

--- a/packages/cactus-cmd-api-server/src/main/typescript/prometheus-exporter/prometheus-exporter.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/prometheus-exporter/prometheus-exporter.ts
@@ -1,0 +1,38 @@
+import promClient from "prom-client";
+import { TotalPluginImports } from "./response.type";
+import { K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS } from "./metrics";
+import { collectMetrics } from "./data-fetcher";
+
+export interface IPrometheusExporterOptions {
+  pollingIntervalInMin?: number;
+}
+
+export class PrometheusExporter {
+  public readonly metricsPollingIntervalInMin: number;
+  public readonly totalPluginImports: TotalPluginImports = { counter: 0 };
+
+  constructor(
+    public readonly prometheusExporterOptions: IPrometheusExporterOptions,
+  ) {
+    this.metricsPollingIntervalInMin =
+      prometheusExporterOptions.pollingIntervalInMin || 1;
+  }
+
+  public setTotalPluginImports(totalPluginImports: number): void {
+    this.totalPluginImports.counter = totalPluginImports;
+    collectMetrics(this.totalPluginImports);
+  }
+
+  public async getPrometheusMetrics(): Promise<string> {
+    const result = await promClient.register.getSingleMetricAsString(
+      K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS,
+    );
+    return result;
+  }
+
+  public startMetricsCollection(): void {
+    const Registry = promClient.Registry;
+    const register = new Registry();
+    promClient.collectDefaultMetrics({ register });
+  }
+}

--- a/packages/cactus-cmd-api-server/src/main/typescript/prometheus-exporter/response.type.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/prometheus-exporter/response.type.ts
@@ -1,0 +1,3 @@
+export type TotalPluginImports = {
+  counter: number;
+};

--- a/packages/cactus-cmd-api-server/src/test/typescript/integration/runtime-plugin-imports.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/integration/runtime-plugin-imports.test.ts
@@ -1,12 +1,26 @@
 import test, { Test } from "tape-promise/tape";
 import { v4 as uuidv4 } from "uuid";
+import { JWK } from "jose";
 
 import { LogLevelDesc } from "@hyperledger/cactus-common";
 
 import { IPluginKeychainMemoryOptions } from "@hyperledger/cactus-plugin-keychain-memory";
-import { PluginImportType } from "@hyperledger/cactus-core-api";
+
+import {
+  PluginConsortiumManual,
+  IPluginConsortiumManualOptions,
+} from "@hyperledger/cactus-plugin-consortium-manual";
+
+import {
+  PluginImportType,
+  ConsortiumDatabase,
+} from "@hyperledger/cactus-core-api";
 
 import { ApiServer, ConfigService } from "../../../main/typescript/public-api";
+
+import { K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS } from "../../../main/typescript/prometheus-exporter/metrics";
+
+import { DefaultApi as ApiServerApi } from "../../../main/typescript/public-api";
 
 const logLevel: LogLevelDesc = "TRACE";
 
@@ -35,9 +49,93 @@ test("can import plugins at runtime (CLI)", async (t: Test) => {
     config: config.getProperties(),
   });
 
+  const startResponse = apiServer.start();
   await t.doesNotReject(
-    apiServer.start(),
+    startResponse,
     "failed to start API server with dynamic plugin imports configured for it...",
   );
+  t.ok(startResponse, "startResponse truthy OK");
+
+  const addressInfoApi = (await startResponse).addressInfoApi;
+  const protocol = apiServerOptions.apiTlsEnabled ? "https" : "http";
+  const { address, port } = addressInfoApi;
+  const apiHost = `${protocol}://${address}:${port}`;
+  t.comment(
+    `Metrics URL: ${apiHost}/api/v1/api-server/get-prometheus-exporter-metrics`,
+  );
+
+  const apiClient = new ApiServerApi({ basePath: apiHost });
+  apiServer.prometheusExporter.setTotalPluginImports(
+    apiServer.getPluginImportsCount(),
+  );
+
+  {
+    const res = await apiClient.getPrometheusExporterMetricsV1();
+    const promMetricsOutput =
+      "# HELP " +
+      K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS +
+      " Total number of plugins imported\n" +
+      "# TYPE " +
+      K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS +
+      " gauge\n" +
+      K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS +
+      '{type="' +
+      K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS +
+      '"} 1';
+    t.ok(res);
+    t.ok(res.data);
+    t.equal(res.status, 200);
+    t.true(
+      res.data.includes(promMetricsOutput),
+      "Total 1 plugins imported as expected. RESULT OK",
+    );
+  }
+
+  // Adding a new plugin to update the prometheus metric K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS
+  const keyPair = await JWK.generate("EC", "secp256k1", { use: "sig" }, true);
+  const keyPairPem = keyPair.toPEM(true);
+  const db: ConsortiumDatabase = {
+    cactusNode: [],
+    consortium: [],
+    consortiumMember: [],
+    ledger: [],
+    pluginInstance: [],
+  };
+
+  const options: IPluginConsortiumManualOptions = {
+    instanceId: uuidv4(),
+    keyPairPem: keyPairPem,
+    consortiumDatabase: db,
+  };
+
+  const pluginConsortiumManual: PluginConsortiumManual = new PluginConsortiumManual(
+    options,
+  );
+
+  const pluginRegistry = await apiServer.getOrInitPluginRegistry();
+  pluginRegistry.add(pluginConsortiumManual);
+
+  {
+    const res = await apiClient.getPrometheusExporterMetricsV1();
+    const promMetricsOutput =
+      "# HELP " +
+      K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS +
+      " Total number of plugins imported\n" +
+      "# TYPE " +
+      K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS +
+      " gauge\n" +
+      K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS +
+      '{type="' +
+      K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS +
+      '"} 2';
+    t.ok(res);
+    t.ok(res.data);
+    t.equal(res.status, 200);
+    t.true(
+      res.data.includes(promMetricsOutput),
+      "Total 2 plugins imported as expected. RESULT OK",
+    );
+  }
+
   test.onFinish(() => apiServer.shutdown());
 });

--- a/packages/cactus-plugin-consortium-manual/README.md
+++ b/packages/cactus-plugin-consortium-manual/README.md
@@ -22,7 +22,7 @@ Once Prometheus is setup, the corresponding scrape_config needs to be added to t
 ```
 
 Here the `host:port` is where the prometheus exporter metrics are exposed. The test cases (For example, packages/cactus-plugin-consortium-manual/src/test/typescript/unit/consortium/get-node-jws-endpoint-v1.test.ts) exposes it over `0.0.0.0` and a random port(). The random port can be found in the running logs of the test case and looks like (42379 in the below mentioned URL)
-`Metrics URL: http://0.0.0.0:42379/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-fabric/get-prometheus-exporter-metrics`
+`Metrics URL: http://0.0.0.0:42379/api/v1/plugins/@hyperledger/cactus-plugin-consortium-manual/get-prometheus-exporter-metrics`
 
 Once edited, you can start the prometheus service by referencing the above edited prometheus.yml file.
 On the prometheus graphical interface (defaulted to http://localhost:9090), choose **Graph** from the menu bar, then select the **Console** tab. From the **Insert metric at cursor** drop down, select **cactus_consortium_manual_total_node_count** and click **execute**

--- a/packages/cactus-plugin-keychain-memory/README.md
+++ b/packages/cactus-plugin-keychain-memory/README.md
@@ -24,7 +24,7 @@ Once Prometheus is setup, the corresponding scrape_config needs to be added to t
 ```
 
 Here the `host:port` is where the prometheus exporter metrics are exposed. The test cases (For example, packages/cactus-plugin-keychain-memory/src/test/typescript/unit/plugin-keychain-memory.test.ts) exposes it over `0.0.0.0` and a random port(). The random port can be found in the running logs of the test case and looks like (42379 in the below mentioned URL)
-`Metrics URL: http://0.0.0.0:42379/api/v1/plugins/@hyperledger/cactus-plugin-keychain-plugin/get-prometheus-exporter-metrics`
+`Metrics URL: http://0.0.0.0:42379/api/v1/plugins/@hyperledger/cactus-plugin-keychain-memory/get-prometheus-exporter-metrics`
 
 Once edited, you can start the prometheus service by referencing the above edited prometheus.yml file.
 On the prometheus graphical interface (defaulted to http://localhost:9090), choose **Graph** from the menu bar, then select the **Console** tab. From the **Insert metric at cursor** drop down, select **cactus_keychain_memory_total_key_count** and click **execute**


### PR DESCRIPTION
# Commit to be reviewed
---------------------------------

feat(api-server): add prometheus exporter
	
	Primary Change
	--------------

	1. The api-server plugin now includes the prometheus metrics exporter integration
	2. OpenAPI spec now has api endpoint for the getting the prometheus metrics

	Refactorings that were also necessary to accomodate 1) and 2)
	------------------------------------------------------------

	3. GetPrometheusMetricsV1 class is created to handle the corresponding api endpoint
	4. IApiServerConstructorOptions interface in ApiServer class now has a prometheusExporter optional field
	5. The ApiServer class has relevant functions and codes to incorporate prometheus exporter
	6. runtime-plugin-imports.test.ts is changed to incorporate the prometheus exporter
	7. Added Readme.md on the prometheus exporter usage
	8. Fixed Readme.md under keychain-memory and consortium-manual plugins

Resolve #539

Signed-off-by: Jagpreet Singh Sasan <jagpreet.singh.sasan@accenture.com>