### PR TITLE
fix(release): package.json publish config non-public #753

### DIFF
--- a/examples/cactus-example-supply-chain-backend/package.json
+++ b/examples/cactus-example-supply-chain-backend/package.json
@@ -41,6 +41,9 @@
       "runOnChangeOnly": true
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10",
     "npm": ">=6"

--- a/examples/cactus-example-supply-chain-business-logic-plugin/package.json
+++ b/examples/cactus-example-supply-chain-business-logic-plugin/package.json
@@ -42,6 +42,9 @@
       "runOnChangeOnly": true
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10",
     "npm": ">=6"

--- a/examples/cactus-example-supply-chain-frontend/package.json
+++ b/examples/cactus-example-supply-chain-frontend/package.json
@@ -62,7 +62,7 @@
     "typescript": "~3.9.5"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "engines": {
     "node": ">=10",

--- a/packages/cactus-cmd-api-server/package.json
+++ b/packages/cactus-cmd-api-server/package.json
@@ -45,6 +45,9 @@
       "runOnChangeOnly": true
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10",
     "npm": ">=6"

--- a/packages/cactus-cockpit/package.json
+++ b/packages/cactus-cockpit/package.json
@@ -16,6 +16,9 @@
     "prepublishOnly": "ng build --prod"
   },
   "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@angular/common": "11.2.1",
     "@angular/core": "11.2.1",

--- a/packages/cactus-core-api/package.json
+++ b/packages/cactus-core-api/package.json
@@ -42,6 +42,9 @@
       "runOnChangeOnly": true
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10",
     "npm": ">=6"

--- a/packages/cactus-plugin-consortium-manual/package.json
+++ b/packages/cactus-plugin-consortium-manual/package.json
@@ -42,6 +42,9 @@
       "runOnChangeOnly": true
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10",
     "npm": ">=6"


### PR DESCRIPTION
Several packages were missing the publish configuration
from their package.json files which made them private
packages on npm by default.
I fixed the visibility manually via npm GUI but we still need
to update the package.json files to match that in version
control as well so here we go.

Fixes #753

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>