### PR TITLE
feat(core-api): decouple web service install & registration #771

### DIFF
--- a/packages/cactus-cmd-api-server/package-lock.json
+++ b/packages/cactus-cmd-api-server/package-lock.json
@@ -178,6 +178,15 @@
 			"integrity": "sha512-8Ly3zIPTnT0/8RCU6Kg/G3uTICf9sRwYOpUzSIM3503tLIKcnJPRuinHhXngJUy2MntrEf6dlpOHXJju90Qh5w==",
 			"dev": true
 		},
+		"@types/xml2js": {
+			"version": "0.4.8",
+			"resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.8.tgz",
+			"integrity": "sha512-EyvT83ezOdec7BhDaEcsklWy7RSIdi6CNe95tmOAK0yx/Lm30C9K75snT3fYayK59ApC2oyW+rcHErdG05FHJA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"accepts": {
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",

--- a/packages/cactus-cmd-api-server/package.json
+++ b/packages/cactus-cmd-api-server/package.json
@@ -118,6 +118,7 @@
     "@types/node-forge": "0.9.3",
     "@types/npm": "2.0.31",
     "@types/semver": "7.3.1",
-    "@types/uuid": "7.0.2"
+    "@types/uuid": "7.0.2",
+    "@types/xml2js": "0.4.8"
   }
 }

--- a/packages/cactus-core-api/src/main/typescript/plugin/web-service/i-plugin-web-service.ts
+++ b/packages/cactus-core-api/src/main/typescript/plugin/web-service/i-plugin-web-service.ts
@@ -1,11 +1,13 @@
-import { IWebServiceEndpoint } from "./i-web-service-endpoint";
-import { ICactusPlugin } from "../i-cactus-plugin";
 import { Server } from "http";
 import { Server as SecureServer } from "https";
 import { Optional } from "typescript-optional";
+import { Application } from "express";
+import { IWebServiceEndpoint } from "./i-web-service-endpoint";
+import { ICactusPlugin } from "../i-cactus-plugin";
 
 export interface IPluginWebService extends ICactusPlugin {
-  installWebServices(expressApp: any): Promise<IWebServiceEndpoint[]>;
+  getOrCreateWebServices(): Promise<IWebServiceEndpoint[]>;
+  registerWebServices(expressApp: Application): Promise<IWebServiceEndpoint[]>;
   getHttpServer(): Optional<Server | SecureServer>;
   shutdown(): Promise<void>;
 }
@@ -15,7 +17,9 @@ export function isIPluginWebService(
 ): pluginInstance is IPluginWebService {
   return (
     pluginInstance &&
-    typeof (pluginInstance as IPluginWebService).installWebServices ===
+    typeof (pluginInstance as IPluginWebService).registerWebServices ===
+      "function" &&
+    typeof (pluginInstance as IPluginWebService).getOrCreateWebServices ===
       "function" &&
     typeof (pluginInstance as IPluginWebService).getHttpServer === "function" &&
     typeof (pluginInstance as IPluginWebService).getPackageName ===

--- a/packages/cactus-plugin-consortium-manual/src/test/typescript/unit/consortium/get-node-jws-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-consortium-manual/src/test/typescript/unit/consortium/get-node-jws-endpoint-v1.test.ts
@@ -72,7 +72,8 @@ test("Can provide JWS", async (t: Test) => {
   );
   const apiClient = new ConsortiumManualApi({ basePath: apiHost });
 
-  await pluginConsortiumManual.installWebServices(expressApp);
+  await pluginConsortiumManual.getOrCreateWebServices();
+  await pluginConsortiumManual.registerWebServices(expressApp);
 
   const epOpts: IGetNodeJwsEndpointOptions = {
     plugin: pluginConsortiumManual,

--- a/packages/cactus-plugin-keychain-memory/src/main/typescript/plugin-keychain-memory.ts
+++ b/packages/cactus-plugin-keychain-memory/src/main/typescript/plugin-keychain-memory.ts
@@ -77,7 +77,7 @@ export class PluginKeychainMemory {
     return res;
   }
 
-  public async installWebServices(
+  public async getOrCreateWebServices(
     expressApp: Express,
   ): Promise<IWebServiceEndpoint[]> {
     const { log } = this;

--- a/packages/cactus-plugin-keychain-memory/src/test/typescript/unit/plugin-keychain-memory.test.ts
+++ b/packages/cactus-plugin-keychain-memory/src/test/typescript/unit/plugin-keychain-memory.test.ts
@@ -82,7 +82,7 @@ test("PluginKeychainMemory", (t1: Test) => {
     );
     const apiClient = new KeychainMemoryApi({ basePath: apiHost });
 
-    await plugin.installWebServices(expressApp);
+    await plugin.getOrCreateWebServices(expressApp);
 
     t.equal(plugin.getKeychainId(), options.keychainId, "Keychain ID set OK");
     t.equal(plugin.getInstanceId(), options.instanceId, "Instance ID set OK");

--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/plugin-keychain-vault-remote-adapter.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/plugin-keychain-vault-remote-adapter.ts
@@ -1,6 +1,7 @@
 import { Server } from "http";
 import { Server as SecureServer } from "https";
 
+import { Express } from "express";
 import { Optional } from "typescript-optional";
 
 import {
@@ -79,8 +80,13 @@ export class PluginKeychainVaultRemoteAdapter
    *
    * @param _expressApp
    */
-  public async installWebServices(): Promise<IWebServiceEndpoint[]> {
+  public async getOrCreateWebServices(): Promise<IWebServiceEndpoint[]> {
     return [];
+  }
+
+  /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+  public registerWebServices(app: Express): Promise<IWebServiceEndpoint[]> {
+    return this.getOrCreateWebServices();
   }
 
   public getHttpServer(): Optional<Server | SecureServer> {

--- a/packages/cactus-plugin-keychain-vault/src/test/typescript/integration/plugin-keychain-vault.test.ts
+++ b/packages/cactus-plugin-keychain-vault/src/test/typescript/integration/plugin-keychain-vault.test.ts
@@ -77,7 +77,8 @@ test("get,set,has,delete alters state as expected", async (t: Test) => {
   );
   const apiClient = new KeychainVaultApi({ basePath: apiHost });
 
-  await plugin.installWebServices(expressApp);
+  await plugin.getOrCreateWebServices();
+  await plugin.registerWebServices(expressApp);
 
   t.equal(plugin.getKeychainId(), options.keychainId, "Keychain ID set OK");
   t.equal(plugin.getInstanceId(), options.instanceId, "Instance ID set OK");

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/plugin-ledger-connector-besu.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/plugin-ledger-connector-besu.ts
@@ -97,6 +97,7 @@ export class PluginLedgerConnectorBesu
     [name: string]: Contract;
   } = {};
 
+  private endpoints: IWebServiceEndpoint[] | undefined;
   private httpServer: Server | SecureServer | null = null;
   private contractsPath?: string;
   public static readonly CLASS_NAME = "PluginLedgerConnectorBesu";
@@ -160,16 +161,23 @@ export class PluginLedgerConnectorBesu
     }
   }
 
-  public async installWebServices(
-    expressApp: Express,
-  ): Promise<IWebServiceEndpoint[]> {
+  async registerWebServices(app: Express): Promise<IWebServiceEndpoint[]> {
+    const webServices = await this.getOrCreateWebServices();
+    webServices.forEach((ws) => ws.registerExpress(app));
+    return webServices;
+  }
+
+  public async getOrCreateWebServices(): Promise<IWebServiceEndpoint[]> {
+    if (Array.isArray(this.endpoints)) {
+      return this.endpoints;
+    }
+
     const endpoints: IWebServiceEndpoint[] = [];
     {
       const endpoint = new DeployContractSolidityBytecodeEndpoint({
         connector: this,
         logLevel: this.options.logLevel,
       });
-      endpoint.registerExpress(expressApp);
       endpoints.push(endpoint);
     }
     {
@@ -177,7 +185,6 @@ export class PluginLedgerConnectorBesu
         connector: this,
         logLevel: this.options.logLevel,
       });
-      endpoint.registerExpress(expressApp);
       endpoints.push(endpoint);
     }
     {
@@ -185,7 +192,6 @@ export class PluginLedgerConnectorBesu
         connector: this,
         logLevel: this.options.logLevel,
       });
-      endpoint.registerExpress(expressApp);
       endpoints.push(endpoint);
     }
     {
@@ -193,7 +199,6 @@ export class PluginLedgerConnectorBesu
         connector: this,
         logLevel: this.options.logLevel,
       });
-      endpoint.registerExpress(expressApp);
       endpoints.push(endpoint);
     }
     {
@@ -201,7 +206,6 @@ export class PluginLedgerConnectorBesu
         connector: this,
         logLevel: this.options.logLevel,
       });
-      endpoint.registerExpress(expressApp);
       endpoints.push(endpoint);
     }
     {
@@ -210,9 +214,9 @@ export class PluginLedgerConnectorBesu
         logLevel: this.options.logLevel,
       };
       const endpoint = new GetPrometheusExporterMetricsEndpointV1(opts);
-      endpoint.registerExpress(expressApp);
       endpoints.push(endpoint);
     }
+    this.endpoints = endpoints;
     return endpoints;
   }
 

--- a/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/deploy-contract-from-json.test.ts
@@ -102,7 +102,8 @@ test(testCase, async (t: Test) => {
   );
   const apiClient = new BesuApi({ basePath: apiHost });
 
-  await connector.installWebServices(expressApp);
+  await connector.getOrCreateWebServices();
+  await connector.registerWebServices(expressApp);
 
   await connector.transact({
     web3SigningCredential: {

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/deploy-contract-go-bin-endpoint-v1/deploy-contract/deploy-cc-from-golang-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/deploy-contract-go-bin-endpoint-v1/deploy-contract/deploy-cc-from-golang-source.test.ts
@@ -147,7 +147,8 @@ test(testCase, async (t: Test) => {
   const { port } = addressInfo;
   test.onFinish(async () => await Servers.shutdown(server));
 
-  await plugin.installWebServices(expressApp);
+  await plugin.getOrCreateWebServices();
+  await plugin.registerWebServices(expressApp);
   const apiUrl = `http://localhost:${port}`;
 
   const apiClient = new FabricApi({ basePath: apiUrl });

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts
@@ -132,7 +132,8 @@ test(testCase, async (t: Test) => {
   );
   const apiClient = new FabricApi({ basePath: apiHost });
 
-  await plugin.installWebServices(expressApp);
+  await plugin.getOrCreateWebServices();
+  await plugin.registerWebServices(expressApp);
 
   const carId = "CAR277";
   const carOwner = uuidv4();

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
@@ -136,7 +136,8 @@ test(testCase, async (t: Test) => {
   );
   const apiClient = new FabricApi({ basePath: apiHost });
 
-  await plugin.installWebServices(expressApp);
+  await plugin.getOrCreateWebServices();
+  await plugin.registerWebServices(expressApp);
 
   const assetId = "asset277";
   const assetOwner = uuidv4();

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/plugin-ledger-connector-quorum.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/plugin-ledger-connector-quorum.ts
@@ -89,6 +89,7 @@ export class PluginLedgerConnectorQuorum
     [name: string]: Contract;
   } = {};
 
+  private endpoints: IWebServiceEndpoint[] | undefined;
   public static readonly CLASS_NAME = "PluginLedgerConnectorQuorum";
 
   public get className(): string {
@@ -151,16 +152,22 @@ export class PluginLedgerConnectorQuorum
     }
   }
 
-  public async installWebServices(
-    expressApp: Express,
-  ): Promise<IWebServiceEndpoint[]> {
+  async registerWebServices(app: Express): Promise<IWebServiceEndpoint[]> {
+    const webServices = await this.getOrCreateWebServices();
+    webServices.forEach((ws) => ws.registerExpress(app));
+    return webServices;
+  }
+
+  public async getOrCreateWebServices(): Promise<IWebServiceEndpoint[]> {
+    if (Array.isArray(this.endpoints)) {
+      return this.endpoints;
+    }
     const endpoints: IWebServiceEndpoint[] = [];
     {
       const endpoint = new DeployContractSolidityBytecodeEndpoint({
         connector: this,
         logLevel: this.options.logLevel,
       });
-      endpoint.registerExpress(expressApp);
       endpoints.push(endpoint);
     }
     {
@@ -168,7 +175,6 @@ export class PluginLedgerConnectorQuorum
         connector: this,
         logLevel: this.options.logLevel,
       });
-      endpoint.registerExpress(expressApp);
       endpoints.push(endpoint);
     }
     {
@@ -176,7 +182,6 @@ export class PluginLedgerConnectorQuorum
         connector: this,
         logLevel: this.options.logLevel,
       });
-      endpoint.registerExpress(expressApp);
       endpoints.push(endpoint);
     }
     {
@@ -184,7 +189,6 @@ export class PluginLedgerConnectorQuorum
         connector: this,
         logLevel: this.options.logLevel,
       });
-      endpoint.registerExpress(expressApp);
       endpoints.push(endpoint);
     }
     {
@@ -193,9 +197,9 @@ export class PluginLedgerConnectorQuorum
         logLevel: this.options.logLevel,
       };
       const endpoint = new GetPrometheusExporterMetricsEndpointV1(opts);
-      endpoint.registerExpress(expressApp);
       endpoints.push(endpoint);
     }
+    this.endpoints = endpoints;
     return endpoints;
   }
 

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/deploy-contract-from-json.test.ts
@@ -110,7 +110,8 @@ test(testCase, async (t: Test) => {
   );
   const apiClient = new QuorumApi({ basePath: apiHost });
 
-  await connector.installWebServices(expressApp);
+  await connector.getOrCreateWebServices();
+  await connector.registerWebServices(expressApp);
 
   await connector.transact({
     web3SigningCredential: {


### PR DESCRIPTION
Primary change:
==============

Divide the endpoint installation method into two smaller
ones where the first one only instantiates the endpoints
and the other one "registers" them as-in it hooks the
endpoint up onto the ExpressJS web app object so that
it will actually be responded to as HTTP requests come
in.

Why though?
We'll need this for the authorization MVP which will
need to be able to introspect the endpoints **prior**
to them getting registered so that it can determine
authz specific parameters like "is this endpoint
secured or non-secure?" or what scopes are necessary
for this endpoint? Etc.

Additional changes:
==================

Everything else that was needed to make the project
compile again and the tests passnig (which is a lot
because this is a very central, heavily used
interface that we just modified).

Fixes #771

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>