### PR TITLE
fix(lint) escaping double quotes to prevent error on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start:cockpit": "lerna run --scope '*/cactus-cockpit' --stream serve:proxy",
     "start:example-supply-chain": "cd ./examples/supply-chain-app/ && npm i --no-package-lock && npm run start",
     "clean": "del-cli \"./packages/cactus-*/{dist,.nyc_output,src/main/typescript/generated/openapi/typescript-axios/*}\"",
-    "lint": "eslint '*/*/src/**/*.{js,ts}' --quiet --fix",
+    "lint": "eslint \"*/*/src/**/*.{js,ts}\" --quiet --fix",
     "tsc": "lerna run tsc",
     "watch": "lerna run --parallel watch",
     "build": "npm-run-all build:dev build:prod",


### PR DESCRIPTION
Primary Change:

- Small change in package.json to fix errors when the ESLint script gets ran.

Resolve #775 