### PR TITLE
refactor(tools): clean up CircleCI guard code in ci.sh

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -34,15 +34,6 @@ function mainTask()
     smem --abbreviate --totals --system || true
   fi
 
-  # Travis does not have (nor need) nvm but CircleCI does have nvm and also
-  # need it big time because their default Node version is 6.x...
-  if [ "${CIRCLECI:-false}" = "true" ]; then
-    set +x
-    nvm install 10.19.0
-    nvm alias default 10.19.0
-    set -x
-  fi
-
   docker --version
   docker-compose --version
   node --version


### PR DESCRIPTION
We'll likely continue using GitHub Actions for CI so the CircleCI specific
guard rails shouldn't be littering the ci.sh script to make it easier
to understand for newcomers.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>