### PR TITLE
fix(tools): ci.sh retry mechanism no longer ignores last failure

### DIFF
--- a/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
+++ b/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
@@ -277,6 +277,7 @@ export class SupplyChainApp {
       discoveryOptions,
       eventHandlerOptions: {
         strategy: DefaultEventHandlerStrategy.NETWORKSCOPEALLFORTX,
+        commitTimeout: 300,
       },
     });
 

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/deploy-contract-go-bin-endpoint-v1/deploy-contract/deploy-cc-from-golang-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/deploy-contract-go-bin-endpoint-v1/deploy-contract/deploy-cc-from-golang-source.test.ts
@@ -131,6 +131,7 @@ test(testCase, async (t: Test) => {
     discoveryOptions,
     eventHandlerOptions: {
       strategy: DefaultEventHandlerStrategy.NETWORKSCOPEALLFORTX,
+      commitTimeout: 300,
     },
   };
   const plugin = new PluginLedgerConnectorFabric(pluginOptions);

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts
@@ -111,6 +111,7 @@ test(testCase, async (t: Test) => {
     discoveryOptions,
     eventHandlerOptions: {
       strategy: DefaultEventHandlerStrategy.NETWORKSCOPEALLFORTX,
+      commitTimeout: 300,
     },
   };
   const plugin = new PluginLedgerConnectorFabric(pluginOptions);

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
@@ -115,6 +115,7 @@ test(testCase, async (t: Test) => {
     discoveryOptions,
     eventHandlerOptions: {
       strategy: DefaultEventHandlerStrategy.NETWORKSCOPEALLFORTX,
+      commitTimeout: 300,
     },
   };
   const plugin = new PluginLedgerConnectorFabric(pluginOptions);

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -70,8 +70,11 @@ function mainTask()
     npm run test:all -- --bail && echo "$(date +%FT%T%z) [CI] Second (#2) try of tests succeeded OK."
   } ||
   {
+    # If the third try fails then the execution will reach the last echo and the exit 1 statement
+    # ensuring that the script crashes if 3 out of 3 test runs have failed.
     echo "$(date +%FT%T%z) [CI] Second (#2) try of tests failed starting third and last try now..."
-    npm run test:all -- --bail && echo "$(date +%FT%T%z) [CI] Third (#3) try of tests succeeded OK."
+    npm run test:all -- --bail && echo "$(date +%FT%T%z) [CI] Third (#3) try of tests succeeded OK." || \
+      echo "$(date +%FT%T%z) [CI] Third (#3) try of tests failed so giving up at this point" ; exit 1
   }
 
   # The webpack production build needs more memory than the default allocation


### PR DESCRIPTION
/facepalm

Since this retry mechanism was introduced test failures
were being ignord by the CI and this will now rectify that
issue which might also start up our CI stability issues
again, but it is what it is. Had to be done.


Depends on #792

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>