### PR TITLE
feat(cmd-api-server): user defined type guard isHealthcheckResponse

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/model/is-healthcheck-response-type-guard.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/model/is-healthcheck-response-type-guard.ts
@@ -1,0 +1,16 @@
+import { Bools } from "@hyperledger/cactus-common";
+import { HealthCheckResponse } from "../generated/openapi/typescript-axios/api";
+
+export function isHealthcheckResponse(x: unknown): x is HealthCheckResponse {
+  return (
+    !!x &&
+    typeof x === "object" &&
+    Bools.isBooleanStrict((x as HealthCheckResponse).success) &&
+    typeof (x as HealthCheckResponse).memoryUsage === "object" &&
+    typeof (x as HealthCheckResponse).memoryUsage.rss === "number" &&
+    typeof (x as HealthCheckResponse).memoryUsage.heapTotal === "number" &&
+    typeof (x as HealthCheckResponse).memoryUsage.heapUsed === "number" &&
+    typeof (x as HealthCheckResponse).memoryUsage.external === "number" &&
+    typeof (x as HealthCheckResponse).createdAt === "string"
+  );
+}

--- a/packages/cactus-cmd-api-server/src/main/typescript/public-api.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/public-api.ts
@@ -17,3 +17,5 @@ export {
 } from "./config/self-signed-pki-generator";
 
 export * from "./generated/openapi/typescript-axios/index";
+
+export { isHealthcheckResponse } from "./model/is-healthcheck-response-type-guard";


### PR DESCRIPTION
Useful for validating if an untyped object has the
API surface of a HealthCheckResponse as defined
in the OpenAPI specs of the API server.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>