### PR TITLE
feat(core): add plugin registry log level constructor arg

### DIFF
--- a/packages/cactus-core/src/main/typescript/plugin-registry.ts
+++ b/packages/cactus-core/src/main/typescript/plugin-registry.ts
@@ -1,5 +1,10 @@
 import { Optional } from "typescript-optional";
 import {
+  Logger,
+  LoggerProvider,
+  LogLevelDesc,
+} from "@hyperledger/cactus-common";
+import {
   ICactusPlugin,
   IPluginKeychain,
   isICactusPlugin,
@@ -11,6 +16,7 @@ import {
  * the `PluginRegistry` class instances.
  */
 export interface IPluginRegistryOptions {
+  logLevel?: LogLevelDesc;
   plugins?: ICactusPlugin[];
 }
 
@@ -23,7 +29,13 @@ export interface IPluginRegistryOptions {
  * classes in place of the interfaces currently describing the plugin architecture.
  */
 export class PluginRegistry {
+  public static readonly CLASS_NAME = "PluginRegistry";
   public readonly plugins: ICactusPlugin[];
+  public readonly log: Logger;
+
+  public get className(): string {
+    return PluginRegistry.CLASS_NAME;
+  }
 
   constructor(public readonly options: IPluginRegistryOptions = {}) {
     const fnTag = `PluginRegistry#constructor()`;
@@ -34,6 +46,11 @@ export class PluginRegistry {
       throw new TypeError(`${fnTag} options.plugins truthy but non-Array`);
     }
     this.plugins = options.plugins || [];
+
+    const level = this.options.logLevel || "INFO";
+    const label = this.className;
+    this.log = LoggerProvider.getOrCreate({ level, label });
+    this.log.debug(`Instantiated ${this.className} OK`);
   }
 
   public getPlugins(): ICactusPlugin[] {


### PR DESCRIPTION
Very minor improvement that makes it possible for the
plugin registry to have an injectable log level for its
logger (most classes already have this in the codebase
but it was forgotten here).

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>