### PR TITLE
refactor(tools): reduce SSHd log level in Fabric All In One image

### DIFF
--- a/tools/docker/fabric-all-in-one/supervisord.conf
+++ b/tools/docker/fabric-all-in-one/supervisord.conf
@@ -5,7 +5,7 @@ logfile_backups=10
 loglevel = debug
 
 [program:sshd]
-command=/usr/sbin/sshd -D -dd
+command=/usr/sbin/sshd -D
 autostart=true
 autorestart=true
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
The extra verbose logs of the SSH daemon were useful when
debugging issues with SSHd itself but it has been stabilized
and so it is no longer helpful but rather just makes debugging other
issues harder with the spammy logs it produces so it seemed like
it was time to drop the log levels a bit. It can always be added back
later if further issues are encountered with SSHd in the container.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>