### PR TITLE
fix(tools): use latest fabric bootstrap.sh script for AIO image

### DIFF
--- a/tools/docker/fabric-all-in-one/Dockerfile_v1.4.x
+++ b/tools/docker/fabric-all-in-one/Dockerfile_v1.4.x
@@ -84,7 +84,7 @@ RUN cp $CACTUS_CFG_PATH/fabric-aio-image.pub ~/.ssh/authorized_keys
 # flag to avoid pulling docker images because during the build phase of this image
 # there is no docker daemon running yet so this has to happen in the CMD once a
 # container has been started from the image => see ./run-fabric-network-sh
-RUN curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/release-2.2/scripts/bootstrap.sh > /bootstrap.sh
+RUN curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/54e27a66812845985c5c067d7f5244a05c6e719b/scripts/bootstrap.sh > /bootstrap.sh
 RUN chmod +x bootstrap.sh
 # Run the bootstrap here so that at least we can pre-fetch the git clone and the binary downloads resulting in
 # faster container startup speed since these steps will not have to be done, only the docker image pulls.
@@ -98,7 +98,7 @@ COPY supervisord.conf /etc/supervisord.conf
 COPY run-fabric-network.sh /
 COPY healthcheck.sh /
 
-# OpenSSH Server (needed for chaincode deployment ) 
+# OpenSSH Server (needed for chaincode deployment )
 EXPOSE 22
 
 # supervisord web ui/dashboard

--- a/tools/docker/fabric-all-in-one/Dockerfile_v2.x
+++ b/tools/docker/fabric-all-in-one/Dockerfile_v2.x
@@ -142,7 +142,7 @@ RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/ hyperledger/fabric-ca:
 # Download and execute the Fabric bootstrap script, but instruct it with the -d
 # flag to avoid pulling docker images because during the build phase of this image
 # there is no docker daemon running yet
-RUN curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/2f69b4222e9c9090b5c1ca235c1b59687566f13e/scripts/bootstrap.sh > /bootstrap.sh
+RUN curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/54e27a66812845985c5c067d7f5244a05c6e719b/scripts/bootstrap.sh > /bootstrap.sh
 RUN chmod +x bootstrap.sh
 # Run the bootstrap here so that at least we can pre-fetch the git clone and the binary downloads resulting in
 # faster container startup speed since these steps will not have to be done, only the docker image pulls.


### PR DESCRIPTION
Fabric appears to have embraced inclusive naming for their branches and
deleted the previous default branch of theirs which all the older revisions
of their bootstrap.sh script is pointing to by way of attempint to check that
branch out.
This broke our containers at runtime because the old bootstrap scripts are
now crashing due to the non-existent branch.
Updated both the 1.4.x and the 2.x dockerfiles to use the current latest
bootstrap.sh script instead in order to alleviate the problem.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>