### PR TITLE
test(connector-fabric): explicitly specify commit timeout

### DIFF
--- a/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
+++ b/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
@@ -277,6 +277,7 @@ export class SupplyChainApp {
       discoveryOptions,
       eventHandlerOptions: {
         strategy: DefaultEventHandlerStrategy.NETWORKSCOPEALLFORTX,
+        commitTimeout: 300,
       },
     });
 

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/deploy-contract-go-bin-endpoint-v1/deploy-contract/deploy-cc-from-golang-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/deploy-contract-go-bin-endpoint-v1/deploy-contract/deploy-cc-from-golang-source.test.ts
@@ -131,6 +131,7 @@ test(testCase, async (t: Test) => {
     discoveryOptions,
     eventHandlerOptions: {
       strategy: DefaultEventHandlerStrategy.NETWORKSCOPEALLFORTX,
+      commitTimeout: 300,
     },
   };
   const plugin = new PluginLedgerConnectorFabric(pluginOptions);

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts
@@ -111,6 +111,7 @@ test(testCase, async (t: Test) => {
     discoveryOptions,
     eventHandlerOptions: {
       strategy: DefaultEventHandlerStrategy.NETWORKSCOPEALLFORTX,
+      commitTimeout: 300,
     },
   };
   const plugin = new PluginLedgerConnectorFabric(pluginOptions);

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
@@ -115,6 +115,7 @@ test(testCase, async (t: Test) => {
     discoveryOptions,
     eventHandlerOptions: {
       strategy: DefaultEventHandlerStrategy.NETWORKSCOPEALLFORTX,
+      commitTimeout: 300,
     },
   };
   const plugin = new PluginLedgerConnectorFabric(pluginOptions);


### PR DESCRIPTION
Without the commit timeout explicitly being specified, it
defaults to 10 seconds which is not enough for commits that
are initial ones for a chaincode because in that edge case
the chaincode gets deployed to the rest of the peers as part
of the execution of that initial transaction and this takes
longer than 10 seconds on average even on relatively strong
hardware.
The trick was figuring out that the documented default timeout
is 300 seconds but in practice it ends up somehow being 10
instead. Once the explicit timeout is specified in the connector
parameters (constructor args) the test appears to be passing.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>