### PR TITLE
fix(cmd-api-server): no CLI args causes crash #794

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/cmd/cactus-api.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/cmd/cactus-api.ts
@@ -16,7 +16,7 @@ const main = async () => {
 
   LoggerProvider.setLogLevel(serverOptions.logLevel);
 
-  if (process.argv[2].includes("help")) {
+  if (process.argv[2]?.includes("help")) {
     const helpText = ConfigService.getHelpText();
     console.log(helpText);
     log.info(`Effective Configuration:`);


### PR DESCRIPTION
Guard against examinig the help command's presence if there's no
CLI arguments specified at all.

Fixes #794

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>