### PR TITLE
refactor(cmd-api-server): cockpit to be dev dependency only

### DIFF
--- a/packages/cactus-cmd-api-server/package.json
+++ b/packages/cactus-cmd-api-server/package.json
@@ -86,7 +86,6 @@
   },
   "homepage": "https://github.com/hyperledger/cactus#readme",
   "dependencies": {
-    "@hyperledger/cactus-cockpit": "0.4.1",
     "@hyperledger/cactus-common": "0.4.0",
     "@hyperledger/cactus-core": "0.4.1",
     "@hyperledger/cactus-core-api": "0.4.1",
@@ -107,6 +106,7 @@
     "uuid": "7.0.2"
   },
   "devDependencies": {
+    "@hyperledger/cactus-cockpit": "0.4.1",
     "@hyperledger/cactus-plugin-keychain-vault": "0.4.1",
     "@hyperledger/cactus-test-tooling": "0.4.0",
     "@types/compression": "1.7.0",


### PR DESCRIPTION
For a production API server deployment where the testing GUI is not
needed we do not need to ship the package with all the baggage
(transitive dependencies) that the cockpit
package brings with it (UI frameworks)

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>