### PR TITLE
fix(examples): supply chain backend bundle build RAM #766

### DIFF
--- a/examples/cactus-example-supply-chain-backend/package.json
+++ b/examples/cactus-example-supply-chain-backend/package.json
@@ -19,9 +19,9 @@
     "webpack:dev": "npm-run-all webpack:dev:node webpack:dev:web",
     "webpack:dev:web": "webpack --env=dev --target=web --config ../../webpack.config.js",
     "webpack:dev:node": "webpack --env=dev --target=node --config ../../webpack.config.js",
-    "webpack:prod": "npm-run-all webpack:prod:node webpack:prod:web",
-    "webpack:prod:web": "webpack --env=prod --target=web --config ../../webpack.config.js",
-    "webpack:prod:node": "webpack --env=prod --target=node --config ../../webpack.config.js"
+    "webpack:prod": "NODE_OPTIONS=--max_old_space_size=4096 npm-run-all webpack:prod:node webpack:prod:web",
+    "webpack:prod:web": "NODE_OPTIONS=--max_old_space_size=4096 webpack --env=prod --target=web --config ../../webpack.config.js",
+    "webpack:prod:node": "NODE_OPTIONS=--max_old_space_size=4096 webpack --env=prod --target=node --config ../../webpack.config.js"
   },
   "watch": {
     "tsc": {


### PR DESCRIPTION
Increase the RAM to 4 GB for the webpack bundling process
so that it has enough to work with instead
of crashing.

Fixes #766

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>