### PR TITLE
refactor(connector-fabric): deploy go contract response

### DIFF
--- a/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
+++ b/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
@@ -277,6 +277,7 @@ export class SupplyChainApp {
       discoveryOptions,
       eventHandlerOptions: {
         strategy: DefaultEventHandlerStrategy.NETWORKSCOPEALLFORTX,
+        commitTimeout: 300,
       },
     });
 

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/json/openapi.json
@@ -377,7 +377,7 @@
                     },
                     "targetPeerAddresses": {
                         "type": "array",
-                        "description": "An array of peer addresses where the contract will be instantiated.",
+                        "description": "An array of peer addresses where the contract will be instantiated. Note that at present only the first item from this array will be used which is the behavior taken from the offical Fabric samples repository and therefore it is assumed to be correct usage.",
                         "example": [
                             "peer0.org1.example.com:7051"
                         ],
@@ -448,15 +448,18 @@
                 "type": "object",
                 "required": [
                     "success",
-                    "installationCommandResponse",
+                    "installationCommandResponses",
                     "instantiationCommandResponse"
                 ],
                 "properties": {
                     "success": {
                         "type": "boolean"
                     },
-                    "installationCommandResponse": {
-                        "$ref": "#/components/schemas/SSHExecCommandResponse"
+                    "installationCommandResponses": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SSHExecCommandResponse"
+                        }
                     },
                     "instantiationCommandResponse": {
                         "$ref": "#/components/schemas/SSHExecCommandResponse"

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -144,7 +144,7 @@ export interface DeployContractGoSourceV1Request {
      */
     targetOrganizations: Array<DeploymentTargetOrganization>;
     /**
-     * An array of peer addresses where the contract will be instantiated.
+     * An array of peer addresses where the contract will be instantiated. Note that at present only the first item from this array will be used which is the behavior taken from the offical Fabric samples repository and therefore it is assumed to be correct usage.
      * @type {Array<string>}
      * @memberof DeployContractGoSourceV1Request
      */
@@ -219,10 +219,10 @@ export interface DeployContractGoSourceV1Response {
     success: boolean;
     /**
      * 
-     * @type {SSHExecCommandResponse}
+     * @type {Array<SSHExecCommandResponse>}
      * @memberof DeployContractGoSourceV1Response
      */
-    installationCommandResponse: SSHExecCommandResponse;
+    installationCommandResponses: Array<SSHExecCommandResponse>;
     /**
      * 
      * @type {SSHExecCommandResponse}

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/deploy-contract-go-bin-endpoint-v1/deploy-contract/deploy-cc-from-golang-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/deploy-contract-go-bin-endpoint-v1/deploy-contract/deploy-cc-from-golang-source.test.ts
@@ -23,6 +23,7 @@ import {
   DefaultEventHandlerStrategy,
   FabricContractInvocationType,
   PluginLedgerConnectorFabric,
+  SSHExecCommandResponse,
 } from "../../../../../main/typescript/public-api";
 
 import { HELLO_WORLD_CONTRACT_GO_SOURCE } from "../../../fixtures/go/hello-world-contract-fabric-v14/hello-world-contract-go-source";
@@ -171,18 +172,21 @@ test(testCase, async (t: Test) => {
   });
 
   const {
-    installationCommandResponse,
-    instantiationCommandResponse,
+    installationCommandResponses: installations,
+    instantiationCommandResponse: instantiation,
     success,
   } = res.data;
 
-  t.comment(`CC installation out: ${installationCommandResponse.stdout}`);
-  t.comment(`CC installation err: ${installationCommandResponse.stderr}`);
-  t.comment(`CC instantiation out: ${instantiationCommandResponse.stdout}`);
-  t.comment(`CC instantiation err: ${instantiationCommandResponse.stderr}`);
+  installations.forEach((icr: SSHExecCommandResponse, idx: number) => {
+    t.comment(`CC installation ${idx} out: ${icr.stdout}`);
+    t.comment(`CC installation ${idx} err: ${icr.stderr}`);
+  });
 
-  t.equal(res.status, 200, "res.status === 200 OK");
-  t.true(success, "res.data.success === true");
+  t.comment(`CC instantiation out: ${instantiation.stdout}`);
+  t.comment(`CC instantiation err: ${instantiation.stderr}`);
+
+  t.equal(res.status, 200, "deployContractGoSourceV1 res.status === 200 OK");
+  t.true(success, "deployContractGoSourceV1 res.data.success === true");
 
   // FIXME - without this wait it randomly fails with an error claiming that
   // the endorsment was impossible to be obtained. The fabric-samples script

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/deploy-contract-go-bin-endpoint-v1/deploy-contract/deploy-cc-from-golang-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/deploy-contract-go-bin-endpoint-v1/deploy-contract/deploy-cc-from-golang-source.test.ts
@@ -131,6 +131,7 @@ test(testCase, async (t: Test) => {
     discoveryOptions,
     eventHandlerOptions: {
       strategy: DefaultEventHandlerStrategy.NETWORKSCOPEALLFORTX,
+      commitTimeout: 300,
     },
   };
   const plugin = new PluginLedgerConnectorFabric(pluginOptions);

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts
@@ -111,6 +111,7 @@ test(testCase, async (t: Test) => {
     discoveryOptions,
     eventHandlerOptions: {
       strategy: DefaultEventHandlerStrategy.NETWORKSCOPEALLFORTX,
+      commitTimeout: 300,
     },
   };
   const plugin = new PluginLedgerConnectorFabric(pluginOptions);

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
@@ -115,6 +115,7 @@ test(testCase, async (t: Test) => {
     discoveryOptions,
     eventHandlerOptions: {
       strategy: DefaultEventHandlerStrategy.NETWORKSCOPEALLFORTX,
+      commitTimeout: 300,
     },
   };
   const plugin = new PluginLedgerConnectorFabric(pluginOptions);


### PR DESCRIPTION
## Dependencies

Depends on #792 

## Commit to be reviewed:

Author: Peter Somogyvari <peter.somogyvari@accenture.com>
Committer: Peter Somogyvari <peter.somogyvari@accenture.com>
Date: 2021-04-14 09:23:28 -0700 

refactor(connector-fabric): deploy go contract response

Include the complete set of SSH command outputs.
Helps with debugging in case a contract deployment goes awry.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>