### PR TITLE
feat(core-api): hasTransactionFinality() on connector API

### DIFF
--- a/packages/cactus-cmd-api-server/src/test/typescript/fixtures/plugin-ledger-connector-stub/plugin-ledger-connector-stub.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/fixtures/plugin-ledger-connector-stub/plugin-ledger-connector-stub.ts
@@ -14,7 +14,10 @@ import {
   ICactusPluginOptions,
 } from "@hyperledger/cactus-core-api";
 
-import { PluginRegistry } from "@hyperledger/cactus-core";
+import {
+  PluginRegistry,
+  consensusHasTransactionFinality,
+} from "@hyperledger/cactus-core";
 
 import {
   Checks,
@@ -128,7 +131,11 @@ export class PluginLedgerConnectorStub
   > {
     return ConsensusAlgorithmFamily.AUTHORITY;
   }
+  public async hasTransactionFinality(): Promise<boolean> {
+    const currentConsensusAlgorithmFamily = await this.getConsensusAlgorithmFamily();
 
+    return consensusHasTransactionFinality(currentConsensusAlgorithmFamily);
+  }
   public async transact(req: unknown): Promise<unknown> {
     const fnTag = `${this.className}#transact()`;
     Checks.truthy(req, `${fnTag} req`);

--- a/packages/cactus-core-api/src/main/json/openapi.json
+++ b/packages/cactus-core-api/src/main/json/openapi.json
@@ -68,6 +68,24 @@
                     "org.hyperledger.cactus.consensusalgorithm.PROOF_OF_WORK"
                 ]
             },
+            "ConsensusAlgorithmFamiliesWithTxFinality":{
+                "type": "string",
+                "description": "Enumerates a list of consensus algorithm families that provide immediate finality",
+                "enum": [
+                    "org.hyperledger.cactus.consensusalgorithm.PROOF_OF_AUTHORITY",
+                    "org.hyperledger.cactus.consensusalgorithm.PROOF_OF_STAKE"
+                ]
+
+            },
+            "ConsensusAlgorithmFamiliesWithOutTxFinality":{
+                "description":"Enumerates a list of consensus algorithm families that do not provide immediate finality",
+                "type": "string",
+                "enum": [
+                    "org.hyperledger.cactus.consensusalgorithm.PROOF_OF_WORK"
+                ],
+                "x-enum-varnames": ["WORK"]
+
+            },
             "PrimaryKey": {
                 "type": "string",
                 "minLength": 1,

--- a/packages/cactus-core-api/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-core-api/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -125,6 +125,25 @@ export interface CactusNodeMeta {
     publicKeyPem: string;
 }
 /**
+ * Enumerates a list of consensus algorithm families that do not provide immediate finality
+ * @export
+ * @enum {string}
+ */
+export enum ConsensusAlgorithmFamiliesWithOutTxFinality {
+    WORK = 'org.hyperledger.cactus.consensusalgorithm.PROOF_OF_WORK'
+}
+
+/**
+ * Enumerates a list of consensus algorithm families that provide immediate finality
+ * @export
+ * @enum {string}
+ */
+export enum ConsensusAlgorithmFamiliesWithTxFinality {
+    AUTHORITY = 'org.hyperledger.cactus.consensusalgorithm.PROOF_OF_AUTHORITY',
+    STAKE = 'org.hyperledger.cactus.consensusalgorithm.PROOF_OF_STAKE'
+}
+
+/**
  * Enumerates a list of consensus algorithm families in existence. Does not intend to be an exhaustive list, just a practical one, meaning that we only include items here that are relevant to Hyperledger Cactus in fulfilling its own duties. This can be extended later as more sophisticated features of Cactus get implemented. This enum is meant to be first and foremest a useful abstraction for achieving practical tasks, not an encyclopedia and therefore we ask of everyone that this to be extended only in ways that serve a practical purpose for the runtime behavior of Cactus or Cactus plugins in general. The bottom line is that we can accept this enum being not 100% accurate as long as it 100% satisfies what it was designed to do.
  * @export
  * @enum {string}

--- a/packages/cactus-core-api/src/main/typescript/plugin/ledger-connector/i-plugin-ledger-connector.ts
+++ b/packages/cactus-core-api/src/main/typescript/plugin/ledger-connector/i-plugin-ledger-connector.ts
@@ -30,4 +30,5 @@ export interface IPluginLedgerConnector<
    * @see {ConsensusAlgorithmFamily}
    */
   getConsensusAlgorithmFamily(): Promise<ConsensusAlgorithmFamily>;
+  hasTransactionFinality(): Promise<boolean>;
 }

--- a/packages/cactus-core/src/main/typescript/consensus-has-transaction-finality.ts
+++ b/packages/cactus-core/src/main/typescript/consensus-has-transaction-finality.ts
@@ -1,0 +1,28 @@
+import {
+  ConsensusAlgorithmFamily,
+  ConsensusAlgorithmFamiliesWithTxFinality,
+  ConsensusAlgorithmFamiliesWithOutTxFinality,
+} from "@hyperledger/cactus-core-api";
+
+export function consensusHasTransactionFinality(
+  consensusAlgorithmFamily: ConsensusAlgorithmFamily,
+): boolean {
+  const isInConsensusAlgorithmFamiliesWithTxFinality = (Object.values(
+    ConsensusAlgorithmFamiliesWithTxFinality,
+  ) as string[]).includes(consensusAlgorithmFamily.toString());
+
+  const isInConsensusAlgorithmFamiliesWithOutTxFinality = (Object.values(
+    ConsensusAlgorithmFamiliesWithOutTxFinality,
+  ) as string[]).includes(consensusAlgorithmFamily.toString());
+
+  const unrecognizedConsensusAlgorithmFamily =
+    !isInConsensusAlgorithmFamiliesWithTxFinality &&
+    !isInConsensusAlgorithmFamiliesWithOutTxFinality;
+
+  if (unrecognizedConsensusAlgorithmFamily) {
+    throw new Error(
+      `Unrecognized consensus algorithm family: ${consensusAlgorithmFamily}`,
+    );
+  }
+  return isInConsensusAlgorithmFamiliesWithTxFinality;
+}

--- a/packages/cactus-core/src/main/typescript/public-api.ts
+++ b/packages/cactus-core/src/main/typescript/public-api.ts
@@ -9,3 +9,5 @@ export {
   AuthorizationOptionsProvider,
   IEndpointAuthzOptionsProviderOptions,
 } from "./web-services/authorization-options-provider";
+
+export { consensusHasTransactionFinality } from "./consensus-has-transaction-finality";

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/plugin-ledger-connector-besu.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/plugin-ledger-connector-besu.ts
@@ -20,7 +20,10 @@ import {
   IPluginKeychain,
 } from "@hyperledger/cactus-core-api";
 
-import { PluginRegistry } from "@hyperledger/cactus-core";
+import {
+  PluginRegistry,
+  consensusHasTransactionFinality,
+} from "@hyperledger/cactus-core";
 
 import {
   Checks,
@@ -220,7 +223,11 @@ export class PluginLedgerConnectorBesu
   > {
     return ConsensusAlgorithmFamily.AUTHORITY;
   }
+  public async hasTransactionFinality(): Promise<boolean> {
+    const currentConsensusAlgorithmFamily = await this.getConsensusAlgorithmFamily();
 
+    return consensusHasTransactionFinality(currentConsensusAlgorithmFamily);
+  }
   public async invokeContract(
     req: InvokeContractV1Request,
   ): Promise<InvokeContractV1Response> {

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/plugin-ledger-connector-corda.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/plugin-ledger-connector-corda.ts
@@ -13,7 +13,7 @@ import {
   ICactusPluginOptions,
   ConsensusAlgorithmFamily,
 } from "@hyperledger/cactus-core-api";
-
+import { consensusHasTransactionFinality } from "@hyperledger/cactus-core";
 import {
   Checks,
   Logger,
@@ -64,6 +64,11 @@ export class PluginLedgerConnectorCorda
     ConsensusAlgorithmFamily
   > {
     return ConsensusAlgorithmFamily.AUTHORITY;
+  }
+  public async hasTransactionFinality(): Promise<boolean> {
+    const currentConsensusAlgorithmFamily = await this.getConsensusAlgorithmFamily();
+
+    return consensusHasTransactionFinality(currentConsensusAlgorithmFamily);
   }
 
   public getAspect(): PluginAspect {

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/plugin-ledger-connector-fabric.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/plugin-ledger-connector-fabric.ts
@@ -33,7 +33,10 @@ import {
   ICactusPluginOptions,
 } from "@hyperledger/cactus-core-api";
 
-import { PluginRegistry } from "@hyperledger/cactus-core";
+import {
+  consensusHasTransactionFinality,
+  PluginRegistry,
+} from "@hyperledger/cactus-core";
 
 import {
   Logger,
@@ -184,7 +187,11 @@ export class PluginLedgerConnectorFabric
   > {
     return ConsensusAlgorithmFamily.AUTHORITY;
   }
+  public async hasTransactionFinality(): Promise<boolean> {
+    const currentConsensusAlgorithmFamily = await this.getConsensusAlgorithmFamily();
 
+    return consensusHasTransactionFinality(currentConsensusAlgorithmFamily);
+  }
   private async sshExec(
     cmd: string,
     label: string,

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/plugin-ledger-connector-quorum.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/plugin-ledger-connector-quorum.ts
@@ -23,7 +23,10 @@ import {
   IPluginKeychain,
 } from "@hyperledger/cactus-core-api";
 
-import { PluginRegistry } from "@hyperledger/cactus-core";
+import {
+  PluginRegistry,
+  consensusHasTransactionFinality,
+} from "@hyperledger/cactus-core";
 
 import {
   Checks,
@@ -205,7 +208,11 @@ export class PluginLedgerConnectorQuorum
   > {
     return ConsensusAlgorithmFamily.AUTHORITY;
   }
+  public async hasTransactionFinality(): Promise<boolean> {
+    const currentConsensusAlgorithmFamily = await this.getConsensusAlgorithmFamily();
 
+    return consensusHasTransactionFinality(currentConsensusAlgorithmFamily);
+  }
   public async invokeContract(
     req: InvokeContractV1Request,
   ): Promise<InvokeContractV1Response> {


### PR DESCRIPTION
Adding function hasTransactionFinality() on connector API, to let ledger query whether the configured consensus has transaction finality at run time.
Fixes #354 