### PR TITLE
feat(connector-besu): contract deployment with constructor arguments

### DIFF
--- a/examples/cactus-example-supply-chain-backend/src/main/typescript/infrastructure/supply-chain-app-dummy-infrastructure.ts
+++ b/examples/cactus-example-supply-chain-backend/src/main/typescript/infrastructure/supply-chain-app-dummy-infrastructure.ts
@@ -213,6 +213,8 @@ export class SupplyChainAppDummyInfrastructure {
         const res = await connector.deployContract({
           contractName: BookshelfRepositoryJSON.contractName,
           bytecode: BookshelfRepositoryJSON.bytecode,
+          contractAbi: BookshelfRepositoryJSON.abi,
+          constructorArgs: [],
           gas: 1000000,
           web3SigningCredential: {
             ethAccount: this.besuAccount.address,

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json
@@ -35,7 +35,7 @@
                 "description": "Enumerates the possible types of receipts that can be waited for by someone or something that has requested the execution of a transaction on a ledger.",
                 "type": "string",
                 "enum": [
-                    "NODE_TX_POOL_ACK", 
+                    "NODE_TX_POOL_ACK",
                     "LEDGER_BLOCK_ACK"
                 ]
             },
@@ -402,9 +402,11 @@
                 "type": "object",
                 "required": [
                     "contractName",
+                    "contractAbi",
                     "bytecode",
                     "web3SigningCredential",
-                    "keychainId"
+                    "keychainId",
+                    "constructorArgs"
                 ],
                 "properties": {
                     "contractName": {
@@ -413,6 +415,17 @@
                         "minLength": 1,
                         "maxLength": 100,
                         "nullable": false
+                    },
+                    "contractAbi": {
+                        "description": "The application binary interface of the solidity contract",
+                        "type": "array",
+                        "items": {},
+                        "nullable": false
+                    },
+                    "constructorArgs": {
+                        "type": "array",
+                        "items": {},
+                        "default": []
                     },
                     "web3SigningCredential": {
                         "$ref": "#/components/schemas/Web3SigningCredential",
@@ -540,7 +553,7 @@
                         "type": "string",
                         "description": "The keychainId for retrieve the contracts json.",
                         "minLength": 1,
-                        "maxLength": 100  
+                        "maxLength": 100
                     }
                 }
             },

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -114,6 +114,18 @@ export interface DeployContractSolidityBytecodeV1Request {
      */
     contractName: string;
     /**
+     * The application binary interface of the solidity contract
+     * @type {Array<any>}
+     * @memberof DeployContractSolidityBytecodeV1Request
+     */
+    contractAbi: Array<any>;
+    /**
+     * 
+     * @type {Array<any>}
+     * @memberof DeployContractSolidityBytecodeV1Request
+     */
+    constructorArgs: Array<any>;
+    /**
      * 
      * @type {Web3SigningCredential}
      * @memberof DeployContractSolidityBytecodeV1Request

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/plugin-ledger-connector-besu.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/plugin-ledger-connector-besu.ts
@@ -546,12 +546,22 @@ export class PluginLedgerConnectorBesu
       }
       const networkId = await this.web3.eth.net.getId();
 
+      const tmpContract = new this.web3.eth.Contract(req.contractAbi);
+      const deployment = tmpContract.deploy({
+        data: req.bytecode,
+        arguments: req.constructorArgs,
+      });
+
+      this.log.debug(`Deployment object of contract: %o`, deployment);
+      const encodedAbi = deployment.encodeABI();
+      const data = `0x${encodedAbi}`;
+
       const web3SigningCredential = req.web3SigningCredential as
         | Web3SigningCredentialPrivateKeyHex
         | Web3SigningCredentialCactusKeychainRef;
       const receipt = await this.transact({
         transactionConfig: {
-          data: `0x${req.bytecode}`,
+          data,
           from: web3SigningCredential.ethAccount,
           gas: req.gas,
           gasPrice: req.gasPrice,

--- a/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/deploy-contract-from-json.test.ts
@@ -138,6 +138,8 @@ test(testCase, async (t: Test) => {
     const deployOut = await connector.deployContract({
       keychainId: keychainPlugin.getKeychainId(),
       contractName: HelloWorldContractJson.contractName,
+      contractAbi: HelloWorldContractJson.abi,
+      constructorArgs: [],
       web3SigningCredential: {
         ethAccount: firstHighNetWorthAccount,
         secret: besuKeyPair.privateKey,

--- a/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/invoke-contract.test.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/invoke-contract.test.ts
@@ -95,6 +95,8 @@ test("deploys contract via .json file", async (t: Test) => {
     const deployOut = await connector.deployContract({
       keychainId: keychainPlugin.getKeychainId(),
       contractName: HelloWorldContractJson.contractName,
+      contractAbi: HelloWorldContractJson.abi,
+      constructorArgs: [],
       web3SigningCredential: {
         ethAccount: firstHighNetWorthAccount,
         secret: besuKeyPair.privateKey,


### PR DESCRIPTION
Previously you couldn't deploy a contract that had constructor arguments
of it's own because there was no way to pass in these.
With this improvement this is now possible.

Depends on #810

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

cc: @jordigiam @AzaharaC 