### PR TITLE
feat(tools): fabric all-in-one 2.x add nodejs to image

### DIFF
--- a/tools/docker/fabric-all-in-one/Dockerfile_v2.x
+++ b/tools/docker/fabric-all-in-one/Dockerfile_v2.x
@@ -40,6 +40,9 @@ RUN apk add --no-cache curl
 # The file binary is used to inspect exectubles when debugging container image issues
 RUN apk add --no-cache file
 
+# Need NodeJS tooling for the Typescript contracts
+RUN apk add --no-cache npm nodejs
+
 # Download and setup path variables for Go
 RUN wget https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
 RUN tar -xvf go1.15.5.linux-amd64.tar.gz
@@ -134,6 +137,7 @@ RUN chmod +x /download-frozen-image-v2.sh
 RUN mkdir -p /etc/hyperledger/fabric/fabric-peer/
 RUN mkdir -p /etc/hyperledger/fabric/fabric-orderer/
 RUN mkdir -p /etc/hyperledger/fabric/fabric-ccenv/
+RUN mkdir -p /etc/hyperledger/fabric/fabric-nodeenv/
 RUN mkdir -p /etc/hyperledger/fabric/fabric-tools/
 RUN mkdir -p /etc/hyperledger/fabric/fabric-baseos/
 RUN mkdir -p /etc/hyperledger/fabric/fabric-ca/
@@ -141,6 +145,7 @@ RUN mkdir -p /etc/hyperledger/fabric/fabric-ca/
 RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/fabric-peer/ hyperledger/fabric-peer:${FABRIC_VERSION}
 RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/fabric-orderer/ hyperledger/fabric-orderer:${FABRIC_VERSION}
 RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/fabric-ccenv/ hyperledger/fabric-ccenv:${FABRIC_VERSION}
+RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/fabric-nodeenv/ hyperledger/fabric-nodeenv:${FABRIC_VERSION}
 RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/fabric-tools/ hyperledger/fabric-tools:${FABRIC_VERSION}
 RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/fabric-baseos/ hyperledger/fabric-baseos:${FABRIC_VERSION}
 RUN /download-frozen-image-v2.sh /etc/hyperledger/fabric/fabric-ca/ hyperledger/fabric-ca:${CA_VERSION}

--- a/tools/docker/fabric-all-in-one/README.md
+++ b/tools/docker/fabric-all-in-one/README.md
@@ -53,7 +53,7 @@ Example `.vscode/tasks.json` file for building/running the image:
 From the project root:
 
 ```sh
-docker build ./tools/docker/fabric-all-in-one/ -f ./tools/docker/fabric-all-in-one/Dockerfile_v2.x -t faio2x
+DOCKER_BUILDKIT=1 docker build ./tools/docker/fabric-all-in-one/ -f ./tools/docker/fabric-all-in-one/Dockerfile_v2.x -t faio2x
 docker run --detach --privileged --publish-all --env FABRIC_VERSION=2.2.0 faio2x
 
 docker ps

--- a/tools/docker/fabric-all-in-one/run-fabric-network.sh
+++ b/tools/docker/fabric-all-in-one/run-fabric-network.sh
@@ -30,6 +30,7 @@ function main()
 
     # Fabric 2.x has this new image called fabric-baseos so we need to load that
     # as well when we detect that we are running Fabrix 2.x not 1.x
+    tar -cC '/etc/hyperledger/fabric/fabric-nodeenv/' . | docker load
     tar -cC '/etc/hyperledger/fabric/fabric-baseos/' . | docker load
   
     /bootstrap.sh ${FABRIC_VERSION} ${CA_VERSION} -b -s


### PR DESCRIPTION
## Dependencies

Depends on #826 

## Commit to review

Author: Peter Somogyvari <peter.somogyvari@accenture.com>
Author Date: Tue Apr 20 2021 23:20:06 GMT-0700 (Pacific Daylight Time)
Committer: Peter Somogyvari <peter.somogyvari@accenture.com>
Committer Date: Tue Apr 20 2021 23:24:44 GMT-0700 (Pacific Daylight Time) 

feat(tools): fabric all-in-one 2.x add nodejs to image

This is necessary so that the AIO image can compile Typescript
contracts down into Javascript for the NodeJS
chaincode runtime.

Tagged on DockerHub as
hyperledger/cactus-fabric2-all-in-one:2021-04-20-nodejs

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>