### PR TITLE
fix(connector-besu): network update only if present in keychain

### DIFF
--- a/packages/cactus-plugin-ledger-connector-besu/package.json
+++ b/packages/cactus-plugin-ledger-connector-besu/package.json
@@ -92,7 +92,8 @@
     "openapi-types": "7.0.1",
     "prom-client": "13.1.0",
     "typescript-optional": "2.0.1",
-    "web3": "1.2.7"
+    "web3": "1.2.7",
+    "web3-utils": "1.2.7"
   },
   "devDependencies": {
     "@hyperledger/cactus-plugin-keychain-memory": "0.4.1",


### PR DESCRIPTION
Only attempt to set/update the networks object on the contract JSON if
it was present in the keychain, leave it alone
otherwise.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>