### PR TITLE
build(lerna): canary publish script dist-tag = current git branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "commit": "git-cz --signoff",
     "prettier": "prettier --write --config .prettierrc.json \"./**/*.{ts,js}\"",
     "version": "npm ci && lerna clean --yes && lerna bootstrap && npm run build:dev && npm run build:prod && npm run test:unit",
-    "lerna-publish-canary": "lerna publish --canary --sign-git-commit --sign-git-tag",
+    "lerna-publish-canary": "npm run run-ci && lerna publish --canary --force-publish --dist-tag $(git branch --show-current) --preid $(git branch --show-current).$(git rev-parse --short HEAD)",
     "lerna-publish": "lerna publish --conventional-commits --sign-git-commit --sign-git-tag"
   },
   "devDependencies": {


### PR DESCRIPTION
Primary change:
=============

Fixes #850 

The npm dist-tag parameter will now be set to whatever is the
current git branch checked out.

This allows for developers to work on their own feature branches
and publish their own canary releases
for every single commit as they see fit without having to wait for the
an upcoming official release.

Miscellaneous change:

The script will now make sure to run the CI script prior to issuing the
canary release so that it is guaranteed
that the canary release does not go
out unless it was made from a revision
of the code that has the tests and build passing.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>