### PR TITLE
feat(connector-fabric): enrollAdmin() and createCaClient()

### DIFF
--- a/packages/cactus-plugin-ledger-connector-xdai/src/main/typescript/plugin-ledger-connector-xdai.ts
+++ b/packages/cactus-plugin-ledger-connector-xdai/src/main/typescript/plugin-ledger-connector-xdai.ts
@@ -21,6 +21,7 @@ import {
   IPluginKeychain,
 } from "@hyperledger/cactus-core-api";
 
+import { consensusHasTransactionFinality } from "@hyperledger/cactus-core";
 import { PluginRegistry } from "@hyperledger/cactus-core";
 
 import {
@@ -120,6 +121,11 @@ export class PluginLedgerConnectorXdai
     );
 
     this.prometheusExporter.startMetricsCollection();
+  }
+
+  public async hasTransactionFinality(): Promise<boolean> {
+    const consensusAlgorithmFamily = await this.getConsensusAlgorithmFamily();
+    return consensusHasTransactionFinality(consensusAlgorithmFamily);
   }
 
   public getPrometheusExporter(): PrometheusExporter {


### PR DESCRIPTION
## Dependencies

Depends on #841


## Commit to review

Author: Peter Somogyvari <peter.somogyvari@accenture.com>
Committer: Peter Somogyvari <peter.somogyvari@accenture.com>
Date: Sat Apr 24 2021 20:55:46 GMT-0700 (Pacific Daylight Time) 

feat(connector-fabric): enrollAdmin() and createCaClient()

These are methods that come in handy while working with
Fabric networks.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>