### PR TITLE
build: webpack ts-loader transpileOnly set to true

### DIFF
--- a/webpack.dev.node.js
+++ b/webpack.dev.node.js
@@ -29,7 +29,7 @@ module.exports = {
           {
             loader: "ts-loader",
             options: {
-              transpileOnly: false,
+              transpileOnly: true,
               configFile: "tsconfig.json",
             },
           },

--- a/webpack.dev.web.js
+++ b/webpack.dev.web.js
@@ -22,7 +22,7 @@ module.exports = {
           {
             loader: "ts-loader",
             options: {
-              transpileOnly: false,
+              transpileOnly: true,
               configFile: "tsconfig.json",
             },
           },

--- a/webpack.prod.node.js
+++ b/webpack.prod.node.js
@@ -29,7 +29,7 @@ module.exports = {
           {
             loader: "ts-loader",
             options: {
-              transpileOnly: false,
+              transpileOnly: true,
               configFile: "tsconfig.json",
             },
           },

--- a/webpack.prod.web.js
+++ b/webpack.prod.web.js
@@ -23,7 +23,7 @@ module.exports = {
           {
             loader: "ts-loader",
             options: {
-              transpileOnly: false,
+              transpileOnly: true,
               configFile: "tsconfig.json",
             },
           },


### PR DESCRIPTION
Needed this because otherwise the perfectly valid Typescript code would
not compile when using TS loader in cases when multiple Cactus packages
were depending on types from certain dependencies (example both core-api
and the besu connector would depend on the socketio package and its
"Server" class would be claimed as incompatible by the TS loader
compilation process even when the source files for those types were byte
to byte the same (but the path was different to them because they
existed in different node_modules directories)

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>