### PR TITLE
feat(core-api): add SocketIoConnectionPathV1 constant to OpenAPI specs

### DIFF
--- a/packages/cactus-core-api/src/main/json/openapi.json
+++ b/packages/cactus-core-api/src/main/json/openapi.json
@@ -31,6 +31,15 @@
     ],
     "components": {
         "schemas": {
+            "Constants": {
+                "type": "string",
+                "enum": [
+                    "/api/v1/async/socket-io/connect"
+                ],
+                "x-enum-varnames": [
+                    "SocketIoConnectionPathV1"
+                ]
+            },
             "PluginImport": {
                 "type": "object",
                 "required": [

--- a/packages/cactus-core-api/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-core-api/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -250,6 +250,15 @@ export interface ConsortiumMember {
 /**
  * 
  * @export
+ * @enum {string}
+ */
+export enum Constants {
+    SocketIoConnectionPathV1 = '/api/v1/async/socket-io/connect'
+}
+
+/**
+ * 
+ * @export
  * @interface GetKeychainEntryRequest
  */
 export interface GetKeychainEntryRequest {


### PR DESCRIPTION
This defines a constant in the OpenAPI specification so that it can be
reused everywhere else in the code, including in the generated
documentation that we intend to create from the OpenAPI specifications
later on and also other packages in the Typescript code who import the
core-api package.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

Related to #297