### PR TITLE
perf(cmd-api-server): shrink API server bundle with type-only imports

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
@@ -1,19 +1,14 @@
 import path from "path";
-import { gte } from "semver";
-import { AddressInfo } from "net";
+import type { AddressInfo } from "net";
 import tls from "tls";
 import { Server, createServer } from "http";
-import { Server as SecureServer } from "https";
+import type { Server as SecureServer } from "https";
 import { createServer as createSecureServer } from "https";
+import { gte } from "semver";
 import npm from "npm";
 import expressHttpProxy from "express-http-proxy";
-import express, {
-  Express,
-  Request,
-  Response,
-  RequestHandler,
-  Application,
-} from "express";
+import type { Application, Request, Response, RequestHandler } from "express";
+import express from "express";
 import { OpenApiValidator } from "express-openapi-validator";
 import compression from "compression";
 import bodyParser from "body-parser";
@@ -377,7 +372,7 @@ export class ApiServer {
       },
     });
 
-    const app: Express = express();
+    const app: Application = express();
     app.use("/api/v*", apiProxyMiddleware);
     app.use(compression());
     app.use(corsMiddleware);


### PR DESCRIPTION
Great explanation can be found here:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>