### PR TITLE
feat(test-tooling): quorum test ledger omit pull parameter

### DIFF
--- a/packages/cactus-test-tooling/src/main/typescript/quorum/quorum-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/quorum/quorum-test-ledger.ts
@@ -171,7 +171,7 @@ export class QuorumTestLedger implements ITestLedger {
     return { publicKey, privateKey };
   }
 
-  public async start(): Promise<Container> {
+  public async start(omitPull = false): Promise<Container> {
     const containerNameAndTag = this.getContainerImageName();
 
     if (this.container) {
@@ -180,7 +180,9 @@ export class QuorumTestLedger implements ITestLedger {
     }
     const docker = new Docker();
 
-    await this.pullContainerImage(containerNameAndTag);
+    if (!omitPull) {
+      await this.pullContainerImage(containerNameAndTag);
+    }
 
     return new Promise<Container>((resolve, reject) => {
       const eventEmitter: EventEmitter = docker.run(


### PR DESCRIPTION
With this boolean argument of the start() method of the test ledger
class one can test locally built container images that were no yet
pushed to a public docker registry.
To use it: build your docker image locally with a tag of "your-tag", then
specify this as the tag to be used and also the omitPull argument of the start
method as true which will result in your local image being used without
any attempts to pull it (which would fail).

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>