### PR TITLE
refactor(test-tooling): quorum AIO supervisord to log to stdout

### DIFF
--- a/tools/docker/quorum-all-in-one/supervisord.conf
+++ b/tools/docker/quorum-all-in-one/supervisord.conf
@@ -2,21 +2,29 @@
 logfile = /var/log/supervisord.log
 logfile_maxbytes = 50MB
 logfile_backups=10
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 loglevel = info
 
 [program:tessera]
 command=/start-tessera.sh
 autostart=true
 autorestart=true
-stderr_logfile=/var/log/tessera.err.log
-stdout_logfile=/var/log/tessera.out.log
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:quorum]
 command=/start-quorum.sh
 autostart=true
 autorestart=true
-stderr_logfile=/var/log/quorum.err.log
-stdout_logfile=/var/log/quorum.out.log
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [inet_http_server]
 port = 0.0.0.0:9001


### PR DESCRIPTION
This makes it much easier to debug issues with the AIO container at runtime because
one does not have to shell into the container, find the log files manually and
then print them there. Instead the container just forwards the
output of Tessera and Quorum straight to it's own stdout/stderr.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>