### PR TITLE
test(connector-fabric): fix module requires Go 1.17 #914

### DIFF
--- a/examples/cactus-example-supply-chain-backend/src/main/typescript/infrastructure/supply-chain-app-dummy-infrastructure.ts
+++ b/examples/cactus-example-supply-chain-backend/src/main/typescript/infrastructure/supply-chain-app-dummy-infrastructure.ts
@@ -276,7 +276,10 @@ export class SupplyChainAppDummyInfrastructure {
           },
           moduleName: "shipment",
           targetOrganizations: [org1Env],
-          pinnedDeps: ["github.com/hyperledger/fabric@v1.4.8"],
+          pinnedDeps: [
+            "github.com/hyperledger/fabric@v1.4.8",
+            "golang.org/x/net@v0.0.0-20210503060351-7fd8e65b6420",
+          ],
         });
         this.log.debug(res);
 

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes.test.ts
@@ -6,7 +6,7 @@ import bodyParser from "body-parser";
 import express from "express";
 import { AddressInfo } from "net";
 
-import { CordaTestLedger } from "@hyperledger/cactus-test-tooling";
+import { Containers, CordaTestLedger } from "@hyperledger/cactus-test-tooling";
 import {
   LogLevelDesc,
   IListenOptions,
@@ -35,6 +35,10 @@ import { K_CACTUS_CORDA_TOTAL_TX_COUNT } from "../../../main/typescript/promethe
 const logLevel: LogLevelDesc = "TRACE";
 
 test("Tests are passing on the JVM side", async (t: Test) => {
+  test.onFailure(async () => {
+    await Containers.logDiagnostics({ logLevel });
+  });
+
   const ledger = new CordaTestLedger({
     imageName: "hyperledger/cactus-corda-4-6-all-in-one-obligation",
     imageVersion: "2021-03-19-feat-686",

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
@@ -2,6 +2,7 @@ import test, { Test } from "tape-promise/tape";
 import { v4 as internalIpV4 } from "internal-ip";
 
 import {
+  Containers,
   CordaTestLedger,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -22,6 +23,10 @@ import {
 
 const testCase = "Tests are passing on the JVM side";
 const logLevel: LogLevelDesc = "TRACE";
+
+test.onFailure(async () => {
+  await Containers.logDiagnostics({ logLevel });
+});
 
 test("BEFORE " + testCase, async (t: Test) => {
   const pruning = pruneDockerAllIfGithubAction({ logLevel });

--- a/packages/cactus-plugin-ledger-connector-fabric/README.md
+++ b/packages/cactus-plugin-ledger-connector-fabric/README.md
@@ -45,7 +45,7 @@ The above diagram shows the sequence diagraom of transact() method of the Plugin
 
 ## Usage
 
-To use this import public-api and create new **PluginLedgerConnectorFabric** and **ChainCodeCompiler**. 
+To use this import public-api and create new **PluginLedgerConnectorFabric** and **ChainCodeCompiler**.
 ```typescript
   const connector: PluginLedgerConnectorFabric = new PluginLedgerConnectorFabric(pluginOptions);
   const compiler = new ChainCodeCompiler({ logLevel });
@@ -55,7 +55,10 @@ For compile the chaincodes:
   const opts: ICompilationOptions = {
     fileName: "hello-world-contract.go",
     moduleName: "hello-world-contract",
-    pinnedDeps: ["github.com/hyperledger/fabric@v1.4.8"],
+    pinnedDeps: [
+      "github.com/hyperledger/fabric@v1.4.8",
+      "golang.org/x/net@v0.0.0-20210503060351-7fd8e65b6420",
+    ],
     modTidyOnly: true, // we just need the go.mod file so tidy only is enough
     sourceCode: HELLO_WORLD_CONTRACT_GO_SOURCE,
   };
@@ -108,7 +111,7 @@ docker run \
   "discoveryOptions": {
     "enabled": true,
     "asLocalhost: true"
-  }  
+  }
   }}}]' \
   cplcb
 ```
@@ -134,7 +137,7 @@ docker run \
   "discoveryOptions": {
     "enabled": true,
     "asLocalhost: true"
-  }  
+  }
   }}}]'
 ```
 
@@ -154,7 +157,7 @@ echo '[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-fabric", "ty
   "discoveryOptions": {
     "enabled": true,
     "asLocalhost: true"
-  }  
+  }
   }}}]' > cactus.json
 
 docker run \
@@ -196,7 +199,7 @@ docker run \
   "discoveryOptions": {
     "enabled": true,
     "asLocalhost: true"
-  }  
+  }
   }}}]' \
   cplcb
 ```
@@ -288,4 +291,4 @@ Please review [CONTIRBUTING.md](../../CONTRIBUTING.md) to get started.
 
 This distribution is published under the Apache License Version 2.0 found in the [LICENSE](../../LICENSE) file.
 
-## Acknowledgments 
+## Acknowledgments

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts
@@ -58,11 +58,6 @@ test(testCase, async (t: Test) => {
     imageName: "hyperledger/cactus-fabric-all-in-one",
     imageVersion: "2021-03-02-ssh-hotfix",
   });
-  await ledger.start();
-  t.doesNotThrow(() => ledger.getContainer(), "Container is set OK");
-  const ledgerContainer = ledger.getContainer();
-  t.ok(ledgerContainer, "ledgerContainer truthy OK");
-  t.ok(ledgerContainer.id, "ledgerContainer.id truthy OK");
 
   const tearDown = async () => {
     await ledger.stop();
@@ -70,6 +65,12 @@ test(testCase, async (t: Test) => {
   };
 
   test.onFinish(tearDown);
+
+  await ledger.start();
+  t.doesNotThrow(() => ledger.getContainer(), "Container is set OK");
+  const ledgerContainer = ledger.getContainer();
+  t.ok(ledgerContainer, "ledgerContainer truthy OK");
+  t.ok(ledgerContainer.id, "ledgerContainer.id truthy OK");
 
   const connectionProfile = await ledger.getConnectionProfileOrg1();
   t.ok(connectionProfile, "getConnectionProfileOrg1() out truthy OK");

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts
@@ -55,8 +55,10 @@ test(testCase, async (t: Test) => {
   const ledger = new FabricTestLedgerV1({
     emitContainerLogs: true,
     publishAllPorts: true,
+    // imageName: "faio14x",
+    // imageVersion: "latest",
     imageName: "hyperledger/cactus-fabric-all-in-one",
-    imageVersion: "2021-03-02-ssh-hotfix",
+    imageVersion: "2021-04-21-2016750",
   });
 
   const tearDown = async () => {
@@ -174,7 +176,10 @@ test(testCase, async (t: Test) => {
     },
     moduleName: "hello-world",
     targetOrganizations: [org1Env, org2Env],
-    pinnedDeps: ["github.com/hyperledger/fabric@v1.4.8"],
+    pinnedDeps: [
+      "github.com/hyperledger/fabric@v1.4.8",
+      "golang.org/x/net@v0.0.0-20210503060351-7fd8e65b6420",
+    ],
   });
 
   const {

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source-private-data.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source-private-data.test.ts
@@ -10,6 +10,7 @@ import express from "express";
 import bodyParser from "body-parser";
 
 import {
+  Containers,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -49,6 +50,10 @@ test(testCase, async (t: Test) => {
   const channelId = "mychannel";
   const channelName = channelId;
 
+  test.onFailure(async () => {
+    await Containers.logDiagnostics({ logLevel });
+  });
+
   const ledger = new FabricTestLedgerV1({
     emitContainerLogs: true,
     publishAllPorts: true,
@@ -56,14 +61,13 @@ test(testCase, async (t: Test) => {
     imageVersion: "2021-04-20-nodejs",
     envVars: new Map([["FABRIC_VERSION", "2.2.0"]]),
   });
-  await ledger.start();
-
   const tearDown = async () => {
     await ledger.stop();
     await ledger.destroy();
   };
 
   test.onFinish(tearDown);
+  await ledger.start();
 
   const connectionProfile = await ledger.getConnectionProfileOrg1();
 
@@ -359,7 +363,7 @@ test(testCase, async (t: Test) => {
     },
   });
 
- 
+
   */
 
   const getResQuery = await apiClient.runTransactionV1({

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source.test.ts
@@ -10,6 +10,7 @@ import express from "express";
 import bodyParser from "body-parser";
 
 import {
+  Containers,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -49,6 +50,10 @@ test(testCase, async (t: Test) => {
   const channelId = "mychannel";
   const channelName = channelId;
 
+  test.onFailure(async () => {
+    await Containers.logDiagnostics({ logLevel });
+  });
+
   const ledger = new FabricTestLedgerV1({
     emitContainerLogs: true,
     publishAllPorts: true,
@@ -58,7 +63,6 @@ test(testCase, async (t: Test) => {
     imageVersion: "2021-04-20-nodejs",
     envVars: new Map([["FABRIC_VERSION", "2.2.0"]]),
   });
-  await ledger.start();
 
   const tearDown = async () => {
     await ledger.stop();
@@ -66,6 +70,7 @@ test(testCase, async (t: Test) => {
   };
 
   test.onFinish(tearDown);
+  await ledger.start();
 
   const connectionProfile = await ledger.getConnectionProfileOrg1();
   t.ok(connectionProfile, "getConnectionProfileOrg1() out truthy OK");

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts
@@ -10,6 +10,7 @@ import express from "express";
 import bodyParser from "body-parser";
 
 import {
+  Containers,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -50,6 +51,10 @@ test(testCase, async (t: Test) => {
   const channelId = "mychannel";
   const channelName = channelId;
 
+  test.onFailure(async () => {
+    await Containers.logDiagnostics({ logLevel });
+  });
+
   const ledger = new FabricTestLedgerV1({
     emitContainerLogs: true,
     publishAllPorts: true,
@@ -59,14 +64,13 @@ test(testCase, async (t: Test) => {
     imageVersion: "2021-04-20-nodejs",
     envVars: new Map([["FABRIC_VERSION", "2.2.0"]]),
   });
-  await ledger.start();
-
   const tearDown = async () => {
     await ledger.stop();
     await ledger.destroy();
   };
 
   test.onFinish(tearDown);
+  await ledger.start();
 
   const connectionProfile = await ledger.getConnectionProfileOrg1();
   t.ok(connectionProfile, "getConnectionProfileOrg1() out truthy OK");

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-typescript-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-typescript-source.test.ts
@@ -10,6 +10,7 @@ import express from "express";
 import bodyParser from "body-parser";
 
 import {
+  Containers,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -50,6 +51,10 @@ test(testCase, async (t: Test) => {
   const channelId = "mychannel";
   const channelName = channelId;
 
+  test.onFailure(async () => {
+    await Containers.logDiagnostics({ logLevel });
+  });
+
   const ledger = new FabricTestLedgerV1({
     emitContainerLogs: true,
     publishAllPorts: true,
@@ -59,14 +64,13 @@ test(testCase, async (t: Test) => {
     imageVersion: "2021-04-20-nodejs",
     envVars: new Map([["FABRIC_VERSION", "2.2.0"]]),
   });
-  await ledger.start();
-
   const tearDown = async () => {
     await ledger.stop();
     await ledger.destroy();
   };
 
   test.onFinish(tearDown);
+  await ledger.start();
 
   const connectionProfile = await ledger.getConnectionProfileOrg1();
   t.ok(connectionProfile, "getConnectionProfileOrg1() out truthy OK");

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
@@ -8,6 +8,7 @@ import bodyParser from "body-parser";
 import express from "express";
 
 import {
+  Containers,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -54,8 +55,12 @@ test("BEFORE " + testCase, async (t: Test) => {
 test(testCase, async (t: Test) => {
   const logLevel: LogLevelDesc = "TRACE";
 
+  test.onFailure(async () => {
+    await Containers.logDiagnostics({ logLevel });
+  });
+
   const ledger = new FabricTestLedgerV1({
-    emitContainerLogs: false,
+    emitContainerLogs: true,
     publishAllPorts: true,
     logLevel,
     imageName: "hyperledger/cactus-fabric2-all-in-one",
@@ -65,8 +70,7 @@ test(testCase, async (t: Test) => {
       ["CA_VERSION", "1.4.9"],
     ]),
   });
-
-  await ledger.start();
+  t.ok(ledger, "ledger (FabricTestLedgerV1) truthy OK");
 
   const tearDownLedger = async () => {
     await ledger.stop();
@@ -74,6 +78,8 @@ test(testCase, async (t: Test) => {
   };
 
   test.onFinish(tearDownLedger);
+
+  await ledger.start();
 
   const enrollAdminOut = await ledger.enrollAdmin();
   const adminWallet = enrollAdminOut[1];

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/unit/chain-code-compiler.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/unit/chain-code-compiler.test.ts
@@ -17,7 +17,10 @@ test.skip("compiles chaincode straight from go source code", async (t: Test) => 
   const opts: ICompilationOptions = {
     fileName: "hello-world-contract.go",
     moduleName: "hello-world-contract",
-    pinnedDeps: ["github.com/hyperledger/fabric@v1.4.8"],
+    pinnedDeps: [
+      "github.com/hyperledger/fabric@v1.4.8",
+      "golang.org/x/net@v0.0.0-20210503060351-7fd8e65b6420",
+    ],
     sourceCode: HELLO_WORLD_CONTRACT_GO_SOURCE,
   };
 

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-deploy-contract-from-json.test.ts
@@ -50,12 +50,11 @@ test(testCase, async (t: Test) => {
   const containerImageName = "hyperledger/cactus-quorum-all-in-one";
   const ledgerOptions = { containerImageName, containerImageVersion };
   const ledger = new QuorumTestLedger(ledgerOptions);
-  await ledger.start();
-
   test.onFinish(async () => {
     await ledger.stop();
     await ledger.destroy();
   });
+  await ledger.start();
 
   const rpcApiHttpHost = await ledger.getRpcApiHttpHost();
   const quorumGenesisOptions: IQuorumGenesisOptions = await ledger.getGenesisJsObject();

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-invoke-contract.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-invoke-contract.test.ts
@@ -30,12 +30,11 @@ test("Quorum Ledger Connector Plugin", async (t: Test) => {
   const containerImageName = "hyperledger/cactus-quorum-all-in-one";
   const ledgerOptions = { containerImageName, containerImageVersion };
   const ledger = new QuorumTestLedger(ledgerOptions);
-  await ledger.start();
-
   test.onFinish(async () => {
     await ledger.stop();
     await ledger.destroy();
   });
+  await ledger.start();
 
   const rpcApiHttpHost = await ledger.getRpcApiHttpHost();
   const quorumGenesisOptions: IQuorumGenesisOptions = await ledger.getGenesisJsObject();

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-deploy-contract-from-json.test.ts
@@ -50,12 +50,12 @@ test(testCase, async (t: Test) => {
   const containerImageVersion = "2021-05-03-quorum-v21.4.1";
   const ledgerOptions = { containerImageName, containerImageVersion };
   const ledger = new QuorumTestLedger(ledgerOptions);
-  await ledger.start();
 
   test.onFinish(async () => {
     await ledger.stop();
     await ledger.destroy();
   });
+  await ledger.start();
 
   const rpcApiHttpHost = await ledger.getRpcApiHttpHost();
   const quorumGenesisOptions: IQuorumGenesisOptions = await ledger.getGenesisJsObject();

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-invoke-contract.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-invoke-contract.test.ts
@@ -30,12 +30,11 @@ test("Quorum Ledger Connector Plugin", async (t: Test) => {
   const containerImageVersion = "2021-05-03-quorum-v21.4.1";
   const ledgerOptions = { containerImageName, containerImageVersion };
   const ledger = new QuorumTestLedger(ledgerOptions);
-  await ledger.start();
-
   test.onFinish(async () => {
     await ledger.stop();
     await ledger.destroy();
   });
+  await ledger.start();
 
   const rpcApiHttpHost = await ledger.getRpcApiHttpHost();
   const quorumGenesisOptions: IQuorumGenesisOptions = await ledger.getGenesisJsObject();

--- a/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/deploy-contract-from-json-xdai.test.ts
+++ b/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/deploy-contract-from-json-xdai.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../main/typescript/public-api";
 import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory";
 import {
+  Containers,
   K_DEV_WHALE_ACCOUNT_PRIVATE_KEY,
   K_DEV_WHALE_ACCOUNT_PUBLIC_KEY,
   OpenEthereumTestLedger,
@@ -42,13 +43,17 @@ test("BEFORE " + testCase, async (t: Test) => {
 });
 
 test(testCase, async (t: Test) => {
-  const ledger = new OpenEthereumTestLedger({});
-  await ledger.start();
+  test.onFailure(async () => {
+    await Containers.logDiagnostics({ logLevel });
+  });
+
+  const ledger = new OpenEthereumTestLedger({ logLevel });
 
   test.onFinish(async () => {
     await ledger.stop();
     await ledger.destroy();
   });
+  await ledger.start();
 
   const rpcApiHttpHost = await ledger.getRpcApiHttpHost();
 

--- a/tools/docker/fabric-all-in-one/Dockerfile_v1.4.x
+++ b/tools/docker/fabric-all-in-one/Dockerfile_v1.4.x
@@ -41,8 +41,8 @@ RUN apk add --no-cache curl
 RUN apk add --no-cache file
 
 # Download and setup path variables for Go
-RUN wget https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
-RUN tar -xvf go1.15.5.linux-amd64.tar.gz
+RUN wget https://golang.org/dl/go1.16.3.linux-amd64.tar.gz
+RUN tar -xvf go1.16.3.linux-amd64.tar.gz
 RUN mv go /usr/local
 ENV GOROOT=/usr/local/go
 ENV GOPATH=/usr/local/go


### PR DESCRIPTION
Depends on #993 

Author: Peter Somogyvari <peter.somogyvari@accenture.com>
Committer: Peter Somogyvari <peter.somogyvari@accenture.com>
Date: Tue May 04 2021 14:32:33 GMT-0700 (Pacific Daylight Time)	 

test(connector-fabric): fix module requires Go 1.17 #914

Primary change:
------------------

Pinned the buggy dependency to yesterday's version
(the bug was introduced in this morning's build).

This prevents today's version from being used and
fixes the problem.

Secondary change:
--------------------

Upgraded the container image that's being used for the test to
the one that has the fabric images pre-cached.
This leads to faster test execution and lower probability
of developers getting hit by the dreaded DockerHub rate limiting issue.

Fixes #914 

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>