### PR TITLE
chore(deps): upgrade to Typescript v.4.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18941,9 +18941,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "tape-promise": "4.0.0",
     "ts-loader": "6.2.1",
     "ts-node": "8.9.1",
-    "typescript": "4.0.3",
+    "typescript": "4.2.4",
     "webpack": "git+https://github.com/petermetz/webpack.git#cactus-webpack-ignore-require-calls-feature",
     "webpack-bundle-analyzer": "3.6.0",
     "webpack-cli": "3.3.11"


### PR DESCRIPTION
This is a preliminary step in us migrating over (potentially) to use
workspaces which in theory will significantly improve the build speeds.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>