### PR TITLE
feat(test-tooling): improvements to fabric aio

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/obtain-profiles.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/obtain-profiles.test.ts
@@ -1,0 +1,67 @@
+import test, { Test } from "tape-promise/tape";
+
+import {
+  FabricTestLedgerV1,
+  pruneDockerAllIfGithubAction,
+} from "@hyperledger/cactus-test-tooling";
+
+import { LogLevelDesc } from "@hyperledger/cactus-common";
+
+const testCase = "obtains configuration profiles from Fabrix 2.x ledger";
+const logLevel: LogLevelDesc = "TRACE";
+
+test("BEFORE " + testCase, async (t: Test) => {
+  const pruning = pruneDockerAllIfGithubAction({ logLevel });
+  await t.doesNotReject(pruning, "Pruning didnt throw OK");
+  t.end();
+});
+
+test(testCase, async (t: Test) => {
+  const ledger = new FabricTestLedgerV1({
+    emitContainerLogs: true,
+    publishAllPorts: true,
+    // imageName: "faio2x",
+    // imageVersion: "latest",
+    imageName: "hyperledger/cactus-fabric2-all-in-one",
+    imageVersion: "2021-04-20-nodejs",
+    envVars: new Map([["FABRIC_VERSION", "2.2.0"]]),
+  });
+  await ledger.start();
+
+  const tearDown = async () => {
+    await ledger.stop();
+    await ledger.destroy();
+  };
+
+  test.onFinish(tearDown);
+
+  const connectionProfile = await ledger.getConnectionProfileOrg1();
+
+  t.ok(connectionProfile, "getConnectionProfileOrg1() out truthy OK");
+
+  const connectionProfileOrg1 = await ledger.getConnectionProfileOrgX("1");
+  t.isEquivalent(connectionProfile, connectionProfileOrg1);
+
+  const connectionProfileOrg2 = await ledger.getConnectionProfileOrgX("2");
+  t.ok(connectionProfileOrg2, "getConnectionProfileOrg2() out truthy OK");
+
+  t.ok(
+    connectionProfileOrg1 !== connectionProfileOrg2,
+    "getConnectionProfileOrg2() out truthy OK",
+  );
+
+  //Should return error, as there is no Org3 in the default deployment of Fabric AIO image
+  const error = "/Error.*/";
+  await t.rejects(
+    async () => await ledger.getConnectionProfileOrgX("3"),
+    error,
+  );
+
+  t.end();
+});
+
+test("AFTER " + testCase, async (t: Test) => {
+  const pruning = pruneDockerAllIfGithubAction({ logLevel });
+  await t.doesNotReject(pruning, "Pruning didnt throw OK");
+  t.end();
+});

--- a/packages/cactus-test-tooling/src/main/typescript/fabric/fabric-test-ledger-v1.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/fabric/fabric-test-ledger-v1.ts
@@ -324,6 +324,127 @@ export class FabricTestLedgerV1 implements ITestLedger {
     return ccp;
   }
 
+  public async getConnectionProfileOrgX(OrgId: string): Promise<any> {
+    const cInfo = await this.getContainerInfo();
+    const container = this.getContainer();
+    const CCP_JSON_PATH_FABRIC_V1 =
+      "/fabric-samples/first-network/connection-org" + OrgId + ".json";
+    const CCP_JSON_PATH_FABRIC_V2 =
+      "/fabric-samples/test-network/organizations/peerOrganizations/org" +
+      OrgId +
+      ".example.com/connection-org" +
+      OrgId +
+      ".json";
+    const ccpJsonPath = compareVersions.compare(
+      this.getFabricVersion(),
+      "2.0",
+      "<",
+    )
+      ? CCP_JSON_PATH_FABRIC_V1
+      : CCP_JSON_PATH_FABRIC_V2;
+    try {
+      const ccpJson = await Containers.pullFile(container, ccpJsonPath);
+      const ccp = JSON.parse(ccpJson);
+
+      {
+        // peer0.org1.example.com
+        const privatePort = 7051;
+        const hostPort = await Containers.getPublicPort(privatePort, cInfo);
+        ccp.peers[
+          "peer0.org" + OrgId + ".example.com"
+        ].url = `grpcs://localhost:${hostPort}`;
+      }
+      if (ccp.peers["peer1.org" + OrgId + ".example.com"]) {
+        // peer1.org1.example.com
+        const privatePort = 8051;
+        const hostPort = await Containers.getPublicPort(privatePort, cInfo);
+        ccp.peers[
+          "peer1.org" + OrgId + ".example.com"
+        ].url = `grpcs://localhost:${hostPort}`;
+      }
+      {
+        // ca_peerOrg1
+        const privatePort = 7054;
+        const hostPort = await Containers.getPublicPort(privatePort, cInfo);
+        const { certificateAuthorities: cas } = ccp;
+        cas[
+          "ca.org" + OrgId + ".example.com"
+        ].url = `https://localhost:${hostPort}`;
+      }
+
+      // FIXME - this still doesn't work. At this moment the only successful tests
+      // we could run was with host ports bound to the matching ports of the internal
+      // containers and with discovery enabled.
+      // When discovery is disabled, it just doesn't yet work and these changes
+      // below are my attempts so far at making the connection profile work without
+      // discovery being turned on (which we cannot use when the ports are randomized
+      // on the host for the parent container)
+      if (this.publishAllPorts) {
+        // orderer.example.com
+
+        const privatePort = 7050;
+        const hostPort = await Containers.getPublicPort(privatePort, cInfo);
+        const url = `grpcs://localhost:${hostPort}`;
+        const ORDERER_PEM_PATH_FABRIC_V1 =
+          "/fabric-samples/first-network/crypto-config/ordererOrganizations/example.com/tlsca/tlsca.example.com-cert.pem";
+        const ORDERER_PEM_PATH_FABRIC_V2 =
+          "/fabric-samples/test-network/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem";
+        const ordererPemPath = compareVersions.compare(
+          this.getFabricVersion(),
+          "2.0",
+          "<",
+        )
+          ? ORDERER_PEM_PATH_FABRIC_V1
+          : ORDERER_PEM_PATH_FABRIC_V2;
+        const pem = await Containers.pullFile(container, ordererPemPath);
+        ccp.orderers = {
+          "orderer.example.com": {
+            url,
+            grpcOptions: {
+              "ssl-target-name-override": "orderer.example.com",
+            },
+            tlsCACerts: {
+              pem,
+            },
+          },
+        };
+        const specificPeer = "peer0.org" + OrgId + ".example.com";
+
+        ccp.channels = {
+          mychannel: {
+            orderers: ["orderer.example.com"],
+            peers: {},
+          },
+        };
+
+        ccp.channels["mychannel"]["peers"][specificPeer] = {
+          endorsingPeer: true,
+          chaincodeQuery: true,
+          ledgerQuery: true,
+          eventSource: true,
+          discover: true,
+        };
+
+        // FIXME: Still have no idea if we can use these options to make it work
+        // with discovery
+        // {
+        //   const { grpcOptions } = ccp.peers["peer0.org1.example.com"];
+        //   grpcOptions.hostnameOverride = `localhost`;
+        // }
+        // {
+        //   const { grpcOptions } = ccp.peers["peer1.org1.example.com"];
+        //   grpcOptions.hostnameOverride = `localhost`;
+        // }
+      }
+      return ccp;
+    } catch (error) {
+      throw new Error(
+        "Could not obtain file necessary for constructing the connection profile: " +
+          error,
+      );
+    }
+  }
+
   public async getSshConfig(): Promise<SshConfig> {
     const fnTag = "FabricTestLedger#getSshConnectionOptions()";
     if (!this.container) {


### PR DESCRIPTION
1. feat(test-tooling): obtain connection profile from multiple orgs 

Allows obtaining a connection profile from any org that is created.
Adds a state database attribute to the test ledger (will be necessary for operations regarding private data)

2. fix(test-tooling): deletes volume created by faio

When a faio instance is deployed, it creates a volume. That volume is not destroyed when faio is shutdown. This commit destroys the created volume.