### PR TITLE
fix(cmd-api-server): drop URI type alt name from self signed TLS cert

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/config/self-signed-pki-generator.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/config/self-signed-pki-generator.ts
@@ -140,10 +140,6 @@ export class SelfSignedPkiGenerator {
         name: "subjectAltName",
         altNames: [
           {
-            type: 6, // URI
-            value: "localhost",
-          },
-          {
             type: 7, // IP
             ip: "127.0.0.1",
           },


### PR DESCRIPTION
The test verifying mTLS support was failing on NodeJS v16
with the error below which was traced back to the fact that
the URL constructor fails with "localhost" as an input at the
verify server identity phase.
This seems like a bug in NodeJS, but maybe it works as intended.

TypeError [ERR_INVALID_URL]: Invalid URL: localhost
    at new NodeError (node:internal/errors:363:5)
    at onParseError (node:internal/url:537:9)
    at new URL (node:internal/url:613:5)
    at node:tls:247:21
    at Array.forEach (<anonymous>)
    at Object.checkServerIdentity (node:tls:243:5)
    at TLSSocket.onConnectSecure (node:_tls_wrap:1551:27)
    at TLSSocket.emit (node:events:365:28)
    at TLSSocket._finishInit (node:_tls_wrap:952:8)
    at TLSWrap.ssl.onhandshakedone (node:_tls_wrap:723:12)

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>