### PR TITLE
test: container shutdown hook prior to starting

### DIFF
--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes.test.ts
@@ -6,7 +6,7 @@ import bodyParser from "body-parser";
 import express from "express";
 import { AddressInfo } from "net";
 
-import { CordaTestLedger } from "@hyperledger/cactus-test-tooling";
+import { Containers, CordaTestLedger } from "@hyperledger/cactus-test-tooling";
 import {
   LogLevelDesc,
   IListenOptions,
@@ -35,6 +35,10 @@ import { K_CACTUS_CORDA_TOTAL_TX_COUNT } from "../../../main/typescript/promethe
 const logLevel: LogLevelDesc = "TRACE";
 
 test("Tests are passing on the JVM side", async (t: Test) => {
+  test.onFailure(async () => {
+    await Containers.logDiagnostics({ logLevel });
+  });
+
   const ledger = new CordaTestLedger({
     imageName: "hyperledger/cactus-corda-4-6-all-in-one-obligation",
     imageVersion: "2021-03-19-feat-686",

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
@@ -2,6 +2,7 @@ import test, { Test } from "tape-promise/tape";
 import { v4 as internalIpV4 } from "internal-ip";
 
 import {
+  Containers,
   CordaTestLedger,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -22,6 +23,10 @@ import {
 
 const testCase = "Tests are passing on the JVM side";
 const logLevel: LogLevelDesc = "TRACE";
+
+test.onFailure(async () => {
+  await Containers.logDiagnostics({ logLevel });
+});
 
 test("BEFORE " + testCase, async (t: Test) => {
   const pruning = pruneDockerAllIfGithubAction({ logLevel });

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts
@@ -58,11 +58,6 @@ test(testCase, async (t: Test) => {
     imageName: "hyperledger/cactus-fabric-all-in-one",
     imageVersion: "2021-03-02-ssh-hotfix",
   });
-  await ledger.start();
-  t.doesNotThrow(() => ledger.getContainer(), "Container is set OK");
-  const ledgerContainer = ledger.getContainer();
-  t.ok(ledgerContainer, "ledgerContainer truthy OK");
-  t.ok(ledgerContainer.id, "ledgerContainer.id truthy OK");
 
   const tearDown = async () => {
     await ledger.stop();
@@ -70,6 +65,12 @@ test(testCase, async (t: Test) => {
   };
 
   test.onFinish(tearDown);
+
+  await ledger.start();
+  t.doesNotThrow(() => ledger.getContainer(), "Container is set OK");
+  const ledgerContainer = ledger.getContainer();
+  t.ok(ledgerContainer, "ledgerContainer truthy OK");
+  t.ok(ledgerContainer.id, "ledgerContainer.id truthy OK");
 
   const connectionProfile = await ledger.getConnectionProfileOrg1();
   t.ok(connectionProfile, "getConnectionProfileOrg1() out truthy OK");

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source-private-data.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source-private-data.test.ts
@@ -10,6 +10,7 @@ import express from "express";
 import bodyParser from "body-parser";
 
 import {
+  Containers,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -49,6 +50,10 @@ test(testCase, async (t: Test) => {
   const channelId = "mychannel";
   const channelName = channelId;
 
+  test.onFailure(async () => {
+    await Containers.logDiagnostics({ logLevel });
+  });
+
   const ledger = new FabricTestLedgerV1({
     emitContainerLogs: true,
     publishAllPorts: true,
@@ -56,14 +61,13 @@ test(testCase, async (t: Test) => {
     imageVersion: "2021-04-20-nodejs",
     envVars: new Map([["FABRIC_VERSION", "2.2.0"]]),
   });
-  await ledger.start();
-
   const tearDown = async () => {
     await ledger.stop();
     await ledger.destroy();
   };
 
   test.onFinish(tearDown);
+  await ledger.start();
 
   const connectionProfile = await ledger.getConnectionProfileOrg1();
 
@@ -359,7 +363,7 @@ test(testCase, async (t: Test) => {
     },
   });
 
- 
+
   */
 
   const getResQuery = await apiClient.runTransactionV1({

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source.test.ts
@@ -10,6 +10,7 @@ import express from "express";
 import bodyParser from "body-parser";
 
 import {
+  Containers,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -49,6 +50,10 @@ test(testCase, async (t: Test) => {
   const channelId = "mychannel";
   const channelName = channelId;
 
+  test.onFailure(async () => {
+    await Containers.logDiagnostics({ logLevel });
+  });
+
   const ledger = new FabricTestLedgerV1({
     emitContainerLogs: true,
     publishAllPorts: true,
@@ -58,7 +63,6 @@ test(testCase, async (t: Test) => {
     imageVersion: "2021-04-20-nodejs",
     envVars: new Map([["FABRIC_VERSION", "2.2.0"]]),
   });
-  await ledger.start();
 
   const tearDown = async () => {
     await ledger.stop();
@@ -66,6 +70,7 @@ test(testCase, async (t: Test) => {
   };
 
   test.onFinish(tearDown);
+  await ledger.start();
 
   const connectionProfile = await ledger.getConnectionProfileOrg1();
   t.ok(connectionProfile, "getConnectionProfileOrg1() out truthy OK");

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts
@@ -10,6 +10,7 @@ import express from "express";
 import bodyParser from "body-parser";
 
 import {
+  Containers,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -50,6 +51,10 @@ test(testCase, async (t: Test) => {
   const channelId = "mychannel";
   const channelName = channelId;
 
+  test.onFailure(async () => {
+    await Containers.logDiagnostics({ logLevel });
+  });
+
   const ledger = new FabricTestLedgerV1({
     emitContainerLogs: true,
     publishAllPorts: true,
@@ -59,14 +64,13 @@ test(testCase, async (t: Test) => {
     imageVersion: "2021-04-20-nodejs",
     envVars: new Map([["FABRIC_VERSION", "2.2.0"]]),
   });
-  await ledger.start();
-
   const tearDown = async () => {
     await ledger.stop();
     await ledger.destroy();
   };
 
   test.onFinish(tearDown);
+  await ledger.start();
 
   const connectionProfile = await ledger.getConnectionProfileOrg1();
   t.ok(connectionProfile, "getConnectionProfileOrg1() out truthy OK");

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-typescript-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-typescript-source.test.ts
@@ -10,6 +10,7 @@ import express from "express";
 import bodyParser from "body-parser";
 
 import {
+  Containers,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -50,6 +51,10 @@ test(testCase, async (t: Test) => {
   const channelId = "mychannel";
   const channelName = channelId;
 
+  test.onFailure(async () => {
+    await Containers.logDiagnostics({ logLevel });
+  });
+
   const ledger = new FabricTestLedgerV1({
     emitContainerLogs: true,
     publishAllPorts: true,
@@ -59,14 +64,13 @@ test(testCase, async (t: Test) => {
     imageVersion: "2021-04-20-nodejs",
     envVars: new Map([["FABRIC_VERSION", "2.2.0"]]),
   });
-  await ledger.start();
-
   const tearDown = async () => {
     await ledger.stop();
     await ledger.destroy();
   };
 
   test.onFinish(tearDown);
+  await ledger.start();
 
   const connectionProfile = await ledger.getConnectionProfileOrg1();
   t.ok(connectionProfile, "getConnectionProfileOrg1() out truthy OK");

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
@@ -8,6 +8,7 @@ import bodyParser from "body-parser";
 import express from "express";
 
 import {
+  Containers,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -54,8 +55,12 @@ test("BEFORE " + testCase, async (t: Test) => {
 test(testCase, async (t: Test) => {
   const logLevel: LogLevelDesc = "TRACE";
 
+  test.onFailure(async () => {
+    await Containers.logDiagnostics({ logLevel });
+  });
+
   const ledger = new FabricTestLedgerV1({
-    emitContainerLogs: false,
+    emitContainerLogs: true,
     publishAllPorts: true,
     logLevel,
     imageName: "hyperledger/cactus-fabric2-all-in-one",
@@ -65,8 +70,7 @@ test(testCase, async (t: Test) => {
       ["CA_VERSION", "1.4.9"],
     ]),
   });
-
-  await ledger.start();
+  t.ok(ledger, "ledger (FabricTestLedgerV1) truthy OK");
 
   const tearDownLedger = async () => {
     await ledger.stop();
@@ -74,6 +78,8 @@ test(testCase, async (t: Test) => {
   };
 
   test.onFinish(tearDownLedger);
+
+  await ledger.start();
 
   const enrollAdminOut = await ledger.enrollAdmin();
   const adminWallet = enrollAdminOut[1];

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-deploy-contract-from-json.test.ts
@@ -50,12 +50,11 @@ test(testCase, async (t: Test) => {
   const containerImageName = "hyperledger/cactus-quorum-all-in-one";
   const ledgerOptions = { containerImageName, containerImageVersion };
   const ledger = new QuorumTestLedger(ledgerOptions);
-  await ledger.start();
-
   test.onFinish(async () => {
     await ledger.stop();
     await ledger.destroy();
   });
+  await ledger.start();
 
   const rpcApiHttpHost = await ledger.getRpcApiHttpHost();
   const quorumGenesisOptions: IQuorumGenesisOptions = await ledger.getGenesisJsObject();

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-invoke-contract.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-invoke-contract.test.ts
@@ -30,12 +30,11 @@ test("Quorum Ledger Connector Plugin", async (t: Test) => {
   const containerImageName = "hyperledger/cactus-quorum-all-in-one";
   const ledgerOptions = { containerImageName, containerImageVersion };
   const ledger = new QuorumTestLedger(ledgerOptions);
-  await ledger.start();
-
   test.onFinish(async () => {
     await ledger.stop();
     await ledger.destroy();
   });
+  await ledger.start();
 
   const rpcApiHttpHost = await ledger.getRpcApiHttpHost();
   const quorumGenesisOptions: IQuorumGenesisOptions = await ledger.getGenesisJsObject();

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-deploy-contract-from-json.test.ts
@@ -50,12 +50,12 @@ test(testCase, async (t: Test) => {
   const containerImageVersion = "2021-05-03-quorum-v21.4.1";
   const ledgerOptions = { containerImageName, containerImageVersion };
   const ledger = new QuorumTestLedger(ledgerOptions);
-  await ledger.start();
 
   test.onFinish(async () => {
     await ledger.stop();
     await ledger.destroy();
   });
+  await ledger.start();
 
   const rpcApiHttpHost = await ledger.getRpcApiHttpHost();
   const quorumGenesisOptions: IQuorumGenesisOptions = await ledger.getGenesisJsObject();

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-invoke-contract.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-invoke-contract.test.ts
@@ -30,12 +30,11 @@ test("Quorum Ledger Connector Plugin", async (t: Test) => {
   const containerImageVersion = "2021-05-03-quorum-v21.4.1";
   const ledgerOptions = { containerImageName, containerImageVersion };
   const ledger = new QuorumTestLedger(ledgerOptions);
-  await ledger.start();
-
   test.onFinish(async () => {
     await ledger.stop();
     await ledger.destroy();
   });
+  await ledger.start();
 
   const rpcApiHttpHost = await ledger.getRpcApiHttpHost();
   const quorumGenesisOptions: IQuorumGenesisOptions = await ledger.getGenesisJsObject();

--- a/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/deploy-contract-from-json-xdai.test.ts
+++ b/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/deploy-contract-from-json-xdai.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../main/typescript/public-api";
 import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory";
 import {
+  Containers,
   K_DEV_WHALE_ACCOUNT_PRIVATE_KEY,
   K_DEV_WHALE_ACCOUNT_PUBLIC_KEY,
   OpenEthereumTestLedger,
@@ -42,13 +43,17 @@ test("BEFORE " + testCase, async (t: Test) => {
 });
 
 test(testCase, async (t: Test) => {
-  const ledger = new OpenEthereumTestLedger({});
-  await ledger.start();
+  test.onFailure(async () => {
+    await Containers.logDiagnostics({ logLevel });
+  });
+
+  const ledger = new OpenEthereumTestLedger({ logLevel });
 
   test.onFinish(async () => {
     await ledger.stop();
     await ledger.destroy();
   });
+  await ledger.start();
 
   const rpcApiHttpHost = await ledger.getRpcApiHttpHost();
 


### PR DESCRIPTION
## Dependencies

Depends on #993 

## Commit to review

Author: Peter Somogyvari <peter.somogyvari@accenture.com>
Committer: Peter Somogyvari <peter.somogyvari@accenture.com>
Date: Fri May 28 2021 00:04:09 GMT-0700 (Pacific Daylight Time) 

test: container shutdown hook prior to starting

Figured out from the additional logs we recently added that
the reason why the Fabric 1.4.x AIO image fails to start for
the 1.4.x tests is because a previously ran test (2.x)
crashes and never stops it's container which then ends up
hogging the ports which cannot be randomized for the
Fabric AIO images yet.

So, adding more logging here and also ensuring that the
test finish hooks that are responsible for shutting down
the containers are registered prior to calling
the start method on the test container classes so that
if the start method hangs the container will still go
away as it should.

This is what gave me the clue from the CI logs:

    # BEFORE runs tx on a Fabric v2.2.0 ledger
    Detected current process to be running inside a Github Action. Pruning all docker resources...
    [2021-05-28T01:23:31.310Z] DEBUG (Containers#pruneDockerResources()): Finished pruning all docker resources. Outcome: {
      containers: { ContainersDeleted: null, SpaceReclaimed: 0 },
      images: { ImagesDeleted: null, SpaceReclaimed: 0 },
      networks: { NetworksDeleted: null },
      volumes: {
        VolumesDeleted: [
          '10afa6c6071a4e362324ec7eaabedbbee088dedc0b0e182880ca4ccc6430b998',
          [length]: 1
        ],
        SpaceReclaimed: 1915254089
      }
    }
    ok 1 Pruning didn't throw OK
    # runs tx on a Fabric v2.2.0 ledger
    # test count(1) != plan(null)
    # failed 1 test
not ok 62 - packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts # time=3600276.779ms

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>