### PR TITLE
test: add logLevel parameter to Fabric AIO ctor calls

### DIFF
--- a/examples/cactus-example-supply-chain-backend/src/main/typescript/infrastructure/supply-chain-app-dummy-infrastructure.ts
+++ b/examples/cactus-example-supply-chain-backend/src/main/typescript/infrastructure/supply-chain-app-dummy-infrastructure.ts
@@ -109,6 +109,7 @@ export class SupplyChainAppDummyInfrastructure {
       publishAllPorts: true,
       imageName: "hyperledger/cactus-fabric-all-in-one",
       imageVersion: "2021-03-02-ssh-hotfix",
+      logLevel: level,
     });
 
     if (this.options.keychain) {

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source-private-data.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source-private-data.test.ts
@@ -61,6 +61,7 @@ test(testCase, async (t: Test) => {
     imageName: "hyperledger/cactus-fabric2-all-in-one",
     imageVersion: "2021-04-20-nodejs",
     envVars: new Map([["FABRIC_VERSION", "2.2.0"]]),
+    logLevel,
   });
   const tearDown = async () => {
     await ledger.stop();

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source.test.ts
@@ -63,6 +63,7 @@ test(testCase, async (t: Test) => {
     imageName: "hyperledger/cactus-fabric2-all-in-one",
     imageVersion: "2021-04-20-nodejs",
     envVars: new Map([["FABRIC_VERSION", "2.2.0"]]),
+    logLevel,
   });
 
   const tearDown = async () => {

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts
@@ -64,6 +64,7 @@ test(testCase, async (t: Test) => {
     imageName: "hyperledger/cactus-fabric2-all-in-one",
     imageVersion: "2021-04-20-nodejs",
     envVars: new Map([["FABRIC_VERSION", "2.2.0"]]),
+    logLevel,
   });
   const tearDown = async () => {
     await ledger.stop();

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-typescript-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-typescript-source.test.ts
@@ -64,6 +64,7 @@ test(testCase, async (t: Test) => {
     imageName: "hyperledger/cactus-fabric2-all-in-one",
     imageVersion: "2021-04-20-nodejs",
     envVars: new Map([["FABRIC_VERSION", "2.2.0"]]),
+    logLevel,
   });
   const tearDown = async () => {
     await ledger.stop();


### PR DESCRIPTION
This is another step taken to win the epic battle that we have been
waging against a particularly nasty test flake that is plaguing the
Fabric tests that use the AIO ledger.

This will make the test output much more verbose, but there's no other
way around to making sure that we can narrow down the root cause of the
flake to a specific issue.