### PR TITLE
test(connector-fabric): fix v1.4.8 golang chaincode test

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts
@@ -55,6 +55,7 @@ test(testCase, async (t: Test) => {
   });
   const ledger = new FabricTestLedgerV1({
     emitContainerLogs: true,
+    logLevel,
     publishAllPorts: true,
     // imageName: "faio14x",
     // imageVersion: "latest",
@@ -179,8 +180,26 @@ test(testCase, async (t: Test) => {
     moduleName: "hello-world",
     targetOrganizations: [org1Env, org2Env],
     pinnedDeps: [
+      "github.com/Knetic/govaluate@v3.0.0+incompatible",
+      "github.com/Shopify/sarama@v1.27.0",
+      "github.com/fsouza/go-dockerclient@v1.6.5",
+      "github.com/grpc-ecosystem/go-grpc-middleware@v1.2.1",
+      "github.com/hashicorp/go-version@v1.2.1",
       "github.com/hyperledger/fabric@v1.4.8",
+      "github.com/hyperledger/fabric-amcl@v0.0.0-20200424173818-327c9e2cf77a",
+      "github.com/miekg/pkcs11@v1.0.3",
+      "github.com/mitchellh/mapstructure@v1.3.3",
+      "github.com/onsi/ginkgo@v1.14.1",
+      "github.com/onsi/gomega@v1.10.2",
+      "github.com/op/go-logging@v0.0.0-20160315200505-970db520ece7",
+      "github.com/pkg/errors@v0.9.1",
+      "github.com/spf13/viper@v1.7.1",
+      "github.com/stretchr/testify@v1.6.1",
+      "github.com/sykesm/zap-logfmt@v0.0.3",
+      "go.uber.org/zap@v1.16.0",
+      "golang.org/x/crypto@v0.0.0-20200820211705-5c72a883971a",
       "golang.org/x/net@v0.0.0-20210503060351-7fd8e65b6420",
+      "google.golang.org/grpc@v1.31.1",
     ],
   });
 


### PR DESCRIPTION
Pinned all the hello world chaincode's dependencies to exact versions
that are known to have worked in the past for builds. We needed this
because the 1.13 go version of the Fabric CLI container could no
longer build (tidy+vendor) the dependencies that were built with the
newer versions of go such as 1.16 and 1.17.

More info about the root cause can be read here:
https://github.com/golang/go/issues/40067

By locking the dependencies versions to older ones we we ensured that
the older go installation of the Fabric CLI container does not fail.

The known-to-be-working dependency versions are coming from
packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/hello-world-contract-fabric-v14/hello-world-contract-go-mod.ts

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>