### PR TITLE
build(dev-container): add GVM (go version manager)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,6 +31,11 @@ RUN apt-get update \
 RUN apt-get update \
     && apt-get install python3-pip -y
 
+# Install GVM (Go Version Manager) dependencies
+RUN apt-get update \
+    && apt-get -y install curl git mercurial make binutils bison gcc build-essential
+
+
 VOLUME [ "/var/lib/docker" ]
 
 # Setting the ENTRYPOINT to docker-init.sh will start up the Docker Engine 
@@ -45,9 +50,18 @@ CMD [ "sleep", "infinity" ]
 
 COPY post-create-commands.sh /home/vscode/bin/
 
-# Installing Node Version Manager (nvm) and Node v16
 USER vscode
 SHELL ["/bin/bash", "--login", "-i", "-c"]
+
+# Install GVM  (Go Version Manager)
+RUN ["/bin/bash", "-c", "bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/1.0.22/binscripts/gvm-installer)"]
+RUN source /home/vscode/.gvm/scripts/gvm
+
+# Install Go
+RUN gvm install go1.16.5 -B
+RUN gvm use go1.16.5 --default
+
+# Installing Node Version Manager (nvm)
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
 RUN source /home/vscode/.bashrc && nvm install 16.3.0
 SHELL ["/bin/bash", "--login", "-c"]


### PR DESCRIPTION
Purpose: Enable the possibility to test/build chain code modules within
the dev container in the future for development/debugging
purposes.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>