### PR TITLE
test: fixed race in besu, quorum test ledger teardown logic

### DIFF
--- a/packages/cactus-test-tooling/src/test/typescript/integration/besu/besu-test-ledger/constructor-validates-options.ts
+++ b/packages/cactus-test-tooling/src/test/typescript/integration/besu/besu-test-ledger/constructor-validates-options.ts
@@ -24,8 +24,10 @@ tap.test(
 
 tap.test("starts/stops/destroys a docker container", async (assert: any) => {
   const besuTestLedger = new BesuTestLedger();
-  assert.tearDown(() => besuTestLedger.stop());
-  assert.tearDown(() => besuTestLedger.destroy());
+  assert.tearDown(async () => {
+    await besuTestLedger.stop();
+    await besuTestLedger.destroy();
+  });
 
   const container: Container = await besuTestLedger.start();
   assert.ok(container);

--- a/packages/cactus-test-tooling/src/test/typescript/integration/quorum/quorum-test-ledger/constructor-validates-options.ts
+++ b/packages/cactus-test-tooling/src/test/typescript/integration/quorum/quorum-test-ledger/constructor-validates-options.ts
@@ -24,8 +24,11 @@ tap.test(
 
 tap.test("starts/stops/destroys a docker container", async (assert: any) => {
   const ledger = new QuorumTestLedger();
-  assert.tearDown(() => ledger.stop());
-  assert.tearDown(() => ledger.destroy());
+  assert.tearDown(async () => {
+    await ledger.stop();
+    await ledger.destroy();
+  });
+
   const container: Container = await ledger.start();
   assert.ok(container);
   const ipAddress: string = await ledger.getContainerIpAddress();


### PR DESCRIPTION
The tests were asynchronously calling the stop and the destroy methods
which sometimes randomly crashed the test case after it successfully
passed the assertions.

Putting both stop and destroy calls in the same function and await-ing
for them one by one guarantees that this does not happen because
destroy will not get called until stop has finished.

Fixes #1052