### PR TITLE
test: call pruneDockerAllIfGithubAction in test.onFinish handler

### DIFF
--- a/examples/cactus-example-carbon-accounting-backend/src/test/typescript/integration/admin-enroll-v1-endpoint.test.ts
+++ b/examples/cactus-example-carbon-accounting-backend/src/test/typescript/integration/admin-enroll-v1-endpoint.test.ts
@@ -97,6 +97,7 @@ test(testCase, async (t: Test) => {
   const carbonAccountingApp = new CarbonAccountingApp(appOptions);
   test.onFinish(async () => {
     await carbonAccountingApp.stop();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   try {
@@ -165,11 +166,5 @@ test(testCase, async (t: Test) => {
     t.notok(out.response.data.success, "out.response.data.success falsy OK");
   }
 
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
   t.end();
 });

--- a/examples/cactus-example-supply-chain-backend/src/test/typescript/integration/supply-chain-backend-api-calls.test.ts
+++ b/examples/cactus-example-supply-chain-backend/src/test/typescript/integration/supply-chain-backend-api-calls.test.ts
@@ -49,7 +49,10 @@ test("Supply chain backend API calls can be executed", async (t: Test) => {
     disableSignalHandlers: true,
   };
   const app = new SupplyChainApp(appOptions);
-  test.onFinish(() => app.stop());
+  test.onFinish(async () => {
+    await app.stop();
+    await pruneDockerAllIfGithubAction({ logLevel });
+  });
 
   // Node A => Besu
   // Node B => Quorum
@@ -127,11 +130,5 @@ test("Supply chain backend API calls can be executed", async (t: Test) => {
     "listShipmentRes status < 300 truthy OK",
   );
 
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/examples/cactus-example-supply-chain-backend/src/test/typescript/integration/supply-chain-cli-via-npm-script.test.ts
+++ b/examples/cactus-example-supply-chain-backend/src/test/typescript/integration/supply-chain-cli-via-npm-script.test.ts
@@ -17,6 +17,7 @@ test("BEFORE " + testCase, async (t: Test) => {
 
 test("Supply chain backend API calls can be executed", async (t: Test) => {
   t.ok(publicApi, "Public API of the package imported OK");
+  test.onFinish(async () => await pruneDockerAllIfGithubAction({ logLevel }));
 
   const projectRoot = path.join(__dirname, "../../../../../../");
 
@@ -61,11 +62,5 @@ test("Supply chain backend API calls can be executed", async (t: Test) => {
 
   await t.doesNotReject(childProcessPromise, "childProcessPromise resolves OK");
 
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/deploy-contract-from-json.test.ts
@@ -49,6 +49,7 @@ test(testCase, async (t: Test) => {
   test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
@@ -487,11 +488,5 @@ test(testCase, async (t: Test) => {
     t2.end();
   });
 
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
   t.end();
 });

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
@@ -46,6 +46,7 @@ test(testCase, async (t: Test) => {
   test.onFinish(async () => {
     await ledger.stop();
     await ledger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
   const ledgerContainer = await ledger.start();
   t.ok(ledgerContainer, "CordaTestLedger container truthy post-start() OK");
@@ -399,11 +400,5 @@ test(testCase, async (t: Test) => {
   t.ok(res, "InvokeContractV1Request truthy OK");
   t.equal(res.status, 200, "InvokeContractV1Request status code === 200 OK");
 
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
   t.end();
 });

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts
@@ -66,6 +66,7 @@ test(testCase, async (t: Test) => {
   const tearDown = async () => {
     await ledger.stop();
     await ledger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   };
 
   test.onFinish(tearDown);
@@ -258,11 +259,5 @@ test(testCase, async (t: Test) => {
   t.true(getRes.status > 199 && setRes.status < 300, "getRes status 2xx OK");
   t.comment(`HelloWorld.get() ResponseBody: ${JSON.stringify(getRes.data)}`);
   t.equal(getRes.data.functionOutput, testValue, "get returns UUID OK");
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
   t.end();
 });

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts
@@ -72,6 +72,7 @@ test(testCase, async (t: Test) => {
   const tearDownLedger = async () => {
     await ledger.stop();
     await ledger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   };
   test.onFinish(tearDownLedger);
 
@@ -222,11 +223,5 @@ test(testCase, async (t: Test) => {
       "Total Transaction Count of 3 recorded as expected. RESULT OK",
     );
   }
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
   t.end();
 });

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source-private-data.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source-private-data.test.ts
@@ -66,6 +66,7 @@ test(testCase, async (t: Test) => {
   const tearDown = async () => {
     await ledger.stop();
     await ledger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   };
 
   test.onFinish(tearDown);
@@ -395,11 +396,5 @@ test(testCase, async (t: Test) => {
     `GetAssetByRange ResponseBody: ${JSON.stringify(getResQuery.data)}`,
   );
 
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source.test.ts
@@ -69,6 +69,7 @@ test(testCase, async (t: Test) => {
   const tearDown = async () => {
     await ledger.stop();
     await ledger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   };
 
   test.onFinish(tearDown);
@@ -325,11 +326,5 @@ test(testCase, async (t: Test) => {
   t.ok(asset.owner, "asset.owner truthy OK");
   t.equal(asset.owner, assetOwner, "asset.owner === assetOwner OK");
 
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
   t.end();
 });

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts
@@ -69,6 +69,7 @@ test(testCase, async (t: Test) => {
   const tearDown = async () => {
     await ledger.stop();
     await ledger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   };
 
   test.onFinish(tearDown);
@@ -334,11 +335,5 @@ test(testCase, async (t: Test) => {
   t.ok(asset.Owner, "asset.Owner truthy OK");
   t.equal(asset.Owner, assetOwner, "asset.owner === assetOwner OK");
 
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
   t.end();
 });

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-typescript-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-typescript-source.test.ts
@@ -69,6 +69,7 @@ test(testCase, async (t: Test) => {
   const tearDown = async () => {
     await ledger.stop();
     await ledger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   };
 
   test.onFinish(tearDown);
@@ -369,11 +370,5 @@ test(testCase, async (t: Test) => {
   t.ok(asset.Owner, "asset.Owner truthy OK");
   t.equal(asset.Owner, assetOwner, "asset.owner === assetOwner OK");
 
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
   t.end();
 });

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
@@ -76,6 +76,7 @@ test(testCase, async (t: Test) => {
   const tearDownLedger = async () => {
     await ledger.stop();
     await ledger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   };
 
   test.onFinish(tearDownLedger);
@@ -229,11 +230,5 @@ test(testCase, async (t: Test) => {
       "Total Transaction Count of 3 recorded as expected. RESULT OK",
     );
   }
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
   t.end();
 });

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-deploy-contract-from-json.test.ts
@@ -54,6 +54,7 @@ test(testCase, async (t: Test) => {
   test.onFinish(async () => {
     await ledger.stop();
     await ledger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
   await ledger.start();
 
@@ -471,11 +472,5 @@ test(testCase, async (t: Test) => {
     t2.end();
   });
 
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
   t.end();
 });

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-deploy-contract-from-json.test.ts
@@ -55,6 +55,7 @@ test(testCase, async (t: Test) => {
   test.onFinish(async () => {
     await ledger.stop();
     await ledger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
   await ledger.start();
 
@@ -472,11 +473,5 @@ test(testCase, async (t: Test) => {
     t2.end();
   });
 
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
   t.end();
 });

--- a/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/deploy-contract-from-json-xdai.test.ts
+++ b/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/deploy-contract-from-json-xdai.test.ts
@@ -52,6 +52,7 @@ test(testCase, async (t: Test) => {
   test.onFinish(async () => {
     await ledger.stop();
     await ledger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
   await ledger.start();
 
@@ -438,11 +439,5 @@ test(testCase, async (t: Test) => {
     t2.end();
   });
 
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
   t.end();
 });

--- a/packages/cactus-test-api-client/src/test/typescript/integration/api-client-routing-node-to-node.test.ts
+++ b/packages/cactus-test-api-client/src/test/typescript/integration/api-client-routing-node-to-node.test.ts
@@ -139,6 +139,7 @@ test(testCase, async (t: Test) => {
     test.onFinish(async () => {
       await quorumTestLedger1.stop();
       await quorumTestLedger1.destroy();
+      await pruneDockerAllIfGithubAction({ logLevel });
     });
     const rpcApiHttpHost1 = await quorumTestLedger1.getRpcApiHttpHost();
 
@@ -296,11 +297,5 @@ test(testCase, async (t: Test) => {
     t2.end();
   });
 
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/get-single-status-endpoint-invalid.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/get-single-status-endpoint-invalid.test.ts
@@ -63,9 +63,10 @@ test(testCase, async (t: Test) => {
   t.comment("Starting Besu Test Ledger");
   const besuTestLedger = new BesuTestLedger({ logLevel });
 
-  test.onFailure(async () => {
+  test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
   await besuTestLedger.start();
 
@@ -236,14 +237,5 @@ test(testCase, async (t: Test) => {
   );
   t.equal(res.status, 200, "response status is 200 OK");
   t.equal(res.data, 0, "the contract status is 0 - INVALID");
-  await besuTestLedger.stop();
-  await besuTestLedger.destroy();
-
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/get-single-status-endpoint.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/get-single-status-endpoint.test.ts
@@ -63,9 +63,10 @@ test(testCase, async (t: Test) => {
   t.comment("Starting Besu Test Ledger");
   const besuTestLedger = new BesuTestLedger({ logLevel });
 
-  test.onFailure(async () => {
+  test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   await besuTestLedger.start();
@@ -272,13 +273,5 @@ test(testCase, async (t: Test) => {
   );
   t.equal(res.status, 200, "response status is 200 OK");
   t.equal(res.data, 1, "the contract status is 1 - Active");
-  await besuTestLedger.stop();
-  await besuTestLedger.destroy();
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/get-status-endpoint.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/get-status-endpoint.test.ts
@@ -67,6 +67,7 @@ test(testCase, async (t: Test) => {
   test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
@@ -449,11 +450,5 @@ test("Test get invalid id status", async (t: Test) => {
   );
   t.equal(res.status, 200, "response status is 200 OK");
   t.equal(res.data[0], "0", "the contract status is 0 - INVALID");
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/initialize-endpoint.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/initialize-endpoint.test.ts
@@ -62,6 +62,7 @@ test(testCase, async (t: Test) => {
     await besuTestLedger.stop();
     t.comment("Ledger #1 destroying...");
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
@@ -232,11 +233,5 @@ test("Test initialize function with invalid params", async (t: Test) => {
   } catch (error) {
     t.equal(error.response.status, 400, "response status is 400");
   }
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/new-contract-endpoint.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/new-contract-endpoint.test.ts
@@ -66,6 +66,7 @@ test(testCase, async (t: Test) => {
   test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
@@ -394,11 +395,5 @@ test("Test new invalid contract with 0 inputAmount token for HTLC", async (t: Te
   } catch (error) {
     t.equal(error.response.status, 400, "response status is 400");
   }
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/refund-endpoint.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/refund-endpoint.test.ts
@@ -75,6 +75,7 @@ test(testCase, async (t: Test) => {
   test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
@@ -582,11 +583,5 @@ test("Test invalid refund with invalid time", async (t: Test) => {
     params: [firstHighNetWorthAccount],
   });
   t.equal(responseFinalBalance.callOutput, "90", "balance of account is 90 OK");
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/withdraw-endpoint.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/withdraw-endpoint.test.ts
@@ -75,6 +75,7 @@ test(testCase, async (t: Test) => {
   test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
@@ -500,11 +501,5 @@ test("Test invalid withdraw with invalid id", async (t: Test) => {
     params: [receiver],
   });
   t.equal(responseFinalBalance.callOutput, "0", "balance of account is 0 OK");
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-single-status-endpoint-invalid.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-single-status-endpoint-invalid.test.ts
@@ -64,9 +64,10 @@ test(testCase, async (t: Test) => {
   t.comment("Starting Besu Test Ledger");
   const besuTestLedger = new BesuTestLedger({ logLevel });
 
-  test.onFailure(async () => {
+  test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   await besuTestLedger.start();
@@ -216,13 +217,5 @@ test(testCase, async (t: Test) => {
   } catch (e) {
     t.equal(e.response.status, 500);
   }
-  await besuTestLedger.stop();
-  await besuTestLedger.destroy();
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-single-status-endpoint.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-single-status-endpoint.test.ts
@@ -59,9 +59,10 @@ test(testCase, async (t: Test) => {
   t.comment("Starting Besu Test Ledger");
   const besuTestLedger = new BesuTestLedger({ logLevel });
 
-  test.onFailure(async () => {
+  test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   await besuTestLedger.start();
@@ -223,13 +224,5 @@ test(testCase, async (t: Test) => {
   );
   t.equal(res.status, 200);
   t.equal(res.data, 1, "the contract status is 1 - Active");
-  await besuTestLedger.stop();
-  await besuTestLedger.destroy();
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-status-endpoint-invalid.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-status-endpoint-invalid.test.ts
@@ -59,9 +59,10 @@ test(testCase, async (t: Test) => {
   t.comment("Starting Besu Test Ledger");
   const besuTestLedger = new BesuTestLedger({ logLevel });
 
-  test.onFailure(async () => {
+  test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   await besuTestLedger.start();
@@ -226,13 +227,5 @@ test(testCase, async (t: Test) => {
   } catch (e) {
     t.equal(e.response.status, 500);
   }
-  await besuTestLedger.stop();
-  await besuTestLedger.destroy();
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-status-endpoint.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-status-endpoint.test.ts
@@ -59,9 +59,10 @@ test(testCase, async (t: Test) => {
   t.comment("Starting Besu Test Ledger");
   const besuTestLedger = new BesuTestLedger({ logLevel });
 
-  test.onFailure(async () => {
+  test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   await besuTestLedger.start();
@@ -223,13 +224,5 @@ test(testCase, async (t: Test) => {
   );
   t.equal(res.status, 200, "response status is 200 OK");
   t.equal(res.data[0], "1", "the contract status is 1 - Active");
-  await besuTestLedger.stop();
-  await besuTestLedger.destroy();
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/initialize-endpoint-invalid.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/initialize-endpoint-invalid.test.ts
@@ -54,9 +54,10 @@ test(testCase, async (t: Test) => {
   t.comment("Starting Besu Test Ledger");
   const besuTestLedger = new BesuTestLedger({ logLevel });
 
-  test.onFailure(async () => {
+  test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   await besuTestLedger.start();
@@ -137,13 +138,5 @@ test(testCase, async (t: Test) => {
   } catch (error) {
     t.ok(error, "pluginHtlc.initialize() error is truthy OK");
   }
-  await besuTestLedger.stop();
-  await besuTestLedger.destroy();
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/initialize-endpoint.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/initialize-endpoint.test.ts
@@ -54,9 +54,10 @@ test(testCase, async (t: Test) => {
   t.comment("Starting Besu Test Ledger");
   const besuTestLedger = new BesuTestLedger({ logLevel });
 
-  test.onFailure(async () => {
+  test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   await besuTestLedger.start();
@@ -137,13 +138,5 @@ test(testCase, async (t: Test) => {
     deployOut.transactionReceipt.contractAddress,
     "pluginHtlc.initialize() output.transactionReceipt.contractAddress is truthy OK",
   );
-  await besuTestLedger.stop();
-  await besuTestLedger.destroy();
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/new-contract-endpoint-invalid.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/new-contract-endpoint-invalid.test.ts
@@ -58,9 +58,10 @@ test(testCase, async (t: Test) => {
   t.comment("Starting Besu Test Ledger");
   const besuTestLedger = new BesuTestLedger({ logLevel });
 
-  test.onFailure(async () => {
+  test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   await besuTestLedger.start();
@@ -188,13 +189,5 @@ test(testCase, async (t: Test) => {
   } catch (error) {
     t.equal(error.response.status, 500, "response status is 500");
   }
-  await besuTestLedger.stop();
-  await besuTestLedger.destroy();
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/new-contract-endpoint.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/new-contract-endpoint.test.ts
@@ -58,9 +58,10 @@ test(testCase, async (t: Test) => {
   t.comment("Starting Besu Test Ledger");
   const besuTestLedger = new BesuTestLedger({ logLevel });
 
-  test.onFailure(async () => {
+  test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   await besuTestLedger.start();
@@ -184,13 +185,5 @@ test(testCase, async (t: Test) => {
   const resp = await api.newContract(bodyObj);
   t.ok(resp, "response newContract is OK");
   t.equal(resp.status, 200, "response status newContract is OK");
-  await besuTestLedger.stop();
-  await besuTestLedger.destroy();
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/refund-endpoint-invalid.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/refund-endpoint-invalid.test.ts
@@ -59,9 +59,10 @@ test(testCase, async (t: Test) => {
   t.comment("Starting Besu Test Ledger");
   const besuTestLedger = new BesuTestLedger({ logLevel });
 
-  test.onFailure(async () => {
+  test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   await besuTestLedger.start();
@@ -228,13 +229,5 @@ test(testCase, async (t: Test) => {
   } catch (error) {
     t.equal(error.response.status, 500, "response status is 500");
   }
-  await besuTestLedger.stop();
-  await besuTestLedger.destroy();
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/refund-endpoint.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/refund-endpoint.test.ts
@@ -63,9 +63,10 @@ test(testCase, async (t: Test) => {
   t.comment("Starting Besu Test Ledger");
   const besuTestLedger = new BesuTestLedger({ logLevel });
 
-  test.onFailure(async () => {
+  test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   await besuTestLedger.start();
@@ -254,13 +255,5 @@ test(testCase, async (t: Test) => {
   );
   t.equal(res.status, 200);
   t.equal(res.data, 2, "the contract status is Refunded");
-  await besuTestLedger.stop();
-  await besuTestLedger.destroy();
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/withdraw-endpoint-invalid.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/withdraw-endpoint-invalid.test.ts
@@ -59,9 +59,10 @@ test(testCase, async (t: Test) => {
   t.comment("Starting Besu Test Ledger");
   const besuTestLedger = new BesuTestLedger({ logLevel });
 
-  test.onFailure(async () => {
+  test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   await besuTestLedger.start();
@@ -217,13 +218,5 @@ test(testCase, async (t: Test) => {
   } catch (error) {
     t.equal(error.response.status, 500, "response status is 500");
   }
-  await besuTestLedger.stop();
-  await besuTestLedger.destroy();
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/withdraw-endpoint.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/withdraw-endpoint.test.ts
@@ -60,9 +60,10 @@ test(testCase, async (t: Test) => {
   t.comment("Starting Besu Test Ledger");
   const besuTestLedger = new BesuTestLedger({ logLevel });
 
-  test.onFailure(async () => {
+  test.onFinish(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   await besuTestLedger.start();
@@ -239,13 +240,5 @@ test(testCase, async (t: Test) => {
   );
   t.equal(resStatus.status, 200, "response status is 200 OK");
   t.equal(resStatus.data, 3, "the contract status is Withdrawn");
-  await besuTestLedger.stop();
-  await besuTestLedger.destroy();
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
   t.end();
 });

--- a/packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/sign-transaction-endpoint.test.ts
+++ b/packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/sign-transaction-endpoint.test.ts
@@ -79,6 +79,7 @@ test(testCase, async (t: Test) => {
   const tearDown = async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   };
 
   test.onFinish(tearDown);
@@ -191,10 +192,4 @@ test(testCase, async (t: Test) => {
       "Response text are equal",
     );
   }
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
-  t.end();
 });

--- a/packages/cactus-test-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/deploy-contract-via-web-service.test.ts
+++ b/packages/cactus-test-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/deploy-contract-via-web-service.test.ts
@@ -57,6 +57,7 @@ test(testCase, async (t: Test) => {
   test.onFinish(async () => {
     await ledger.stop();
     await ledger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
   });
 
   // 2. Start the actual ledger
@@ -266,11 +267,5 @@ test(testCase, async (t: Test) => {
     );
   });
 
-  t.end();
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
   t.end();
 });

--- a/packages/cactus-test-tooling/package-lock.json
+++ b/packages/cactus-test-tooling/package-lock.json
@@ -12,6 +12,7 @@
 				"axios": "0.21.1",
 				"compare-versions": "3.6.0",
 				"dockerode": "3.2.0",
+				"execa": "5.1.1",
 				"fabric-client": "1.4.14",
 				"fabric-network": "1.4.14",
 				"fs-extra": "9.0.0",
@@ -23,6 +24,7 @@
 				"p-retry": "4.4.0",
 				"run-time-error": "1.4.0",
 				"tar-stream": "2.1.2",
+				"temp": "0.9.4",
 				"typescript-optional": "2.0.1",
 				"web3": "1.2.7",
 				"web3-core": "1.3.4"
@@ -1669,9 +1671,9 @@
 			}
 		},
 		"node_modules/execa": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
-			"integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
 			"dependencies": {
 				"cross-spawn": "^7.0.3",
 				"get-stream": "^6.0.0",
@@ -1685,6 +1687,9 @@
 			},
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
 			}
 		},
 		"node_modules/execa/node_modules/get-stream": {
@@ -7944,9 +7949,9 @@
 			}
 		},
 		"execa": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
-			"integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
 			"requires": {
 				"cross-spawn": "^7.0.3",
 				"get-stream": "^6.0.0",

--- a/packages/cactus-test-tooling/package.json
+++ b/packages/cactus-test-tooling/package.json
@@ -85,6 +85,7 @@
     "axios": "0.21.1",
     "compare-versions": "3.6.0",
     "dockerode": "3.2.0",
+    "execa": "5.1.1",
     "fabric-client": "1.4.14",
     "fabric-network": "1.4.14",
     "fs-extra": "9.0.0",
@@ -96,6 +97,7 @@
     "p-retry": "4.4.0",
     "run-time-error": "1.4.0",
     "tar-stream": "2.1.2",
+    "temp": "0.9.4",
     "typescript-optional": "2.0.1",
     "web3": "1.2.7",
     "web3-core": "1.3.4"

--- a/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
@@ -3,6 +3,7 @@ import { Stream } from "stream";
 import { IncomingMessage } from "http";
 import { Container, ContainerInfo } from "dockerode";
 import Dockerode from "dockerode";
+import execa from "execa";
 import tar from "tar-stream";
 import fs from "fs-extra";
 import pRetry from "p-retry";
@@ -305,12 +306,17 @@ export class Containers {
   public static async exec(
     container: Container,
     cmd: string[],
+    timeoutMs = 300000, // 5 minutes default timeout
+    logLevel: LogLevelDesc = "INFO",
   ): Promise<string> {
     const fnTag = "Containers#exec()";
     Checks.truthy(container, `${fnTag} container`);
     Checks.truthy(cmd, `${fnTag} cmd`);
     Checks.truthy(Array.isArray(cmd), `${fnTag} isArray(cmd)`);
     Checks.truthy(cmd.length > 0, `${fnTag} path non empty array`);
+    Checks.nonBlankString(logLevel, `${fnTag} logLevel`);
+
+    const log = LoggerProvider.getOrCreate({ label: fnTag, level: logLevel });
 
     const exec = await container.exec({
       Cmd: cmd,
@@ -320,15 +326,29 @@ export class Containers {
     });
 
     return new Promise((resolve, reject) => {
+      log.debug(`Calling Exec Start on Docker Engine API...`);
+
       exec.start({ Tty: true }, (err: any, stream: Stream) => {
+        const timeoutIntervalId = setInterval(() => {
+          reject(new Error(`Docker Exec timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+
         if (err) {
-          return reject(err);
+          clearInterval(timeoutIntervalId);
+          const errorMessage = `Docker Engine API Exec Start Failed:`;
+          log.error(errorMessage, err);
+          return reject(new RuntimeError(errorMessage, err));
         }
+        log.debug(`Obtained output stream of Exec Start OK`);
         let output = "";
         stream.on("data", (data: Buffer) => {
           output += data.toString("utf-8");
         });
-        stream.on("end", () => resolve(output));
+        stream.on("end", () => {
+          clearInterval(timeoutIntervalId);
+          log.debug(`Finished Docker Exec OK. Output: ${output.length} bytes`);
+          resolve(output);
+        });
       });
     });
   }
@@ -525,15 +545,17 @@ export class Containers {
     let volumes;
     let images;
     let networks;
+    log.debug(`Pruning all docker resources...`);
+    try {
+      const { all } = await execa("docker", ["system", "df"], { all: true });
+      log.debug(all);
+    } catch (ex) {
+      log.info(`Ignoring failure of docker system df.`, ex);
+    }
     try {
       containers = await docker.pruneContainers();
     } catch (ex) {
       log.warn(`Failed to prune docker containers: `, ex);
-    }
-    try {
-      volumes = await docker.pruneVolumes();
-    } catch (ex) {
-      log.warn(`Failed to prune docker volumes: `, ex);
     }
     try {
       images = await docker.pruneImages();
@@ -541,11 +563,38 @@ export class Containers {
       log.warn(`Failed to prune docker images: `, ex);
     }
     try {
+      volumes = await docker.pruneVolumes();
+    } catch (ex) {
+      log.warn(`Failed to prune docker volumes: `, ex);
+    }
+    try {
       networks = await docker.pruneNetworks();
     } catch (ex) {
       log.warn(`Failed to prune docker networks: `, ex);
     }
 
+    const existingImages = await docker.listImages();
+    const imageIds = existingImages.map((it) => it.Id);
+    log.debug(`Clearing ${imageIds.length} images.... %o`, imageIds);
+
+    const cleanUpCmds = [
+      // `docker kill $(docker ps -q)`,
+      // `docker rm $(docker ps -a -q)`,
+      // `docker rmi $(docker images -q -a)`,
+      { binary: "docker", args: ["rmi", ...imageIds] },
+      { binary: "docker", args: ["volume", "prune", "--force"] },
+    ];
+    for (const { binary, args } of cleanUpCmds) {
+      try {
+        const { all, command } = await execa(binary, args, { all: true });
+        log.debug(command);
+        log.debug(all);
+      } catch (ex) {
+        // The first 3 commands might fail if there are no containers or images
+        // to delete (e.g. their number is zero)
+        log.info("Ignoring docker resource cleanup command failure.", ex);
+      }
+    }
     const response: IPruneDockerResourcesResponse = {
       containers,
       images,
@@ -554,6 +603,18 @@ export class Containers {
     };
 
     log.debug(`Finished pruning all docker resources. Outcome: %o`, response);
+    try {
+      const { all } = await execa("df", [], { all: true });
+      log.debug(all);
+    } catch (ex) {
+      log.info(`Ignoring failure of df.`, ex);
+    }
+    try {
+      const { all } = await execa("docker", ["system", "df"], { all: true });
+      log.debug(all);
+    } catch (ex) {
+      log.info(`Ignoring failure of docker system df.`, ex);
+    }
     return response;
   }
 }

--- a/packages/cactus-test-tooling/src/test/typescript/integration/rustc-container/rustc-container-target-bundler.test.ts
+++ b/packages/cactus-test-tooling/src/test/typescript/integration/rustc-container/rustc-container-target-bundler.test.ts
@@ -74,6 +74,8 @@ test("compiles Rust code to bundler targeted .wasm", async (t: Test) => {
   const wasmPackBuildOut = await Containers.exec(
     dockerodeContainer,
     RustcBuildCmd.WASM_PACK_BUILD_BUNDLER,
+    300000,
+    "TRACE",
   );
   t.ok(wasmPackBuildOut, "wasmPackBuildOut truthy OK");
 


### PR DESCRIPTION
This may or may not make a difference with the flaky tests (the theory
is that it does).

Why? I noticed that one of the random test failures we have happens
when the test container's stop+destroy calls in the finish handler are
not being awaited for by the test runner internally before starting a
new test case in the same test file.
This lead to situations where a race appeared to cause crashes because
the pruning began before the container could gracefully shut itself
down.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>