### PR TITLE
test(test-tooling): containers#pruneDockerResources prints disk usage

### DIFF
--- a/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
@@ -578,9 +578,6 @@ export class Containers {
     log.debug(`Clearing ${imageIds.length} images.... %o`, imageIds);
 
     const cleanUpCmds = [
-      // `docker kill $(docker ps -q)`,
-      // `docker rm $(docker ps -a -q)`,
-      // `docker rmi $(docker images -q -a)`,
       { binary: "docker", args: ["rmi", ...imageIds] },
       { binary: "docker", args: ["volume", "prune", "--force"] },
     ];


### PR DESCRIPTION
Also adds a timeout and a log level parameter to the containers#exec
utility function to improve the developer experience while
troubleshooting test failures related to containers.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>