### PR TITLE
docs(examples): migrate containers to ubuntu-20.04 Docker-in-Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -57,3 +57,5 @@ cactus-openapi-spec.json
 cactus-openapi-spec-*.json
 .npmrc
 *.log
+
+examples/*/Dockerfile

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ As blockchain technology proliferates, blockchain integration will become an inc
       -p 4000:4000 \
       -p 4100:4100 \
       -p 4200:4200 \
-      hyperledger/cactus-example-supply-chain-app:2021-03-24-feat-362
+      ghcr.io/hyperledger/cactus-example-supply-chain-app:2021-07-01--fix-1063-v2
     ```
 2. Wait for the output to show the message `INFO (api-server): Cactus Cockpit reachable http://0.0.0.0:3100`
 3. Visit http://localhost:3100 in a web browser with Javascript enabled

--- a/examples/carbon-accounting/Dockerfile
+++ b/examples/carbon-accounting/Dockerfile
@@ -1,15 +1,37 @@
-FROM node:12.20.1-alpine3.12 as builder
+FROM node:16.3.0-buster-slim as builder
 
-RUN apk update
+RUN apt-get update
+RUN apt-get -y upgrade
+
+# Generic dependencies that are usually needed by other software
+RUN apt-get install -y build-essential libssl-dev libffi-dev python3-dev
 
 # Need git because some of our npm depedencies might be coming
 # straight from github instead of being an npm package on npmjs.com.
-RUN apk add --no-cache git
+RUN apt-get install -y git
 
-# Some install scripts of the npm package fabric-network need python
-RUN apk add --no-cache python3 py3-pip
+# Need OpenJDK for the OpenAPI generator tool
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN npm install modclean -g
+WORKDIR /opt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+    && curl \
+        -L \
+        -o openjdk.tar.gz \
+        https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz \
+    && mkdir jdk \
+    && tar zxf openjdk.tar.gz -C jdk --strip-components=1 \
+    && rm -rf openjdk.tar.gz \
+    && ln -sf /opt/jdk/bin/* /usr/local/bin/ \
+    && java  --version \
+    && javac --version \
+    && jlink --version
+
+# Some install scripts of the npm package fabric-network need python/pip
+RUN apt-get install -y python3-pip
 
 WORKDIR /
 RUN mkdir /app/
@@ -18,50 +40,40 @@ COPY ./ ./
 RUN npm ci
 RUN ./node_modules/.bin/lerna clean --yes
 RUN ./node_modules/.bin/lerna bootstrap
+RUN npm rebuild
 RUN npm run build:dev:backend
 RUN npm run webpack:dev:web
-RUN npm run build:dev:frontend -- --scope='@hyperledger/cactus-example-supply-chain-frontend'
-RUN ./node_modules/.bin/lerna clean --yes
-RUN ./node_modules/.bin/lerna bootstrap -- --production --no-optional
+RUN npm run build:dev:frontend -- --scope='@hyperledger/cactus-example-carbon-accounting-frontend'
 
 RUN rm -rf ./packages/cactus-test-plugin*
 RUN rm -rf ./packages/cactus-test-cmd*
 RUN rm -rf ./packages/cactus-test-api*
 RUN rm -rf ./node_modules/
 
-FROM docker:20.10.2-dind-rootless as runner
+FROM cruizba/ubuntu-dind:19.03.11 as runner
 
 USER root
 
-RUN apk update
-
-# Add bash for convenience, sh has less features
-RUN apk add --no-cache bash
+RUN apt-get update
+RUN apt -y upgrade
 
 # Need curl for healthchecks
-RUN apk add --no-cache curl
+RUN apt-get -y install --no-install-recommends curl
 
 # The file binary is used to inspect exectubles when debugging container image issues
-RUN apk add --no-cache file
+RUN apt-get -y install --no-install-recommends file
 
-RUN apk add --no-cache nodejs
-RUN apk add --no-cache npm
 
-RUN apk add --no-cache ca-certificates
-RUN apk add --no-cache tzdata
-
-# Install supervisord because we need to run the docker daemon and also the fabric network
-# meaning that we have multiple processes to run.
-RUN apk add --no-cache supervisor
+RUN apt-get -y install --no-install-recommends ca-certificates
+RUN apt-get -y install --no-install-recommends tzdata
 
 ARG APP=/usr/src/app/
 
 ENV TZ=Etc/UTC
 ENV APP_USER=appuser
 
-RUN addgroup --system $APP_USER
-RUN adduser --system $APP_USER -G $APP_USER
-RUN addgroup $APP_USER rootless
+RUN useradd -m ${APP_USER}
+RUN usermod -a -G ${APP_USER} ${APP_USER}
 RUN mkdir -p ${APP}
 
 COPY --chown=$APP_USER:$APP_USER --from=builder /app/ ${APP}
@@ -70,16 +82,25 @@ RUN mkdir -p "${APP}/log/"
 RUN chown -R $APP_USER:$APP_USER "${APP}/log/"
 
 # TODO: Can we hack it together so that the whole thing works rootless?
-# USER $APP_USER
+USER ${APP_USER}
+
+SHELL ["/bin/bash", "--login", "-i", "-c"]
+
+# Installing Node Version Manager (nvm)
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+RUN source ~/.bashrc && nvm install 16.3.0
+SHELL ["/bin/bash", "--login", "-c"]
 
 WORKDIR ${APP}
 
 COPY --chown=${APP_USER}:${APP_USER} ./examples/carbon-accounting/healthcheck.sh /
 
+ENV AUTHORIZATION_CONFIG_JSON="{}"
+ENV AUTHORIZATION_PROTOCOL=NONE
 ENV CACTUS_NODE_ID=-
 ENV CONSORTIUM_ID=-
 ENV KEY_PAIR_PEM=-
-ENV COCKPIT_WWW_ROOT=examples/cactus-example-supply-chain-frontend/www/
+ENV COCKPIT_WWW_ROOT=examples/cactus-example-carbon-accounting-frontend/www/
 ENV COCKPIT_TLS_ENABLED=false
 ENV COCKPIT_CORS_DOMAIN_CSV=\*
 ENV COCKPIT_MTLS_ENABLED=false
@@ -98,7 +119,7 @@ ENV API_HOST=0.0.0.0
 ENV API_PORT=4000
 ENV LOG_LEVEL=TRACE
 
-COPY examples/supply-chain-app/supervisord.conf /etc/supervisord.conf
+COPY examples/carbon-accounting/supervisord.conf /etc/supervisord.conf
 
 # supervisord web ui/dashboard
 EXPOSE 9001
@@ -115,9 +136,11 @@ EXPOSE 4200
 # GUI #3
 EXPOSE 3200
 
+USER root
+
 # Extend the parent image's entrypoint
 # https://superuser.com/questions/1459466/can-i-add-an-additional-docker-entrypoint-script
 ENTRYPOINT ["/usr/bin/supervisord"]
 CMD ["--configuration", "/etc/supervisord.conf", "--nodaemon"]
 HEALTHCHECK --interval=1s --timeout=5s --start-period=20s --retries=250 \
-    CMD /usr/src/app/examples/supply-chain-app/healthcheck.sh
+    CMD /usr/src/app/examples/carbon-accounting/healthcheck.sh

--- a/examples/carbon-accounting/supervisord.conf
+++ b/examples/carbon-accounting/supervisord.conf
@@ -2,27 +2,17 @@
 logfile = /usr/src/app/log/supervisord.log
 logfile_maxbytes = 50MB
 logfile_backups=10
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
 loglevel = info
 
-[inet_http_server]
-port = 0.0.0.0:9001
-
 [program:dockerd]
-command=dockerd-entrypoint.sh
+command=/usr/local/bin/dockerd
 autostart=true
 autorestart=true
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
+stderr_logfile=/usr/src/app/log/dockerd.err.log
+stdout_logfile=/usr/src/app/log/dockerd.out.log
 
-
-[program:supply-chain-app]
-command=node /usr/src/app/examples/cactus-example-supply-chain-backend/dist/lib/main/typescript/supply-chain-app-cli.js
+[program:carbon-accounting-app]
+command=/home/appuser/.nvm/versions/node/v16.3.0/bin/node /usr/src/app/examples/cactus-example-carbon-accounting-backend/dist/lib/main/typescript/carbon-accounting-app-cli.js
 autostart=true
 autorestart=unexpected
 exitcodes=0
@@ -30,3 +20,6 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
+
+[inet_http_server]
+port = 0.0.0.0:9001

--- a/examples/supply-chain-app/Dockerfile
+++ b/examples/supply-chain-app/Dockerfile
@@ -1,18 +1,37 @@
-FROM node:16.2.0-alpine3.13 as builder
+FROM node:16.3.0-buster-slim as builder
 
-RUN apk update
+RUN apt-get update
+RUN apt-get -y upgrade
 
-RUN apk --no-cache --update add alpine-sdk && \
-    apk --no-cache --update add libffi-dev openssl-dev && \
-    apk --no-cache --update add build-base && \
-    apk --no-cache --update add openjdk11
+# Generic dependencies that are usually needed by other software
+RUN apt-get install -y build-essential libssl-dev libffi-dev python3-dev
 
 # Need git because some of our npm depedencies might be coming
 # straight from github instead of being an npm package on npmjs.com.
-RUN apk add --no-cache git
+RUN apt-get install -y git
 
-# Some install scripts of the npm package fabric-network need python
-RUN apk add --no-cache python3 py3-pip
+# Need OpenJDK for the OpenAPI generator tool
+ENV DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /opt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+    && curl \
+        -L \
+        -o openjdk.tar.gz \
+        https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz \
+    && mkdir jdk \
+    && tar zxf openjdk.tar.gz -C jdk --strip-components=1 \
+    && rm -rf openjdk.tar.gz \
+    && ln -sf /opt/jdk/bin/* /usr/local/bin/ \
+    && java  --version \
+    && javac --version \
+    && jlink --version
+
+# Some install scripts of the npm package fabric-network need python/pip
+RUN apt-get install -y python3-pip
 
 WORKDIR /
 RUN mkdir /app/
@@ -21,50 +40,40 @@ COPY ./ ./
 RUN npm ci
 RUN ./node_modules/.bin/lerna clean --yes
 RUN ./node_modules/.bin/lerna bootstrap
+RUN npm rebuild
 RUN npm run build:dev:backend
 RUN npm run webpack:dev:web
 RUN npm run build:dev:frontend -- --scope='@hyperledger/cactus-example-supply-chain-frontend'
-RUN ./node_modules/.bin/lerna clean --yes
-RUN ./node_modules/.bin/lerna bootstrap -- --production --no-optional
 
 RUN rm -rf ./packages/cactus-test-plugin*
 RUN rm -rf ./packages/cactus-test-cmd*
 RUN rm -rf ./packages/cactus-test-api*
 RUN rm -rf ./node_modules/
 
-FROM docker:20.10.2-dind-rootless as runner
+FROM cruizba/ubuntu-dind:19.03.11 as runner
 
 USER root
 
-RUN apk update
-
-# Add bash for convenience, sh has less features
-RUN apk add --no-cache bash
+RUN apt-get update
+RUN apt -y upgrade
 
 # Need curl for healthchecks
-RUN apk add --no-cache curl
+RUN apt-get -y install --no-install-recommends curl
 
 # The file binary is used to inspect exectubles when debugging container image issues
-RUN apk add --no-cache file
+RUN apt-get -y install --no-install-recommends file
 
-RUN apk add --no-cache nodejs
-RUN apk add --no-cache npm
 
-RUN apk add --no-cache ca-certificates
-RUN apk add --no-cache tzdata
-
-# Install supervisord because we need to run the docker daemon and also the fabric network
-# meaning that we have multiple processes to run.
-RUN apk add --no-cache supervisor
+RUN apt-get -y install --no-install-recommends ca-certificates
+RUN apt-get -y install --no-install-recommends tzdata
 
 ARG APP=/usr/src/app/
 
 ENV TZ=Etc/UTC
 ENV APP_USER=appuser
 
-RUN addgroup --system $APP_USER
-RUN adduser --system $APP_USER -G $APP_USER
-RUN addgroup $APP_USER rootless
+RUN useradd -m ${APP_USER}
+RUN usermod -a -G ${APP_USER} ${APP_USER}
 RUN mkdir -p ${APP}
 
 COPY --chown=$APP_USER:$APP_USER --from=builder /app/ ${APP}
@@ -73,12 +82,21 @@ RUN mkdir -p "${APP}/log/"
 RUN chown -R $APP_USER:$APP_USER "${APP}/log/"
 
 # TODO: Can we hack it together so that the whole thing works rootless?
-# USER $APP_USER
+USER ${APP_USER}
+
+SHELL ["/bin/bash", "--login", "-i", "-c"]
+
+# Installing Node Version Manager (nvm)
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+RUN source ~/.bashrc && nvm install 16.3.0
+SHELL ["/bin/bash", "--login", "-c"]
 
 WORKDIR ${APP}
 
 COPY --chown=${APP_USER}:${APP_USER} ./examples/supply-chain-app/healthcheck.sh /
 
+ENV AUTHORIZATION_CONFIG_JSON="{}"
+ENV AUTHORIZATION_PROTOCOL=NONE
 ENV CACTUS_NODE_ID=-
 ENV CONSORTIUM_ID=-
 ENV KEY_PAIR_PEM=-
@@ -117,6 +135,8 @@ EXPOSE 3100
 EXPOSE 4200
 # GUI #3
 EXPOSE 3200
+
+USER root
 
 # Extend the parent image's entrypoint
 # https://superuser.com/questions/1459466/can-i-add-an-additional-docker-entrypoint-script

--- a/examples/supply-chain-app/README.md
+++ b/examples/supply-chain-app/README.md
@@ -14,7 +14,7 @@
       -p 4000:4000 \
       -p 4100:4100 \
       -p 4200:4200 \
-      hyperledger/cactus-example-supply-chain-app:2021-03-24-feat-362
+      ghcr.io/hyperledger/cactus-example-supply-chain-app:2021-07-01--fix-1063-v2
     ```
 2. Observe the example application pulling up in the logs
    1. the test ledger containers,

--- a/examples/supply-chain-app/supervisord.conf
+++ b/examples/supply-chain-app/supervisord.conf
@@ -5,14 +5,14 @@ logfile_backups=10
 loglevel = info
 
 [program:dockerd]
-command=dockerd-entrypoint.sh
+command=/usr/local/bin/dockerd
 autostart=true
 autorestart=true
 stderr_logfile=/usr/src/app/log/dockerd.err.log
 stdout_logfile=/usr/src/app/log/dockerd.out.log
 
 [program:supply-chain-app]
-command=node /usr/src/app/examples/cactus-example-supply-chain-backend/dist/lib/main/typescript/supply-chain-app-cli.js
+command=/home/appuser/.nvm/versions/node/v16.3.0/bin/node /usr/src/app/examples/cactus-example-supply-chain-backend/dist/lib/main/typescript/supply-chain-app-cli.js
 autostart=true
 autorestart=unexpected
 exitcodes=0

--- a/packages/cactus-cmd-api-server/package-lock.json
+++ b/packages/cactus-cmd-api-server/package-lock.json
@@ -26,6 +26,7 @@
 				"node-forge": "0.10.0",
 				"npm": "7.8.0",
 				"prom-client": "13.1.0",
+				"rxjs": "7.1.0",
 				"semver": "7.3.2",
 				"socket.io": "4.0.1",
 				"socket.io-client": "4.0.1",
@@ -4034,6 +4035,14 @@
 				"string_decoder": "~0.10.x"
 			}
 		},
+		"node_modules/rxjs": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.1.0.tgz",
+			"integrity": "sha512-gCFO5iHIbRPwznl6hAYuwNFld8W4S2shtSJIqG27ReWXo9IWrCyEICxUA+6vJHwSR/OakoenC4QsDxq50tzYmw==",
+			"dependencies": {
+				"tslib": "~2.1.0"
+			}
+		},
 		"node_modules/safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -4265,6 +4274,11 @@
 			"engines": {
 				"node": ">=0.6"
 			}
+		},
+		"node_modules/tslib": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+			"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 		},
 		"node_modules/type-is": {
 			"version": "1.6.18",
@@ -7371,6 +7385,14 @@
 				"string_decoder": "~0.10.x"
 			}
 		},
+		"rxjs": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.1.0.tgz",
+			"integrity": "sha512-gCFO5iHIbRPwznl6hAYuwNFld8W4S2shtSJIqG27ReWXo9IWrCyEICxUA+6vJHwSR/OakoenC4QsDxq50tzYmw==",
+			"requires": {
+				"tslib": "~2.1.0"
+			}
+		},
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -7556,6 +7578,11 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+		},
+		"tslib": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+			"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 		},
 		"type-is": {
 			"version": "1.6.18",

--- a/packages/cactus-cmd-api-server/package.json
+++ b/packages/cactus-cmd-api-server/package.json
@@ -106,6 +106,7 @@
     "node-forge": "0.10.0",
     "npm": "7.8.0",
     "prom-client": "13.1.0",
+    "rxjs": "7.1.0",
     "semver": "7.3.2",
     "socket.io": "4.0.1",
     "socket.io-client": "4.0.1",


### PR DESCRIPTION
This restores the supply chain example app into a working state.

Also migrated the carbon accounting example app onto the new base
image, but that one isn't fully functional just yet (but at least the
contanier build isn't broken anymore which is already signfiicant
progress.)

The image built from this revision of the source code has been
tagged on the container registry as:
ghcr.io/hyperledger/cactus-example-supply-chain-app:2021-07-01--fix-1063-v2

Fixes #1063

(this is the second try to fix that issue, the previous one failed)

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>