### PR TITLE
fix(connector-corda): kotlin compilation error due to missing method

### DIFF
--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/impl/ApiPluginLedgerConnectorCordaServiceImpl.kt
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/impl/ApiPluginLedgerConnectorCordaServiceImpl.kt
@@ -97,7 +97,7 @@ class ApiPluginLedgerConnectorCordaServiceImpl(
         // org.hyperledger.cactus.plugin.ledger.connector.corda.server.model.InvokeContractV1Response["returnValue"]->
         // net.corda.client.jackson.internal.StxJson["wire"]->net.corda.client.jackson.internal.WireTransactionJson["outputs"])]
         // with root cause
-        return InvokeContractV1Response(true, id.toString(), (returnValue as SignedTransaction).id, progress)
+        return InvokeContractV1Response(true, id.toString(), (returnValue as SignedTransaction).id.toString(), progress)
     }
 
     // FIXME - make it clear in the documentation that this deployment endpoint is not recommended for production
@@ -277,6 +277,10 @@ class ApiPluginLedgerConnectorCordaServiceImpl(
         val nodeDiagnosticInfoCactus = reader.readValue<NodeDiagnosticInfo>(json)
         logger.debug("Responding with marshalled ${NodeDiagnosticInfo::class.qualifiedName}: {}", nodeDiagnosticInfoCactus)
         return DiagnoseNodeV1Response(nodeDiagnosticInfo = nodeDiagnosticInfoCactus)
+    }
+
+    override fun getPrometheusExporterMetricsV1(): String {
+        TODO("Not yet implemented")
     }
 
     override fun invokeContractV1(invokeContractV1Request: InvokeContractV1Request?): InvokeContractV1Response {


### PR DESCRIPTION
When we added the prometheus monitoring endpoint to the
OpenAPI spec, the kotlin implementation was not updated
and this has lead to the container image build process failing
which was not noticed because currently the GHA CI does not
build the container images and therefore you can get away
with introducing issues to the container image build.
(this is soon to be rectified)

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>