### PR TITLE
feat(keychain-vault): add the missing endpoint classes #676

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "@hyperledger/cactus",
       "dependencies": {
         "@types/ssh2": "0.5.46",
-        "artillery": "^1.5.6",
+        "artillery": "1.7.2",
         "cspell": "5.4.0"
       },
       "devDependencies": {
@@ -22,6 +22,7 @@
         "@typescript-eslint/parser": "4.14.1",
         "buffer": "6.0.1",
         "cache-loader": "4.1.0",
+        "codecov": "3.8.2",
         "cross-env": "5.2.0",
         "crypto-browserify": "3.12.0",
         "del-cli": "3.0.1",
@@ -4759,6 +4760,15 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "node_modules/argv": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
+      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.10"
+      }
+    },
     "node_modules/arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -6975,6 +6985,34 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/codecov": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.8.2.tgz",
+      "integrity": "sha512-6w/kt/xvmPsWMfDFPE/T054txA9RTgcJEw36PNa6MYX+YV29jCHCRFXwbQ3QZBTOgnex1J2WP8bo2AT8TWWz9g==",
+      "dev": true,
+      "dependencies": {
+        "argv": "0.0.2",
+        "ignore-walk": "3.0.3",
+        "js-yaml": "3.14.1",
+        "teeny-request": "7.0.1",
+        "urlgrey": "0.4.4"
+      },
+      "bin": {
+        "codecov": "bin/codecov"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/codecov/node_modules/ignore-walk": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.4"
       }
     },
     "node_modules/collection-visit": {
@@ -13456,9 +13494,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -19273,6 +19311,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "dev": true,
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
     "node_modules/stream-http": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.1.tgz",
@@ -19551,6 +19598,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
+      "dev": true
     },
     "node_modules/sumchecker": {
       "version": "3.0.1",
@@ -21735,6 +21788,31 @@
         "node": ">=10"
       }
     },
+    "node_modules/teeny-request": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.0.1.tgz",
+      "integrity": "sha512-sasJmQ37klOlplL4Ia/786M5YlOcoLGQyq2TE4WHSRupbAuDaQW0PfVxV4MtdBtRJ4ngzS+1qim8zP6Zp35qCw==",
+      "dev": true,
+      "dependencies": {
+        "http-proxy-agent": "^4.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "stream-events": "^1.0.5",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
@@ -22728,6 +22806,12 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "dev": true
+    },
+    "node_modules/urlgrey": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
+      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
       "dev": true
     },
     "node_modules/use": {
@@ -27652,6 +27736,12 @@
         }
       }
     },
+    "argv": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
+      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
+      "dev": true
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -29452,6 +29542,30 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
+    },
+    "codecov": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.8.2.tgz",
+      "integrity": "sha512-6w/kt/xvmPsWMfDFPE/T054txA9RTgcJEw36PNa6MYX+YV29jCHCRFXwbQ3QZBTOgnex1J2WP8bo2AT8TWWz9g==",
+      "dev": true,
+      "requires": {
+        "argv": "0.0.2",
+        "ignore-walk": "3.0.3",
+        "js-yaml": "3.14.1",
+        "teeny-request": "7.0.1",
+        "urlgrey": "0.4.4"
+      },
+      "dependencies": {
+        "ignore-walk": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+          "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+          "dev": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        }
+      }
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -34590,9 +34704,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -39297,6 +39411,15 @@
         }
       }
     },
+    "stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "dev": true,
+      "requires": {
+        "stubs": "^3.0.0"
+      }
+    },
     "stream-http": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.1.tgz",
@@ -39515,6 +39638,12 @@
         "minimist": "^1.2.0",
         "through": "^2.3.4"
       }
+    },
+    "stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
+      "dev": true
     },
     "sumchecker": {
       "version": "3.0.1",
@@ -41059,6 +41188,27 @@
         "diff": "^4.0.2"
       }
     },
+    "teeny-request": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.0.1.tgz",
+      "integrity": "sha512-sasJmQ37klOlplL4Ia/786M5YlOcoLGQyq2TE4WHSRupbAuDaQW0PfVxV4MtdBtRJ4ngzS+1qim8zP6Zp35qCw==",
+      "dev": true,
+      "requires": {
+        "http-proxy-agent": "^4.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "stream-events": "^1.0.5",
+        "uuid": "^8.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
+      }
+    },
     "temp-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
@@ -41843,6 +41993,12 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
+    },
+    "urlgrey": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
+      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
+      "dev": true
     },
     "use": {
       "version": "3.1.1",

--- a/packages/cactus-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
@@ -88,10 +88,10 @@ test("NodeJS API server + Rust plugin work together", async (t: Test) => {
   const key = uuidv4();
   const expected = uuidv4();
 
-  await apiClient.setKeychainEntry({ key, value: expected });
+  await apiClient.setKeychainEntryV1({ key, value: expected });
   const {
     data: { value: actual },
-  } = await apiClient.getKeychainEntry({ key });
+  } = await apiClient.getKeychainEntryV1({ key });
 
   t.equal(actual, expected, "Keychain stored value matches input OK");
 

--- a/packages/cactus-plugin-keychain-vault/package-lock.json
+++ b/packages/cactus-plugin-keychain-vault/package-lock.json
@@ -10,7 +10,6 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"axios": "0.21.1",
-				"express": "4.17.1",
 				"http-status-codes": "2.1.4",
 				"node-vault": "0.9.21",
 				"prom-client": "13.1.0",
@@ -142,18 +141,6 @@
 			"integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
 			"dev": true
 		},
-		"node_modules/accepts": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-			"dependencies": {
-				"mime-types": "~2.1.24",
-				"negotiator": "0.6.2"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -164,11 +151,6 @@
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
 			}
-		},
-		"node_modules/array-flatten": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 		},
 		"node_modules/asn1": {
 			"version": "0.2.4",
@@ -225,34 +207,6 @@
 			"resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
 			"integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
 		},
-		"node_modules/body-parser": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-			"integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
-			"dependencies": {
-				"bytes": "3.1.0",
-				"content-type": "~1.0.4",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"http-errors": "1.7.2",
-				"iconv-lite": "0.4.24",
-				"on-finished": "~2.3.0",
-				"qs": "6.7.0",
-				"raw-body": "2.4.0",
-				"type-is": "~1.6.17"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/bytes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -268,38 +222,6 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
-		},
-		"node_modules/content-disposition": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-			"dependencies": {
-				"safe-buffer": "5.1.2"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/content-type": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/cookie": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/cookie-signature": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
 		"node_modules/core-util-is": {
 			"version": "1.0.2",
@@ -331,14 +253,6 @@
 				"node": ">=0.10"
 			}
 		},
-		"node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
 		"node_modules/default-gateway": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
@@ -359,19 +273,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/destroy": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-		},
 		"node_modules/ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -379,32 +280,6 @@
 			"dependencies": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
-			}
-		},
-		"node_modules/ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-		},
-		"node_modules/encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-		},
-		"node_modules/etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/execa": {
@@ -425,46 +300,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/express": {
-			"version": "4.17.1",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-			"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
-			"dependencies": {
-				"accepts": "~1.3.7",
-				"array-flatten": "1.1.1",
-				"body-parser": "1.19.0",
-				"content-disposition": "0.5.3",
-				"content-type": "~1.0.4",
-				"cookie": "0.4.0",
-				"cookie-signature": "1.0.6",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "~1.1.2",
-				"fresh": "0.5.2",
-				"merge-descriptors": "1.0.1",
-				"methods": "~1.1.2",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.5",
-				"qs": "6.7.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.1.2",
-				"send": "0.17.1",
-				"serve-static": "1.14.1",
-				"setprototypeof": "1.1.1",
-				"statuses": "~1.5.0",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.10.0"
 			}
 		},
 		"node_modules/extend": {
@@ -489,23 +324,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-		},
-		"node_modules/finalhandler": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-			"dependencies": {
-				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.3",
-				"statuses": "~1.5.0",
-				"unpipe": "~1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.13.1",
@@ -534,22 +352,6 @@
 			},
 			"engines": {
 				"node": ">= 0.12"
-			}
-		},
-		"node_modules/forwarded": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/get-stream": {
@@ -589,21 +391,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/http-errors": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-			"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
-			"dependencies": {
-				"depd": "~1.1.2",
-				"inherits": "2.0.3",
-				"setprototypeof": "1.1.1",
-				"statuses": ">= 1.5.0 < 2",
-				"toidentifier": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -631,22 +418,6 @@
 			"engines": {
 				"node": ">=10.17.0"
 			}
-		},
-		"node_modules/iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"node_modules/internal-ip": {
 			"version": "6.2.0",
@@ -676,6 +447,7 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
 			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"dev": true,
 			"engines": {
 				"node": ">= 0.10"
 			}
@@ -756,43 +528,11 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
 			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
-		"node_modules/media-typer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true
-		},
-		"node_modules/methods": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-			"bin": {
-				"mime": "cli.js"
-			},
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/mime-db": {
 			"version": "1.45.0",
@@ -838,14 +578,6 @@
 				"npm": ">=1.4.0"
 			}
 		},
-		"node_modules/negotiator": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/node-vault": {
 			"version": "0.9.21",
 			"resolved": "https://registry.npmjs.org/node-vault/-/node-vault-0.9.21.tgz",
@@ -884,17 +616,6 @@
 			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"engines": {
 				"node": "*"
-			}
-		},
-		"node_modules/on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"dependencies": {
-				"ee-first": "1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/onetime": {
@@ -948,14 +669,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/parseurl": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -964,11 +677,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/path-to-regexp": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
 		"node_modules/performance-now": {
 			"version": "2.1.0",
@@ -986,18 +694,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/proxy-addr": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
-			"integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
-			"dependencies": {
-				"forwarded": "~0.1.2",
-				"ipaddr.js": "1.9.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
 		"node_modules/psl": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -1009,36 +705,6 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/qs": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-			"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
-		"node_modules/range-parser": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/raw-body": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-			"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
-			"dependencies": {
-				"bytes": "3.1.0",
-				"http-errors": "1.7.2",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/request": {
@@ -1113,53 +779,6 @@
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
-		"node_modules/send": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-			"dependencies": {
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"destroy": "~1.0.4",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "~1.7.2",
-				"mime": "1.6.0",
-				"ms": "2.1.1",
-				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.1",
-				"statuses": "~1.5.0"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/send/node_modules/ms": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-		},
-		"node_modules/serve-static": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
-			"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
-			"dependencies": {
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.3",
-				"send": "0.17.1"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/setprototypeof": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
-		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -1206,14 +825,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/statuses": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/stealthy-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
@@ -1237,14 +848,6 @@
 			"integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
 			"dependencies": {
 				"bintrees": "1.0.1"
-			}
-		},
-		"node_modules/toidentifier": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-			"engines": {
-				"node": ">=0.6"
 			}
 		},
 		"node_modules/tough-cookie": {
@@ -1288,30 +891,10 @@
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
-		"node_modules/type-is": {
-			"version": "1.6.18",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-			"dependencies": {
-				"media-typer": "0.3.0",
-				"mime-types": "~2.1.24"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/typescript-optional": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/typescript-optional/-/typescript-optional-2.0.1.tgz",
 			"integrity": "sha512-xuwmqsCjE4OeeMKxbNX3jjNcISGzYh5Q9R1rM5OyxEVNIr94CB5llCkfKW+1nZTKbbUV0axN3QAUuX2fus/DhQ=="
-		},
-		"node_modules/unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
@@ -1321,28 +904,12 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"node_modules/utils-merge": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
 		"node_modules/uuid": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
 			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
 			"bin": {
 				"uuid": "bin/uuid"
-			}
-		},
-		"node_modules/vary": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/verror": {
@@ -1488,15 +1055,6 @@
 			"integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
 			"dev": true
 		},
-		"accepts": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-			"requires": {
-				"mime-types": "~2.1.24",
-				"negotiator": "0.6.2"
-			}
-		},
 		"ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1507,11 +1065,6 @@
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
 			}
-		},
-		"array-flatten": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 		},
 		"asn1": {
 			"version": "0.2.4",
@@ -1562,28 +1115,6 @@
 			"resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
 			"integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
 		},
-		"body-parser": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-			"integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
-			"requires": {
-				"bytes": "3.1.0",
-				"content-type": "~1.0.4",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"http-errors": "1.7.2",
-				"iconv-lite": "0.4.24",
-				"on-finished": "~2.3.0",
-				"qs": "6.7.0",
-				"raw-body": "2.4.0",
-				"type-is": "~1.6.17"
-			}
-		},
-		"bytes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -1596,29 +1127,6 @@
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
-		},
-		"content-disposition": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-			"requires": {
-				"safe-buffer": "5.1.2"
-			}
-		},
-		"content-type": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-		},
-		"cookie": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
-		},
-		"cookie-signature": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -1644,14 +1152,6 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
-		"debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"requires": {
-				"ms": "2.0.0"
-			}
-		},
 		"default-gateway": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
@@ -1666,16 +1166,6 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
-		"depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-		},
-		"destroy": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1684,26 +1174,6 @@
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
 			}
-		},
-		"ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-		},
-		"encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-		},
-		"escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-		},
-		"etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
 		},
 		"execa": {
 			"version": "5.0.0",
@@ -1720,43 +1190,6 @@
 				"onetime": "^5.1.2",
 				"signal-exit": "^3.0.3",
 				"strip-final-newline": "^2.0.0"
-			}
-		},
-		"express": {
-			"version": "4.17.1",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-			"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
-			"requires": {
-				"accepts": "~1.3.7",
-				"array-flatten": "1.1.1",
-				"body-parser": "1.19.0",
-				"content-disposition": "0.5.3",
-				"content-type": "~1.0.4",
-				"cookie": "0.4.0",
-				"cookie-signature": "1.0.6",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "~1.1.2",
-				"fresh": "0.5.2",
-				"merge-descriptors": "1.0.1",
-				"methods": "~1.1.2",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.5",
-				"qs": "6.7.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.1.2",
-				"send": "0.17.1",
-				"serve-static": "1.14.1",
-				"setprototypeof": "1.1.1",
-				"statuses": "~1.5.0",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
 			}
 		},
 		"extend": {
@@ -1779,20 +1212,6 @@
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
-		"finalhandler": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-			"requires": {
-				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.3",
-				"statuses": "~1.5.0",
-				"unpipe": "~1.0.0"
-			}
-		},
 		"follow-redirects": {
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
@@ -1812,16 +1231,6 @@
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
-		},
-		"forwarded": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
-		},
-		"fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
 		"get-stream": {
 			"version": "6.0.0",
@@ -1851,18 +1260,6 @@
 				"har-schema": "^2.0.0"
 			}
 		},
-		"http-errors": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-			"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
-			"requires": {
-				"depd": "~1.1.2",
-				"inherits": "2.0.3",
-				"setprototypeof": "1.1.1",
-				"statuses": ">= 1.5.0 < 2",
-				"toidentifier": "1.0.0"
-			}
-		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -1883,19 +1280,6 @@
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
 			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
 			"dev": true
-		},
-		"iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			}
-		},
-		"inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"internal-ip": {
 			"version": "6.2.0",
@@ -1918,7 +1302,8 @@
 		"ipaddr.js": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"dev": true
 		},
 		"is-ip": {
 			"version": "3.1.0",
@@ -1987,31 +1372,11 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
 			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
-		"media-typer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true
-		},
-		"methods": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-		},
-		"mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
 		},
 		"mime-db": {
 			"version": "1.45.0",
@@ -2041,11 +1406,6 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
 			"integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ=="
-		},
-		"negotiator": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
 		},
 		"node-vault": {
 			"version": "0.9.21",
@@ -2082,14 +1442,6 @@
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
 			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-		},
-		"on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"requires": {
-				"ee-first": "1.1.1"
-			}
 		},
 		"onetime": {
 			"version": "5.1.2",
@@ -2130,21 +1482,11 @@
 				"p-finally": "^1.0.0"
 			}
 		},
-		"parseurl": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-		},
 		"path-key": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
-		},
-		"path-to-regexp": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
 		"performance-now": {
 			"version": "2.1.0",
@@ -2159,15 +1501,6 @@
 				"tdigest": "^0.1.1"
 			}
 		},
-		"proxy-addr": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
-			"integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
-			"requires": {
-				"forwarded": "~0.1.2",
-				"ipaddr.js": "1.9.1"
-			}
-		},
 		"psl": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -2177,27 +1510,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-		},
-		"qs": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-			"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-		},
-		"range-parser": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-		},
-		"raw-body": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-			"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
-			"requires": {
-				"bytes": "3.1.0",
-				"http-errors": "1.7.2",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
-			}
 		},
 		"request": {
 			"version": "2.88.0",
@@ -2261,49 +1573,6 @@
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
-		"send": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-			"requires": {
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"destroy": "~1.0.4",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "~1.7.2",
-				"mime": "1.6.0",
-				"ms": "2.1.1",
-				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.1",
-				"statuses": "~1.5.0"
-			},
-			"dependencies": {
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-				}
-			}
-		},
-		"serve-static": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
-			"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
-			"requires": {
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.3",
-				"send": "0.17.1"
-			}
-		},
-		"setprototypeof": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
-		},
 		"shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2341,11 +1610,6 @@
 				"tweetnacl": "~0.14.0"
 			}
 		},
-		"statuses": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-		},
 		"stealthy-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
@@ -2364,11 +1628,6 @@
 			"requires": {
 				"bintrees": "1.0.1"
 			}
-		},
-		"toidentifier": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
 		},
 		"tough-cookie": {
 			"version": "2.4.3",
@@ -2404,24 +1663,10 @@
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
-		"type-is": {
-			"version": "1.6.18",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-			"requires": {
-				"media-typer": "0.3.0",
-				"mime-types": "~2.1.24"
-			}
-		},
 		"typescript-optional": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/typescript-optional/-/typescript-optional-2.0.1.tgz",
 			"integrity": "sha512-xuwmqsCjE4OeeMKxbNX3jjNcISGzYh5Q9R1rM5OyxEVNIr94CB5llCkfKW+1nZTKbbUV0axN3QAUuX2fus/DhQ=="
-		},
-		"unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 		},
 		"uri-js": {
 			"version": "4.4.1",
@@ -2431,20 +1676,10 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"utils-merge": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-		},
 		"uuid": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
 			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-		},
-		"vary": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
 		},
 		"verror": {
 			"version": "1.10.0",

--- a/packages/cactus-plugin-keychain-vault/package.json
+++ b/packages/cactus-plugin-keychain-vault/package.json
@@ -87,7 +87,6 @@
     "@hyperledger/cactus-core": "0.5.0",
     "@hyperledger/cactus-core-api": "0.5.0",
     "axios": "0.21.1",
-    "express": "4.17.1",
     "http-status-codes": "2.1.4",
     "node-vault": "0.9.21",
     "prom-client": "13.1.0",

--- a/packages/cactus-plugin-keychain-vault/src/main/json/openapi.json
+++ b/packages/cactus-plugin-keychain-vault/src/main/json/openapi.json
@@ -12,8 +12,80 @@
   "components": {
     "schemas": {
       "PrometheusExporterMetricsResponse": {
-          "type": "string",
-          "nullable": false
+        "type": "string",
+        "nullable": false
+      },
+      "HasKeychainEntryRequestV1": {
+        "type": "object",
+        "required": [
+          "key"
+        ],
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The key to check for presence in the keychain.",
+            "minLength": 1,
+            "maxLength": 1024,
+            "nullable": false
+          }
+        }
+      },
+      "HasKeychainEntryResponseV1": {
+        "type": "object",
+        "required": [
+          "key",
+          "isPresent",
+          "checkedAt"
+        ],
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The key that was used to check the presence of the value in the keychain.",
+            "minLength": 1,
+            "maxLength": 1024,
+            "nullable": false
+          },
+          "checkedAt": {
+            "type": "string",
+            "description": "Date and time encoded as JSON when the presence check was performed by the plugin backend.",
+            "nullable": false
+          },
+          "isPresent": {
+            "type": "boolean",
+            "description": "The boolean true or false indicating the presence or absence of an entry under 'key'.",
+            "nullable": false
+          }
+        }
+      },
+      "DeleteKeychainEntryRequestV1": {
+        "type": "object",
+        "required": [
+          "key"
+        ],
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The key of the entry to delete from the keychain.",
+            "minLength": 1,
+            "maxLength": 1024,
+            "nullable": false
+          }
+        }
+      },
+      "DeleteKeychainEntryResponseV1": {
+        "type": "object",
+        "required": [
+          "key"
+        ],
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The key of the entry that was deleted from the keychain.",
+            "minLength": 1,
+            "maxLength": 1024,
+            "nullable": false
+          }
+        }
       }
     }
   },
@@ -23,30 +95,98 @@
         "x-hyperledger-cactus": {
           "http": {
             "path": "/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/get-keychain-entry",
-            "verbLowerCase": "get"
+            "verbLowerCase": "post"
           }
         },
-        "operationId": "getKeychainEntry",
+        "operationId": "getKeychainEntryV1",
         "summary": "Retrieves the contents of a keychain entry from the backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "../../../../cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_get_entry_request_body"
+          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v0.5.0/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_get_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "../../../../cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_200"
+            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v0.5.0/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_200"
           },
           "400": {
-            "$ref": "../../../../cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_400"
+            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v0.5.0/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_400"
           },
           "401": {
-            "$ref": "../../../../cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_401"
+            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v0.5.0/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_401"
           },
           "404": {
-            "$ref": "../../../../cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_404"
+            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v0.5.0/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_404"
           },
           "500": {
-            "$ref": "../../../../cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_500"
+            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v0.5.0/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_500"
+          }
+        }
+      }
+    },
+    "/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/delete-keychain-entry": {
+      "post": {
+        "x-hyperledger-cactus": {
+          "http": {
+            "path": "/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/delete-keychain-entry",
+            "verbLowerCase": "post"
+          }
+        },
+        "operationId": "deleteKeychainEntryV1",
+        "summary": "Deletes an entry from the keychain stored under the provided key.",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteKeychainEntryRequestV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteKeychainEntryResponseV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/has-keychain-entry": {
+      "post": {
+        "x-hyperledger-cactus": {
+          "http": {
+            "path": "/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/has-keychain-entry",
+            "verbLowerCase": "post"
+          }
+        },
+        "operationId": "hasKeychainEntryV1",
+        "summary": "Retrieves the information regarding a key being present on the keychain or not.",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HasKeychainEntryRequestV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HasKeychainEntryResponseV1"
+                }
+              }
+            }
           }
         }
       }
@@ -59,51 +199,51 @@
             "verbLowerCase": "post"
           }
         },
-        "operationId": "setKeychainEntry",
+        "operationId": "setKeychainEntryV1",
         "summary": "Sets a value under a key on the keychain backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "../../../../cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_set_entry_request_body"
+          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v0.5.0/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_set_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "../../../../cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_200"
+            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v0.5.0/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_200"
           },
           "400": {
-            "$ref": "../../../../cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_400"
+            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v0.5.0/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_400"
           },
           "401": {
-            "$ref": "../../../../cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_401"
+            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v0.5.0/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_401"
           },
           "500": {
-            "$ref": "../../../../cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_500"
+            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v0.5.0/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_500"
           }
         }
       }
     },
     "/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/get-prometheus-exporter-metrics": {
       "get": {
-          "x-hyperledger-cactus": {
-              "http": {
-                  "verbLowerCase": "get",
-                  "path": "/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/get-prometheus-exporter-metrics"
-              }
-          },
-          "operationId": "getPrometheusExporterMetricsV1",
-          "summary": "Get the Prometheus Metrics",
-          "parameters": [],
-          "responses": {
-              "200": {
-                  "description": "OK",
-                  "content": {
-                      "text/plain": {
-                          "schema": {
-                              "$ref": "#/components/schemas/PrometheusExporterMetricsResponse"
-                          }
-                      }
-                  }
-              }
+        "x-hyperledger-cactus": {
+          "http": {
+            "verbLowerCase": "get",
+            "path": "/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/get-prometheus-exporter-metrics"
           }
+        },
+        "operationId": "getPrometheusExporterMetricsV1",
+        "summary": "Get the Prometheus Metrics",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrometheusExporterMetricsResponse"
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -24,6 +24,32 @@ import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } fr
 /**
  * 
  * @export
+ * @interface DeleteKeychainEntryRequestV1
+ */
+export interface DeleteKeychainEntryRequestV1 {
+    /**
+     * The key of the entry to delete from the keychain.
+     * @type {string}
+     * @memberof DeleteKeychainEntryRequestV1
+     */
+    key: string;
+}
+/**
+ * 
+ * @export
+ * @interface DeleteKeychainEntryResponseV1
+ */
+export interface DeleteKeychainEntryResponseV1 {
+    /**
+     * The key of the entry that was deleted from the keychain.
+     * @type {string}
+     * @memberof DeleteKeychainEntryResponseV1
+     */
+    key: string;
+}
+/**
+ * 
+ * @export
  * @interface GetKeychainEntryRequest
  */
 export interface GetKeychainEntryRequest {
@@ -52,6 +78,44 @@ export interface GetKeychainEntryResponse {
      * @memberof GetKeychainEntryResponse
      */
     value: string;
+}
+/**
+ * 
+ * @export
+ * @interface HasKeychainEntryRequestV1
+ */
+export interface HasKeychainEntryRequestV1 {
+    /**
+     * The key to check for presence in the keychain.
+     * @type {string}
+     * @memberof HasKeychainEntryRequestV1
+     */
+    key: string;
+}
+/**
+ * 
+ * @export
+ * @interface HasKeychainEntryResponseV1
+ */
+export interface HasKeychainEntryResponseV1 {
+    /**
+     * The key that was used to check the presence of the value in the keychain.
+     * @type {string}
+     * @memberof HasKeychainEntryResponseV1
+     */
+    key: string;
+    /**
+     * Date and time encoded as JSON when the presence check was performed by the plugin backend.
+     * @type {string}
+     * @memberof HasKeychainEntryResponseV1
+     */
+    checkedAt: string;
+    /**
+     * The boolean true or false indicating the presence or absence of an entry under \'key\'.
+     * @type {boolean}
+     * @memberof HasKeychainEntryResponseV1
+     */
+    isPresent: boolean;
 }
 /**
  * 
@@ -94,14 +158,48 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
     return {
         /**
          * 
-         * @summary Retrieves the contents of a keychain entry from the backend.
-         * @param {GetKeychainEntryRequest} getKeychainEntryRequest Request body to obtain a keychain entry via its key
+         * @summary Deletes an entry from the keychain stored under the provided key.
+         * @param {DeleteKeychainEntryRequestV1} [deleteKeychainEntryRequestV1] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getKeychainEntry: async (getKeychainEntryRequest: GetKeychainEntryRequest, options: any = {}): Promise<RequestArgs> => {
+        deleteKeychainEntryV1: async (deleteKeychainEntryRequestV1?: DeleteKeychainEntryRequestV1, options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/delete-keychain-entry`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(deleteKeychainEntryRequestV1, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Retrieves the contents of a keychain entry from the backend.
+         * @param {GetKeychainEntryRequest} getKeychainEntryRequest Requst body to obtain a keychain entry via its key
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getKeychainEntryV1: async (getKeychainEntryRequest: GetKeychainEntryRequest, options: any = {}): Promise<RequestArgs> => {
             // verify required parameter 'getKeychainEntryRequest' is not null or undefined
-            assertParamExists('getKeychainEntry', 'getKeychainEntryRequest', getKeychainEntryRequest)
+            assertParamExists('getKeychainEntryV1', 'getKeychainEntryRequest', getKeychainEntryRequest)
             const localVarPath = `/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/get-keychain-entry`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -160,14 +258,48 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary Sets a value under a key on the keychain backend.
-         * @param {SetKeychainEntryRequest} setKeychainEntryRequest Request body to write/update a keychain entry via its key
+         * @summary Retrieves the information regarding a key being present on the keychain or not.
+         * @param {HasKeychainEntryRequestV1} [hasKeychainEntryRequestV1] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        setKeychainEntry: async (setKeychainEntryRequest: SetKeychainEntryRequest, options: any = {}): Promise<RequestArgs> => {
+        hasKeychainEntryV1: async (hasKeychainEntryRequestV1?: HasKeychainEntryRequestV1, options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/has-keychain-entry`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(hasKeychainEntryRequestV1, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Sets a value under a key on the keychain backend.
+         * @param {SetKeychainEntryRequest} setKeychainEntryRequest Requst body to write/update a keychain entry via its key
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        setKeychainEntryV1: async (setKeychainEntryRequest: SetKeychainEntryRequest, options: any = {}): Promise<RequestArgs> => {
             // verify required parameter 'setKeychainEntryRequest' is not null or undefined
-            assertParamExists('setKeychainEntry', 'setKeychainEntryRequest', setKeychainEntryRequest)
+            assertParamExists('setKeychainEntryV1', 'setKeychainEntryRequest', setKeychainEntryRequest)
             const localVarPath = `/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/set-keychain-entry`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -206,13 +338,24 @@ export const DefaultApiFp = function(configuration?: Configuration) {
     return {
         /**
          * 
-         * @summary Retrieves the contents of a keychain entry from the backend.
-         * @param {GetKeychainEntryRequest} getKeychainEntryRequest Request body to obtain a keychain entry via its key
+         * @summary Deletes an entry from the keychain stored under the provided key.
+         * @param {DeleteKeychainEntryRequestV1} [deleteKeychainEntryRequestV1] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getKeychainEntry(getKeychainEntryRequest: GetKeychainEntryRequest, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetKeychainEntryResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getKeychainEntry(getKeychainEntryRequest, options);
+        async deleteKeychainEntryV1(deleteKeychainEntryRequestV1?: DeleteKeychainEntryRequestV1, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<DeleteKeychainEntryResponseV1>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteKeychainEntryV1(deleteKeychainEntryRequestV1, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
+         * @summary Retrieves the contents of a keychain entry from the backend.
+         * @param {GetKeychainEntryRequest} getKeychainEntryRequest Requst body to obtain a keychain entry via its key
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getKeychainEntryV1(getKeychainEntryRequest: GetKeychainEntryRequest, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetKeychainEntryResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getKeychainEntryV1(getKeychainEntryRequest, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -227,13 +370,24 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Sets a value under a key on the keychain backend.
-         * @param {SetKeychainEntryRequest} setKeychainEntryRequest Request body to write/update a keychain entry via its key
+         * @summary Retrieves the information regarding a key being present on the keychain or not.
+         * @param {HasKeychainEntryRequestV1} [hasKeychainEntryRequestV1] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async setKeychainEntry(setKeychainEntryRequest: SetKeychainEntryRequest, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SetKeychainEntryResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.setKeychainEntry(setKeychainEntryRequest, options);
+        async hasKeychainEntryV1(hasKeychainEntryRequestV1?: HasKeychainEntryRequestV1, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<HasKeychainEntryResponseV1>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.hasKeychainEntryV1(hasKeychainEntryRequestV1, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
+         * @summary Sets a value under a key on the keychain backend.
+         * @param {SetKeychainEntryRequest} setKeychainEntryRequest Requst body to write/update a keychain entry via its key
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async setKeychainEntryV1(setKeychainEntryRequest: SetKeychainEntryRequest, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SetKeychainEntryResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.setKeychainEntryV1(setKeychainEntryRequest, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -248,13 +402,23 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
     return {
         /**
          * 
-         * @summary Retrieves the contents of a keychain entry from the backend.
-         * @param {GetKeychainEntryRequest} getKeychainEntryRequest Request body to obtain a keychain entry via its key
+         * @summary Deletes an entry from the keychain stored under the provided key.
+         * @param {DeleteKeychainEntryRequestV1} [deleteKeychainEntryRequestV1] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getKeychainEntry(getKeychainEntryRequest: GetKeychainEntryRequest, options?: any): AxiosPromise<GetKeychainEntryResponse> {
-            return localVarFp.getKeychainEntry(getKeychainEntryRequest, options).then((request) => request(axios, basePath));
+        deleteKeychainEntryV1(deleteKeychainEntryRequestV1?: DeleteKeychainEntryRequestV1, options?: any): AxiosPromise<DeleteKeychainEntryResponseV1> {
+            return localVarFp.deleteKeychainEntryV1(deleteKeychainEntryRequestV1, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Retrieves the contents of a keychain entry from the backend.
+         * @param {GetKeychainEntryRequest} getKeychainEntryRequest Requst body to obtain a keychain entry via its key
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getKeychainEntryV1(getKeychainEntryRequest: GetKeychainEntryRequest, options?: any): AxiosPromise<GetKeychainEntryResponse> {
+            return localVarFp.getKeychainEntryV1(getKeychainEntryRequest, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -267,13 +431,23 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary Sets a value under a key on the keychain backend.
-         * @param {SetKeychainEntryRequest} setKeychainEntryRequest Request body to write/update a keychain entry via its key
+         * @summary Retrieves the information regarding a key being present on the keychain or not.
+         * @param {HasKeychainEntryRequestV1} [hasKeychainEntryRequestV1] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        setKeychainEntry(setKeychainEntryRequest: SetKeychainEntryRequest, options?: any): AxiosPromise<SetKeychainEntryResponse> {
-            return localVarFp.setKeychainEntry(setKeychainEntryRequest, options).then((request) => request(axios, basePath));
+        hasKeychainEntryV1(hasKeychainEntryRequestV1?: HasKeychainEntryRequestV1, options?: any): AxiosPromise<HasKeychainEntryResponseV1> {
+            return localVarFp.hasKeychainEntryV1(hasKeychainEntryRequestV1, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Sets a value under a key on the keychain backend.
+         * @param {SetKeychainEntryRequest} setKeychainEntryRequest Requst body to write/update a keychain entry via its key
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        setKeychainEntryV1(setKeychainEntryRequest: SetKeychainEntryRequest, options?: any): AxiosPromise<SetKeychainEntryResponse> {
+            return localVarFp.setKeychainEntryV1(setKeychainEntryRequest, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -287,14 +461,26 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
 export class DefaultApi extends BaseAPI {
     /**
      * 
-     * @summary Retrieves the contents of a keychain entry from the backend.
-     * @param {GetKeychainEntryRequest} getKeychainEntryRequest Request body to obtain a keychain entry via its key
+     * @summary Deletes an entry from the keychain stored under the provided key.
+     * @param {DeleteKeychainEntryRequestV1} [deleteKeychainEntryRequestV1] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DefaultApi
      */
-    public getKeychainEntry(getKeychainEntryRequest: GetKeychainEntryRequest, options?: any) {
-        return DefaultApiFp(this.configuration).getKeychainEntry(getKeychainEntryRequest, options).then((request) => request(this.axios, this.basePath));
+    public deleteKeychainEntryV1(deleteKeychainEntryRequestV1?: DeleteKeychainEntryRequestV1, options?: any) {
+        return DefaultApiFp(this.configuration).deleteKeychainEntryV1(deleteKeychainEntryRequestV1, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Retrieves the contents of a keychain entry from the backend.
+     * @param {GetKeychainEntryRequest} getKeychainEntryRequest Requst body to obtain a keychain entry via its key
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public getKeychainEntryV1(getKeychainEntryRequest: GetKeychainEntryRequest, options?: any) {
+        return DefaultApiFp(this.configuration).getKeychainEntryV1(getKeychainEntryRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -310,14 +496,26 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @summary Sets a value under a key on the keychain backend.
-     * @param {SetKeychainEntryRequest} setKeychainEntryRequest Request body to write/update a keychain entry via its key
+     * @summary Retrieves the information regarding a key being present on the keychain or not.
+     * @param {HasKeychainEntryRequestV1} [hasKeychainEntryRequestV1] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DefaultApi
      */
-    public setKeychainEntry(setKeychainEntryRequest: SetKeychainEntryRequest, options?: any) {
-        return DefaultApiFp(this.configuration).setKeychainEntry(setKeychainEntryRequest, options).then((request) => request(this.axios, this.basePath));
+    public hasKeychainEntryV1(hasKeychainEntryRequestV1?: HasKeychainEntryRequestV1, options?: any) {
+        return DefaultApiFp(this.configuration).hasKeychainEntryV1(hasKeychainEntryRequestV1, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Sets a value under a key on the keychain backend.
+     * @param {SetKeychainEntryRequest} setKeychainEntryRequest Requst body to write/update a keychain entry via its key
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public setKeychainEntryV1(setKeychainEntryRequest: SetKeychainEntryRequest, options?: any) {
+        return DefaultApiFp(this.configuration).setKeychainEntryV1(setKeychainEntryRequest, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/plugin-keychain-vault-remote-adapter.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/plugin-keychain-vault-remote-adapter.ts
@@ -110,7 +110,7 @@ export class PluginKeychainVaultRemoteAdapter
 
   public async has(key: string): Promise<boolean> {
     try {
-      await this.backend.getKeychainEntry({ key });
+      await this.backend.getKeychainEntryV1({ key });
       return true;
     } catch (ex) {
       // FIXME check for errors being thrown due to something other than
@@ -120,7 +120,7 @@ export class PluginKeychainVaultRemoteAdapter
   }
 
   public async get<T>(key: string): Promise<T> {
-    const { data } = await this.backend.getKeychainEntry({ key });
+    const { data } = await this.backend.getKeychainEntryV1({ key });
     // FIXME what to do here? Does it make any sense to have the get() method
     // of the keychain be generically parameterized when we know we can only
     // return a string anyway?
@@ -129,7 +129,7 @@ export class PluginKeychainVaultRemoteAdapter
 
   public async set<T>(key: string, value: T): Promise<void> {
     // FIXME Does it make any sense to have the set() method be generic?
-    await this.backend.setKeychainEntry({
+    await this.backend.setKeychainEntryV1({
       key,
       value: (value as unknown) as string,
     });
@@ -139,7 +139,7 @@ export class PluginKeychainVaultRemoteAdapter
     // FIXME Pretty sure vault can do delete so we don't have to hack it like this
     // but it cannot be done in this code until the rust code has been updated
     // to have that endpoint as well...
-    await this.backend.setKeychainEntry({ key, value: "" });
+    await this.backend.setKeychainEntryV1({ key, value: "" });
   }
 
   public getInstanceId(): string {

--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/plugin-keychain-vault.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/plugin-keychain-vault.ts
@@ -1,7 +1,7 @@
-import { Server } from "http";
-import { Server as SecureServer } from "https";
+import type { Server } from "http";
+import type { Server as SecureServer } from "https";
 
-import { Express } from "express";
+import type { Express } from "express";
 import { Optional } from "typescript-optional";
 import Vault from "node-vault";
 import HttpStatus from "http-status-codes";
@@ -13,16 +13,11 @@ import {
   LoggerProvider,
 } from "@hyperledger/cactus-common";
 import {
-  ICactusPlugin,
   ICactusPluginOptions,
+  IPluginKeychain,
   IPluginWebService,
   IWebServiceEndpoint,
 } from "@hyperledger/cactus-core-api";
-
-// TODO: Writing the getExpressRequestHandler() method for
-// GetKeychainEntryEndpointV1 and SetKeychainEntryEndpointV1
-// import { GetKeychainEntryEndpointV1 } from "./web-services/get-keychain-entry-endpoint-v1";
-// import { SetKeychainEntryEndpointV1 } from "./web-services/set-keychain-entry-endpoint-v1";
 
 import { PrometheusExporter } from "./prometheus-exporter/prometheus-exporter";
 
@@ -30,6 +25,10 @@ import {
   IGetPrometheusExporterMetricsEndpointV1Options,
   GetPrometheusExporterMetricsEndpointV1,
 } from "./web-services/get-prometheus-exporter-metrics-endpoint-v1";
+import { GetKeychainEntryEndpointV1 } from "./web-services/get-keychain-entry-endpoint-v1";
+import { SetKeychainEntryEndpointV1 } from "./web-services/set-keychain-entry-endpoint-v1";
+import { HasKeychainEntryEndpointV1 } from "./web-services/has-keychain-entry-endpoint-v1";
+import { DeleteKeychainEntryEndpointV1 } from "./web-services/delete-keychain-entry-endpoint-v1";
 
 export interface IPluginKeychainVaultOptions extends ICactusPluginOptions {
   logLevel?: LogLevelDesc;
@@ -62,7 +61,7 @@ export interface IPluginKeychainVaultOptions extends ICactusPluginOptions {
 
 export const K_DEFAULT_KV_SECRETS_MOUNT_PATH = "secret/";
 
-export class PluginKeychainVault implements ICactusPlugin, IPluginWebService {
+export class PluginKeychainVault implements IPluginWebService, IPluginKeychain {
   public static readonly CLASS_NAME = "PluginKeychainVault";
 
   private readonly apiVersion: string;
@@ -143,23 +142,34 @@ export class PluginKeychainVault implements ICactusPlugin, IPluginWebService {
     }
     const endpoints: IWebServiceEndpoint[] = [];
 
-    // TODO: Writing the getExpressRequestHandler() method for
-    // GetKeychainEntryEndpointV1 and SetKeychainEntryEndpointV1
-
-    // {
-    //   const ep = new GetKeychainEntryEndpointV1({
-    //     logLevel: this.opts.logLevel,
-    //   });
-    //   ep.registerExpress(expressApp);
-    //   endpoints.push(ep);
-    // }
-    // {
-    //   const ep = new SetKeychainEntryEndpointV1({
-    //     logLevel: this.opts.logLevel,
-    //   });
-    //   ep.registerExpress(expressApp);
-    //   endpoints.push(ep);
-    // }
+    {
+      const ep = new GetKeychainEntryEndpointV1({
+        logLevel: this.opts.logLevel,
+        plugin: this,
+      });
+      endpoints.push(ep);
+    }
+    {
+      const ep = new SetKeychainEntryEndpointV1({
+        logLevel: this.opts.logLevel,
+        plugin: this,
+      });
+      endpoints.push(ep);
+    }
+    {
+      const ep = new HasKeychainEntryEndpointV1({
+        logLevel: this.opts.logLevel,
+        plugin: this,
+      });
+      endpoints.push(ep);
+    }
+    {
+      const ep = new DeleteKeychainEntryEndpointV1({
+        logLevel: this.opts.logLevel,
+        plugin: this,
+      });
+      endpoints.push(ep);
+    }
     {
       const opts: IGetPrometheusExporterMetricsEndpointV1Options = {
         plugin: this,
@@ -168,7 +178,6 @@ export class PluginKeychainVault implements ICactusPlugin, IPluginWebService {
       const ep = new GetPrometheusExporterMetricsEndpointV1(opts);
       endpoints.push(ep);
     }
-
     this.endpoints = endpoints;
 
     return endpoints;
@@ -203,7 +212,7 @@ export class PluginKeychainVault implements ICactusPlugin, IPluginWebService {
   }
 
   public getEncryptionAlgorithm(): string {
-    return null as any;
+    return "AES256";
   }
 
   protected pathFor(key: string): string {

--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/delete-keychain-entry-endpoint-v1.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/delete-keychain-entry-endpoint-v1.ts
@@ -16,23 +16,24 @@ import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";
 
 import OAS from "../../json/openapi.json";
 import { PluginKeychainVault } from "../plugin-keychain-vault";
+import { DeleteKeychainEntryResponseV1 } from "../generated/openapi/typescript-axios";
 
-export interface ISetKeychainEntryEndpointV1Options {
+export interface IDeleteKeychainEntryEndpointV1Options {
   logLevel?: LogLevelDesc;
   plugin: PluginKeychainVault;
 }
 
-export class SetKeychainEntryEndpointV1 implements IWebServiceEndpoint {
-  public static readonly CLASS_NAME = "SetKeychainEntryEndpointV1";
+export class DeleteKeychainEntryEndpointV1 implements IWebServiceEndpoint {
+  public static readonly CLASS_NAME = "DeleteKeychainEntryEndpointV1";
 
   private readonly log: Logger;
   private readonly plugin: PluginKeychainVault;
 
   public get className(): string {
-    return SetKeychainEntryEndpointV1.CLASS_NAME;
+    return DeleteKeychainEntryEndpointV1.CLASS_NAME;
   }
 
-  constructor(public readonly options: ISetKeychainEntryEndpointV1Options) {
+  constructor(public readonly options: IDeleteKeychainEntryEndpointV1Options) {
     const fnTag = `${this.className}#constructor()`;
     Checks.truthy(options, `${fnTag} arg options`);
     Checks.truthy(options.plugin, `${fnTag} arg options.plugin`);
@@ -49,9 +50,9 @@ export class SetKeychainEntryEndpointV1 implements IWebServiceEndpoint {
     this.log.debug(`Instantiated ${this.className} OK`);
   }
 
-  public get oasPath() {
+  private get oasPath() {
     return OAS.paths[
-      "/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/set-keychain-entry"
+      "/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/delete-keychain-entry"
     ].post;
   }
 
@@ -88,8 +89,10 @@ export class SetKeychainEntryEndpointV1 implements IWebServiceEndpoint {
     const tag = `${this.getVerbLowerCase().toUpperCase()} ${this.getPath()}`;
     try {
       this.log.debug(`${tag} %o`, req.body);
-      const { key, value } = req.body;
-      const resBody = await this.plugin.set(key, value);
+      await this.plugin.delete(req.body.key);
+      const resBody: DeleteKeychainEntryResponseV1 = {
+        key: req.body.key,
+      };
       res.status(200);
       res.json(resBody);
     } catch (ex) {

--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/get-keychain-entry-endpoint-v1.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/get-keychain-entry-endpoint-v1.ts
@@ -1,4 +1,4 @@
-import { Express } from "express";
+import type { Express, Request, Response } from "express";
 
 import {
   Logger,
@@ -15,15 +15,19 @@ import {
 import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";
 
 import OAS from "../../json/openapi.json";
+import { PluginKeychainVault } from "../plugin-keychain-vault";
+import { GetKeychainEntryResponse } from "../generated/openapi/typescript-axios";
 
 export interface IGetKeychainEntryEndpointV1Options {
   logLevel?: LogLevelDesc;
+  plugin: PluginKeychainVault;
 }
 
 export class GetKeychainEntryEndpointV1 implements IWebServiceEndpoint {
   public static readonly CLASS_NAME = "GetKeychainEntryEndpointV1";
 
   private readonly log: Logger;
+  private readonly plugin: PluginKeychainVault;
 
   public get className(): string {
     return GetKeychainEntryEndpointV1.CLASS_NAME;
@@ -32,6 +36,13 @@ export class GetKeychainEntryEndpointV1 implements IWebServiceEndpoint {
   constructor(public readonly options: IGetKeychainEntryEndpointV1Options) {
     const fnTag = `${this.className}#constructor()`;
     Checks.truthy(options, `${fnTag} arg options`);
+    Checks.truthy(options.plugin, `${fnTag} arg options.plugin`);
+    Checks.truthy(
+      options.plugin instanceof PluginKeychainVault,
+      `${fnTag} arg options.plugin instanceof PluginKeychainVault`,
+    );
+
+    this.plugin = options.plugin;
 
     const level = this.options.logLevel || "INFO";
     const label = this.className;
@@ -39,7 +50,7 @@ export class GetKeychainEntryEndpointV1 implements IWebServiceEndpoint {
     this.log.debug(`Instantiated ${this.className} OK`);
   }
 
-  private getOperation() {
+  private get oasPath() {
     return OAS.paths[
       "/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/get-keychain-entry"
     ].post;
@@ -63,14 +74,32 @@ export class GetKeychainEntryEndpointV1 implements IWebServiceEndpoint {
   }
 
   public getVerbLowerCase(): string {
-    return this.getOperation()["x-hyperledger-cactus"].http.verbLowerCase;
+    return this.oasPath["x-hyperledger-cactus"].http.verbLowerCase;
   }
 
   public getPath(): string {
-    return this.getOperation()["x-hyperledger-cactus"].http.path;
+    return this.oasPath["x-hyperledger-cactus"].http.path;
   }
 
   public getExpressRequestHandler(): IExpressRequestHandler {
-    throw new Error("Method not implemented.");
+    return this.handleRequest.bind(this);
+  }
+
+  public async handleRequest(req: Request, res: Response): Promise<void> {
+    const tag = `${this.getVerbLowerCase().toUpperCase()} ${this.getPath()}`;
+    try {
+      this.log.debug(`${tag} %o`, req.body);
+      const value = await this.plugin.get(req.body.key);
+      const resBody: GetKeychainEntryResponse = {
+        key: req.body.key,
+        value: value as string,
+      };
+      res.status(200);
+      res.json(resBody);
+    } catch (ex) {
+      this.log.debug(`${tag} Failed to serve request:`, ex);
+      res.status(500);
+      res.json({ error: ex.stack });
+    }
   }
 }

--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/has-keychain-entry-endpoint-v1.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/has-keychain-entry-endpoint-v1.ts
@@ -16,23 +16,24 @@ import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";
 
 import OAS from "../../json/openapi.json";
 import { PluginKeychainVault } from "../plugin-keychain-vault";
+import { HasKeychainEntryResponseV1 } from "../generated/openapi/typescript-axios";
 
-export interface ISetKeychainEntryEndpointV1Options {
+export interface IHasKeychainEntryEndpointV1Options {
   logLevel?: LogLevelDesc;
   plugin: PluginKeychainVault;
 }
 
-export class SetKeychainEntryEndpointV1 implements IWebServiceEndpoint {
-  public static readonly CLASS_NAME = "SetKeychainEntryEndpointV1";
+export class HasKeychainEntryEndpointV1 implements IWebServiceEndpoint {
+  public static readonly CLASS_NAME = "HasKeychainEntryEndpointV1";
 
   private readonly log: Logger;
   private readonly plugin: PluginKeychainVault;
 
   public get className(): string {
-    return SetKeychainEntryEndpointV1.CLASS_NAME;
+    return HasKeychainEntryEndpointV1.CLASS_NAME;
   }
 
-  constructor(public readonly options: ISetKeychainEntryEndpointV1Options) {
+  constructor(public readonly options: IHasKeychainEntryEndpointV1Options) {
     const fnTag = `${this.className}#constructor()`;
     Checks.truthy(options, `${fnTag} arg options`);
     Checks.truthy(options.plugin, `${fnTag} arg options.plugin`);
@@ -49,9 +50,9 @@ export class SetKeychainEntryEndpointV1 implements IWebServiceEndpoint {
     this.log.debug(`Instantiated ${this.className} OK`);
   }
 
-  public get oasPath() {
+  private get oasPath() {
     return OAS.paths[
-      "/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/set-keychain-entry"
+      "/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/has-keychain-entry"
     ].post;
   }
 
@@ -88,8 +89,12 @@ export class SetKeychainEntryEndpointV1 implements IWebServiceEndpoint {
     const tag = `${this.getVerbLowerCase().toUpperCase()} ${this.getPath()}`;
     try {
       this.log.debug(`${tag} %o`, req.body);
-      const { key, value } = req.body;
-      const resBody = await this.plugin.set(key, value);
+      const isPresent = await this.plugin.has(req.body.key);
+      const resBody: HasKeychainEntryResponseV1 = {
+        isPresent,
+        checkedAt: new Date().toJSON(),
+        key: req.body.key,
+      };
       res.status(200);
       res.json(resBody);
     } catch (ex) {

--- a/packages/cactus-plugin-keychain-vault/src/test/typescript/integration/cactus-keychain-vault-server.test.ts
+++ b/packages/cactus-plugin-keychain-vault/src/test/typescript/integration/cactus-keychain-vault-server.test.ts
@@ -54,10 +54,10 @@ test("NodeJS API client + Rust plugin works together", async (tMain: Test) => {
   const expected = uuidv4();
 
   tMain.comment("Calling set keychain entry...");
-  await apiClient.setKeychainEntry({ key, value: expected });
+  await apiClient.setKeychainEntryV1({ key, value: expected });
   const {
     data: { value: actual },
-  } = await apiClient.getKeychainEntry({ key });
+  } = await apiClient.getKeychainEntryV1({ key });
 
   tMain.equal(actual, expected, "Keychain stored value matches input OK");
 

--- a/packages/cactus-test-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
+++ b/packages/cactus-test-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
@@ -100,10 +100,10 @@ test("NodeJS API server + Rust plugin work together", async (t: Test) => {
   const key = uuidv4();
   const expected = uuidv4();
 
-  await apiClient.setKeychainEntry({ key, value: expected });
+  await apiClient.setKeychainEntryV1({ key, value: expected });
   const {
     data: { value: actual },
-  } = await apiClient.getKeychainEntry({ key });
+  } = await apiClient.getKeychainEntryV1({ key });
 
   t.equal(actual, expected, "Keychain stored value matches input OK");
 

--- a/packages/cactus-test-tooling/package-lock.json
+++ b/packages/cactus-test-tooling/package-lock.json
@@ -39,8 +39,7 @@
 				"@types/ssh2-streams": "0.1.8",
 				"@types/tar-stream": "2.1.0",
 				"@types/temp": "0.9.0",
-				"esm": "3.2.25",
-				"temp": "0.9.4"
+				"esm": "3.2.25"
 			},
 			"engines": {
 				"node": ">=10",
@@ -4559,7 +4558,6 @@
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
 			"integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
-			"dev": true,
 			"dependencies": {
 				"mkdirp": "^0.5.1",
 				"rimraf": "~2.6.2"
@@ -4572,7 +4570,6 @@
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-			"dev": true,
 			"dependencies": {
 				"minimist": "^1.2.5"
 			},
@@ -4584,7 +4581,6 @@
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
 			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-			"dev": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -10346,7 +10342,6 @@
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
 			"integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
-			"dev": true,
 			"requires": {
 				"mkdirp": "^0.5.1",
 				"rimraf": "~2.6.2"
@@ -10356,7 +10351,6 @@
 					"version": "0.5.5",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-					"dev": true,
 					"requires": {
 						"minimist": "^1.2.5"
 					}
@@ -10365,7 +10359,6 @@
 					"version": "2.6.3",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
 					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
 					}


### PR DESCRIPTION
1. Adds the has/delete endpoints (which were missing completely)
2. Adds the get/set endpoints which were partially already implemented.
3. Moves the express dependency to be a dev dependency since we only
use the types (e.g. only needed at compile time, not at runtime)
4. Adds specific test cases to the API client verifying the
get/set/has/delete endpoints
5. Renames the getKeychainEntry and setKeychainEntry operationIDs
to have a V1 suffix.

Fixes #676

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

cc: @Zzocker @sichen1234