### PR TITLE
feat(connector-fabric): endorsing peers request arg #1122

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -29,6 +29,7 @@
         "escc",
         "execa",
         "faio",
+        "fidm",
         "fsouza",
         "GETHKEYCHAINPASSWORD",
         "ghcr",

--- a/packages/cactus-plugin-ledger-connector-fabric/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/package.json
@@ -72,6 +72,7 @@
   },
   "homepage": "https://github.com/hyperledger/cactus#readme",
   "dependencies": {
+    "@fidm/x509": "1.2.1",
     "@hyperledger/cactus-common": "0.6.0",
     "@hyperledger/cactus-core": "0.6.0",
     "@hyperledger/cactus-core-api": "0.6.0",

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/json/openapi.json
@@ -331,6 +331,16 @@
                     "params"
                 ],
                 "properties": {
+                    "endorsingPeers": {
+                        "description": "An array of MSP IDs to set as the list of endorsing peers for the transaction.",
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 4096,
+                            "nullable": false
+                        }
+                    },
                     "transientData": {
                         "type": "object",
                         "nullable": true

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -681,6 +681,12 @@ export interface InlineResponse501 {
  */
 export interface RunTransactionRequest {
     /**
+     * An array of MSP IDs to set as the list of endorsing peers for the transaction.
+     * @type {Array<string>}
+     * @memberof RunTransactionRequest
+     */
+    endorsingPeers?: Array<string>;
+    /**
      * 
      * @type {object}
      * @memberof RunTransactionRequest

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
@@ -232,6 +232,29 @@ test(testCase, async (t: Test) => {
   }
 
   {
+    const req: RunTransactionRequest = {
+      signingCredential,
+      gatewayOptions: {
+        identity: keychainEntryKey,
+        wallet: {
+          json: keychainEntryValue,
+        },
+      },
+      channelName,
+      invocationType: FabricContractInvocationType.Send,
+      contractName,
+      methodName: "CreateAsset",
+      params: ["asset388", "green", "111", assetOwner, "299"],
+      endorsingPeers: ["org1.example.com", "Org2MSP"],
+    };
+
+    const res = await apiClient.runTransactionV1(req);
+    t.ok(res, "Create green asset response truthy OK");
+    t.ok(res.data, "Create green asset response.data truthy OK");
+    t.equal(res.status, 200, "Create green asset response.status=200 OK");
+  }
+
+  {
     const res = await apiClient.runTransactionV1({
       gatewayOptions: {
         connectionProfile,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1798,6 +1798,19 @@
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
 
+"@fidm/asn1@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@fidm/asn1/-/asn1-1.0.4.tgz#afbf9f10a0cb83aca2114c6f59a97dd48eb7dd84"
+  integrity sha512-esd1jyNvRb2HVaQGq2Gg8Z0kbQPXzV9Tq5Z14KNIov6KfFD6PTaRIO8UpcsYiTNzOqJpmyzWgVTrUwFV3UF4TQ==
+
+"@fidm/x509@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@fidm/x509/-/x509-1.2.1.tgz#ae546a661005d776cc4dca674b399c1132c1e0e4"
+  integrity sha512-nwc2iesjyc9hkuzcrMCBXQRn653XuAUKorfWM8PZyJawiy1QzLj4vahwzaI25+pfpwOLvMzbJ0uKpWLDNmo16w==
+  dependencies:
+    "@fidm/asn1" "^1.0.4"
+    tweetnacl "^1.0.1"
+
 "@grpc/grpc-js@^1.3.4":
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.3.6.tgz#6e2d17610c2c8df0f6ceab0e1968f563df74b173"
@@ -19424,7 +19437,7 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-tweetnacl@^1.0.3:
+tweetnacl@^1.0.1, tweetnacl@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz"
   integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==


### PR DESCRIPTION
Makes it possible to set the endorsing peers on a transaction
when submitted through the Fabric connector.

For example these values can be passed in to the new parameter
and it will set the endorsers up accordingly prior to submitting
the transaction to the ledger:
- org1.example.com
- Org1MSP
- org2.example.com
- Org2MSP

(You only need either the org domain or the msp ID, no need
to specify both of them for it to work).

For a working example, see this test case:
packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts

Depends on #1123
Depends on #1130

Fixes #1122

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>