### PR TITLE
build(deps): fix sync-npm-deps-to-tsc-projects tool

### DIFF
--- a/examples/cactus-example-carbon-accounting-backend/tsconfig.json
+++ b/examples/cactus-example-carbon-accounting-backend/tsconfig.json
@@ -41,7 +41,7 @@
   ],
   "include": [
     "./src",
-    "src/**/*.json",
+    "src/**/*.json"
   ],
   "exclude": [
     "./src/utility-emissions-channel"

--- a/examples/cactus-example-carbon-accounting-business-logic-plugin/tsconfig.json
+++ b/examples/cactus-example-carbon-accounting-business-logic-plugin/tsconfig.json
@@ -9,7 +9,7 @@
   },
   "include": [
     "./src",
-    "src/**/*.json",
+    "src/**/*.json"
   ],
   "references": [
     {

--- a/examples/cactus-example-supply-chain-backend/tsconfig.json
+++ b/examples/cactus-example-supply-chain-backend/tsconfig.json
@@ -9,7 +9,7 @@
   },
   "include": [
     "./src",
-    "src/**/*.json",
+    "src/**/*.json"
   ],
   "references": [
     {

--- a/examples/cactus-example-supply-chain-business-logic-plugin/tsconfig.json
+++ b/examples/cactus-example-supply-chain-business-logic-plugin/tsconfig.json
@@ -9,7 +9,7 @@
   },
   "include": [
     "./src",
-    "src/**/*.json",
+    "src/**/*.json"
   ],
   "references": [
     {

--- a/extensions/cactus-plugin-object-store-ipfs/tsconfig.json
+++ b/extensions/cactus-plugin-object-store-ipfs/tsconfig.json
@@ -1,10 +1,27 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist/lib/", /* Redirect output structure to the directory. */
+    "outDir": "./dist/lib/",
     "declarationDir": "dist/types",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "../../.build-cache/cactus-plugin-object-store-ipfs.tsbuildinfo",
+    "skipLibCheck": true
   },
   "include": [
     "./src"
+  ],
+  "references": [
+    {
+      "path": "../../packages/cactus-common/tsconfig.json"
+    },
+    {
+      "path": "../../packages/cactus-core/tsconfig.json"
+    },
+    {
+      "path": "../../packages/cactus-core-api/tsconfig.json"
+    },
+    {
+      "path": "../../packages/cactus-test-tooling/tsconfig.json"
+    }
   ]
 }

--- a/packages/cactus-cmd-api-server/package.json
+++ b/packages/cactus-cmd-api-server/package.json
@@ -100,7 +100,6 @@
     "uuid": "7.0.2"
   },
   "devDependencies": {
-    "@hyperledger/cactus-cockpit": "0.5.0",
     "@hyperledger/cactus-plugin-keychain-vault": "0.6.0",
     "@hyperledger/cactus-test-tooling": "0.6.0",
     "@types/compression": "1.7.0",

--- a/packages/cactus-cmd-api-server/tsconfig.json
+++ b/packages/cactus-cmd-api-server/tsconfig.json
@@ -9,7 +9,7 @@
   },
   "include": [
     "./src",
-    "src/**/*.json",
+    "src/**/*.json"
   ],
   "references": [
     {

--- a/packages/cactus-core-api/tsconfig.json
+++ b/packages/cactus-core-api/tsconfig.json
@@ -9,7 +9,7 @@
   },
   "include": [
     "./src",
-    "src/**/*.json",
+    "src/**/*.json"
   ],
   "references": [
     {

--- a/packages/cactus-plugin-consortium-manual/tsconfig.json
+++ b/packages/cactus-plugin-consortium-manual/tsconfig.json
@@ -9,7 +9,7 @@
   },
   "include": [
     "./src",
-    "**/openapi.json",
+    "**/openapi.json"
   ],
   "references": [
     {

--- a/packages/cactus-plugin-htlc-eth-besu-erc20/tsconfig.json
+++ b/packages/cactus-plugin-htlc-eth-besu-erc20/tsconfig.json
@@ -10,7 +10,7 @@
   },
   "include": [
     "./src",
-    "src/**/*.json",
+    "src/**/*.json"
   ],
   "references": [
     {

--- a/packages/cactus-plugin-htlc-eth-besu/tsconfig.json
+++ b/packages/cactus-plugin-htlc-eth-besu/tsconfig.json
@@ -10,7 +10,7 @@
   },
   "include": [
     "./src",
-    "src/**/*.json",
+    "src/**/*.json"
   ],
   "references": [
     {

--- a/packages/cactus-plugin-keychain-aws-sm/tsconfig.json
+++ b/packages/cactus-plugin-keychain-aws-sm/tsconfig.json
@@ -5,11 +5,11 @@
     "outDir": "./dist/lib/",
     "declarationDir": "dist/types",
     "rootDir": "./src",
-    "tsBuildInfoFile": "../../.build-cache/cactus-plugin-keychain-vault.tsbuildinfo"
+    "tsBuildInfoFile": "../../.build-cache/cactus-plugin-keychain-aws-sm.tsbuildinfo"
   },
   "include": [
     "./src",
-    "**/openapi.json",
+    "**/openapi.json"
   ],
   "references": [
     {

--- a/packages/cactus-plugin-keychain-azure-kv/tsconfig.json
+++ b/packages/cactus-plugin-keychain-azure-kv/tsconfig.json
@@ -9,7 +9,7 @@
   },
   "include": [
     "./src",
-    "**/openapi.json",
+    "**/openapi.json"
   ],
   "references": [
     {

--- a/packages/cactus-plugin-keychain-google-sm/tsconfig.json
+++ b/packages/cactus-plugin-keychain-google-sm/tsconfig.json
@@ -9,7 +9,7 @@
   },
   "include": [
     "./src",
-    "**/openapi.json",
+    "**/openapi.json"
   ],
   "references": [
     {

--- a/packages/cactus-plugin-keychain-memory/tsconfig.json
+++ b/packages/cactus-plugin-keychain-memory/tsconfig.json
@@ -9,7 +9,7 @@
   },
   "include": [
     "./src",
-    "**/openapi.json",
+    "**/openapi.json"
   ],
   "references": [
     {

--- a/packages/cactus-plugin-keychain-vault/tsconfig.json
+++ b/packages/cactus-plugin-keychain-vault/tsconfig.json
@@ -9,7 +9,7 @@
   },
   "include": [
     "./src",
-    "**/openapi.json",
+    "**/openapi.json"
   ],
   "references": [
     {

--- a/packages/cactus-plugin-ledger-connector-besu/tsconfig.json
+++ b/packages/cactus-plugin-ledger-connector-besu/tsconfig.json
@@ -10,7 +10,7 @@
   },
   "include": [
     "./src",
-    "src/**/*.json",
+    "src/**/*.json"
   ],
   "references": [
     {

--- a/packages/cactus-plugin-ledger-connector-corda/tsconfig.json
+++ b/packages/cactus-plugin-ledger-connector-corda/tsconfig.json
@@ -10,7 +10,7 @@
   },
   "include": [
     "./src",
-    "src/**/*.json",
+    "src/**/*.json"
   ],
   "references": [
     {

--- a/packages/cactus-plugin-ledger-connector-fabric/tsconfig.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/tsconfig.json
@@ -10,7 +10,7 @@
   },
   "include": [
     "./src",
-    "src/**/*.json",
+    "src/**/*.json"
   ],
   "exclude": [
     "./src/test/typescript/fixtures/go/basic-asset-transfer/chaincode-typescript/**/*.ts"

--- a/packages/cactus-plugin-ledger-connector-quorum/tsconfig.json
+++ b/packages/cactus-plugin-ledger-connector-quorum/tsconfig.json
@@ -10,7 +10,7 @@
   },
   "include": [
     "./src",
-    "src/**/*.json",
+    "src/**/*.json"
   ],
   "references": [
     {

--- a/packages/cactus-plugin-ledger-connector-xdai/tsconfig.json
+++ b/packages/cactus-plugin-ledger-connector-xdai/tsconfig.json
@@ -10,7 +10,7 @@
   },
   "include": [
     "./src",
-    "src/**/*.json",
+    "src/**/*.json"
   ],
   "references": [
     {

--- a/packages/cactus-test-plugin-htlc-eth-besu-erc20/tsconfig.json
+++ b/packages/cactus-test-plugin-htlc-eth-besu-erc20/tsconfig.json
@@ -10,7 +10,7 @@
   },
   "include": [
     "./src",
-    "src/**/*.json",
+    "src/**/*.json"
   ],
   "references": [
     {

--- a/packages/cactus-test-plugin-htlc-eth-besu/tsconfig.json
+++ b/packages/cactus-test-plugin-htlc-eth-besu/tsconfig.json
@@ -10,7 +10,7 @@
   },
   "include": [
     "./src",
-    "src/**/*.json",
+    "src/**/*.json"
   ],
   "references": [
     {
@@ -26,16 +26,16 @@
       "path": "../cactus-core-api/tsconfig.json"
     },
     {
-      "path": "../cactus-plugin-keychain-memory/tsconfig.json"
-    },
-    {
       "path": "../cactus-plugin-htlc-eth-besu/tsconfig.json"
     },
     {
-      "path": "../cactus-test-tooling/tsconfig.json"
+      "path": "../cactus-plugin-keychain-memory/tsconfig.json"
     },
     {
       "path": "../cactus-plugin-ledger-connector-besu/tsconfig.json"
+    },
+    {
+      "path": "../cactus-test-tooling/tsconfig.json"
     }
   ]
 }

--- a/packages/cactus-test-plugin-ledger-connector-quorum/tsconfig.json
+++ b/packages/cactus-test-plugin-ledger-connector-quorum/tsconfig.json
@@ -10,7 +10,7 @@
   },
   "include": [
     "./src",
-    "src/**/*.json",
+    "src/**/*.json"
   ],
   "references": [
     {

--- a/tools/sync-npm-deps-to-tsc-projects.ts
+++ b/tools/sync-npm-deps-to-tsc-projects.ts
@@ -85,6 +85,26 @@ const main = async (argv: string[], env: NodeJS.ProcessEnv) => {
     console.log(newTsConfigJson);
     await fs.writeFile(tsConfigPath, newTsConfigJson);
   }
+
+  const tsConfigReferences = tsConfigPaths.map((it) => ({
+    path: "./" + path.relative(PROJECT_DIR, it),
+  }));
+  await updateRootTsConfig({ PROJECT_DIR, tsConfigReferences });
 };
+
+export async function updateRootTsConfig(req: {
+  PROJECT_DIR: string;
+  tsConfigReferences: Array<{ path: string }>;
+}): Promise<void> {
+  const tsConfigPath = path.join(req.PROJECT_DIR, "./tsconfig.json");
+  const tsConfigBuffer = await fs.readFile(tsConfigPath);
+  const tsConfigJson = tsConfigBuffer.toString("utf-8");
+  const tsConfig = JSON5.parse(tsConfigJson);
+  tsConfig.references = req.tsConfigReferences;
+  const newTsConfigJson = JSON.stringify(tsConfig, null, 2);
+  console.log(`New tsconfig.json contents for ${tsConfigPath}: `);
+  console.log(newTsConfigJson);
+  await fs.writeFile(tsConfigPath, newTsConfigJson);
+}
 
 main(process.argv, process.env);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,127 +1,128 @@
 {
   "files": [],
   "references": [
-    { "path": "./packages/cactus-common/tsconfig.json" },
-    { "path": "./packages/cactus-core-api/tsconfig.json" },
-    { "path": "./packages/cactus-test-tooling/tsconfig.json" },
-    { "path": "./packages/cactus-core/tsconfig.json" },
-    { "path": "./packages/cactus-plugin-consortium-manual/tsconfig.json" },
-    { "path": "./packages/cactus-plugin-keychain-aws-sm/tsconfig.json" },
-    { "path": "./packages/cactus-plugin-keychain-google-sm/tsconfig.json" },
-    { "path": "./packages/cactus-plugin-keychain-azure-kv/tsconfig.json" },
-    { "path": "./packages/cactus-plugin-keychain-memory/tsconfig.json" },
-    { "path": "./packages/cactus-plugin-keychain-vault/tsconfig.json" },
-    { "path": "./packages/cactus-plugin-ledger-connector-corda/tsconfig.json" },
-    { "path": "./packages/cactus-api-client/tsconfig.json" },
-    { "path": "./packages/cactus-plugin-ledger-connector-besu/tsconfig.json" },
+    {
+      "path": "./packages/cactus-api-client/tsconfig.json"
+    },
+    {
+      "path": "./packages/cactus-cmd-api-server/tsconfig.json"
+    },
+    {
+      "path": "./packages/cactus-common/tsconfig.json"
+    },
+    {
+      "path": "./packages/cactus-core/tsconfig.json"
+    },
+    {
+      "path": "./packages/cactus-core-api/tsconfig.json"
+    },
+    {
+      "path": "./packages/cactus-plugin-consortium-manual/tsconfig.json"
+    },
+    {
+      "path": "./packages/cactus-plugin-htlc-eth-besu-erc20/tsconfig.json"
+    },
+    {
+      "path": "./packages/cactus-plugin-keychain-aws-sm/tsconfig.json"
+    },
+    {
+      "path": "./packages/cactus-plugin-keychain-azure-kv/tsconfig.json"
+    },
+    {
+      "path": "./packages/cactus-plugin-keychain-google-sm/tsconfig.json"
+    },
+    {
+      "path": "./packages/cactus-plugin-keychain-memory/tsconfig.json"
+    },
+    {
+      "path": "./packages/cactus-plugin-htlc-eth-besu/tsconfig.json"
+    },
+    {
+      "path": "./packages/cactus-plugin-ledger-connector-besu/tsconfig.json"
+    },
+    {
+      "path": "./packages/cactus-plugin-keychain-vault/tsconfig.json"
+    },
+    {
+      "path": "./packages/cactus-plugin-ledger-connector-corda/tsconfig.json"
+    },
     {
       "path": "./packages/cactus-plugin-ledger-connector-fabric/tsconfig.json"
     },
     {
       "path": "./packages/cactus-plugin-ledger-connector-quorum/tsconfig.json"
     },
-    { "path": "./packages/cactus-plugin-ledger-connector-xdai/tsconfig.json" },
     {
-      "path": "./examples/cactus-example-carbon-accounting-business-logic-plugin/tsconfig.json"
+      "path": "./packages/cactus-plugin-ledger-connector-xdai/tsconfig.json"
     },
     {
-      "path": "./examples/cactus-example-supply-chain-business-logic-plugin/tsconfig.json"
+      "path": "./packages/cactus-test-api-client/tsconfig.json"
     },
-    { "path": "./packages/cactus-plugin-htlc-eth-besu-erc20/tsconfig.json" },
-    { "path": "./packages/cactus-plugin-htlc-eth-besu/tsconfig.json" },
     {
-      "path": "./examples/cactus-example-carbon-accounting-frontend/tsconfig.json"
+      "path": "./packages/cactus-test-cmd-api-server/tsconfig.json"
     },
-    { "path": "./examples/cactus-example-supply-chain-frontend/tsconfig.json" },
-    { "path": "./packages/cactus-cmd-api-server/tsconfig.json" },
     {
-      "path": "./examples/cactus-example-carbon-accounting-backend/tsconfig.json"
+      "path": "./packages/cactus-test-plugin-consortium-manual/tsconfig.json"
     },
-    { "path": "./examples/cactus-example-supply-chain-backend/tsconfig.json" },
-
-
-    { "path": "./packages/cactus-test-api-client/tsconfig.json" },
-    { "path": "./packages/cactus-test-cmd-api-server/tsconfig.json" },
-    { "path": "./packages/cactus-test-plugin-consortium-manual/tsconfig.json" },
+    {
+      "path": "./packages/cactus-test-plugin-htlc-eth-besu/tsconfig.json"
+    },
     {
       "path": "./packages/cactus-test-plugin-htlc-eth-besu-erc20/tsconfig.json"
     },
-    { "path": "./packages/cactus-test-plugin-htlc-eth-besu/tsconfig.json" },
     {
       "path": "./packages/cactus-test-plugin-ledger-connector-besu/tsconfig.json"
     },
     {
       "path": "./packages/cactus-test-plugin-ledger-connector-quorum/tsconfig.json"
     },
-
+    {
+      "path": "./packages/cactus-test-tooling/tsconfig.json"
+    },
+    {
+      "path": "./examples/cactus-example-carbon-accounting-backend/tsconfig.json"
+    },
+    {
+      "path": "./examples/cactus-example-carbon-accounting-business-logic-plugin/tsconfig.json"
+    },
+    {
+      "path": "./examples/cactus-example-supply-chain-backend/tsconfig.json"
+    },
+    {
+      "path": "./examples/cactus-example-carbon-accounting-frontend/tsconfig.json"
+    },
+    {
+      "path": "./examples/cactus-example-supply-chain-business-logic-plugin/tsconfig.json"
+    },
+    {
+      "path": "./examples/cactus-example-supply-chain-frontend/tsconfig.json"
+    },
+    {
+      "path": "./extensions/cactus-plugin-object-store-ipfs/tsconfig.json"
+    }
   ],
   "compilerOptions": {
-    /* Basic Options */
-    "incremental": true /* Enable incremental compilation */,
-    "target": "ES2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
-    "module": "CommonJS" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "incremental": true,
+    "target": "ES2017",
+    "module": "CommonJS",
     "lib": [
       "es2015",
       "es2016",
       "es2017",
       "es2019",
       "dom"
-    ] /* Specify library files to be included in the compilation. */,
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true /* Generates corresponding '.d.ts' file. */,
-    // "declarationDir": "dist/types",
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true, /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./dist/lib/",
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
-    "removeComments": false /* Do not emit comments to output. */,
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-    /* Strict Type-Checking Options */
-    "strict": true /* Enable all strict type-checking options. */,
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-    /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-    /* Module Resolution Options */
-    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
-    "resolveJsonModule": true /* When true allows the importing of json files in Typescript code */,
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    ],
+    "declaration": true,
+    "removeComments": false,
+    "strict": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
     "typeRoots": [
       "./node_modules/@types",
       "./typings"
-    ] /* List of folders to include type definitions from. */,
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    "inlineSourceMap": true /* Emit a single file with source maps instead of having a separate file. */,
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-    /* Advanced Options */
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+    ],
+    "esModuleInterop": true,
+    "inlineSourceMap": true,
+    "forceConsistentCasingInFileNames": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,13 +169,6 @@
     symbol-observable "4.0.0"
     uuid "8.3.2"
 
-"@angular/common@11.2.1":
-  version "11.2.1"
-  resolved "https://registry.npmjs.org/@angular/common/-/common-11.2.1.tgz"
-  integrity sha512-6FuZvJkYq8ZD4Bi6n7zaok1BMe5ve3EZDXLM7cDl2Hktpc+z0/mIZtVYMR0zvf7VX48E4zUU039779ixy0zDMw==
-  dependencies:
-    tslib "^2.0.0"
-
 "@angular/common@12.1.1":
   version "12.1.1"
   resolved "https://registry.npmjs.org/@angular/common/-/common-12.1.1.tgz"
@@ -215,13 +208,6 @@
   resolved "https://registry.npmjs.org/@angular/compiler/-/compiler-9.0.0.tgz"
   integrity sha512-ctjwuntPfZZT2mNj2NDIVu51t9cvbhl/16epc5xEwyzyDt76pX9UgwvY+MbXrf/C/FWwdtmNtfP698BKI+9leQ==
 
-"@angular/core@11.2.1":
-  version "11.2.1"
-  resolved "https://registry.npmjs.org/@angular/core/-/core-11.2.1.tgz"
-  integrity sha512-FfMMG9yWW1xfZmHp8NtXJlNbLrgZ5Fm7FguRfTAuH007gDoknm+V3INKGyQfYOsIlxuJCSzyEeM3270lmbzYaQ==
-  dependencies:
-    tslib "^2.0.0"
-
 "@angular/core@12.1.1":
   version "12.1.1"
   resolved "https://registry.npmjs.org/@angular/core/-/core-12.1.1.tgz"
@@ -233,13 +219,6 @@
   version "9.0.0"
   resolved "https://registry.npmjs.org/@angular/core/-/core-9.0.0.tgz"
   integrity sha512-6Pxgsrf0qF9iFFqmIcWmjJGkkCaCm6V5QNnxMy2KloO3SDq6QuMVRbN9RtC8Urmo25LP+eZ6ZgYqFYpdD8Hd9w==
-
-"@angular/forms@11.2.1":
-  version "11.2.1"
-  resolved "https://registry.npmjs.org/@angular/forms/-/forms-11.2.1.tgz"
-  integrity sha512-/Xy1DQCZkCs1qWudmxooscPmVDkOEsgy9YJIoAYzsrRNINOpggBxBYRO9dztRmp2yDvRSAFTylmfQyTOrWrK7Q==
-  dependencies:
-    tslib "^2.0.0"
 
 "@angular/forms@12.1.1":
   version "12.1.1"
@@ -253,13 +232,6 @@
   resolved "https://registry.npmjs.org/@angular/language-service/-/language-service-12.1.1.tgz"
   integrity sha512-8jpfEJcK2rO6JFhqrSoHqAXyIiOmWtAnl6cNkvzvQjQgrzlIwFuixEgcohq8QaKN4vWYZtnX6YKxUakNmGo+Ww==
 
-"@angular/platform-browser-dynamic@11.2.1":
-  version "11.2.1"
-  resolved "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-11.2.1.tgz"
-  integrity sha512-7DEAwy3w2GqhVDe9e5AZoFFEd6e/cnACkz39R4VWY8YiSz/HFtOQ7lQPmjzkmXMEKuGVnQzFwD4aAQWXd/myQg==
-  dependencies:
-    tslib "^2.0.0"
-
 "@angular/platform-browser-dynamic@12.1.1":
   version "12.1.1"
   resolved "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-12.1.1.tgz"
@@ -267,26 +239,12 @@
   dependencies:
     tslib "^2.2.0"
 
-"@angular/platform-browser@11.2.1":
-  version "11.2.1"
-  resolved "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-11.2.1.tgz"
-  integrity sha512-wu1B6AY0Om1Pj3U7woLGNbuAgajKEg+B6IKIaCwXv03lID53hpMagyBiNJLLEL6PIRO33G3rPbRKW9gGEr52vg==
-  dependencies:
-    tslib "^2.0.0"
-
 "@angular/platform-browser@12.1.1":
   version "12.1.1"
   resolved "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-12.1.1.tgz"
   integrity sha512-R78K0DYxplYUvctq/7MvoBjuMDgMNrL1h8Bov0g7lN5hQWBQwBjl//CiJgx8H7uSiba9DQ0Jwu5Xxvkzkr8ggA==
   dependencies:
     tslib "^2.2.0"
-
-"@angular/router@11.2.1":
-  version "11.2.1"
-  resolved "https://registry.npmjs.org/@angular/router/-/router-11.2.1.tgz"
-  integrity sha512-YAq3zO8xdfjqEZ8Ur3go+5JXGIwpSTDj86dzZUMhTIsUuSVluBNdG1A+BQV2X5QNLh7VtdwfW5Npbjkn0Go/Cw==
-  dependencies:
-    tslib "^2.0.0"
 
 "@angular/router@12.1.1":
   version "12.1.1"
@@ -1992,95 +1950,6 @@
   resolved "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
-"@hyperledger/cactus-api-client@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@hyperledger/cactus-api-client/-/cactus-api-client-0.5.0.tgz#3ef013f76669fc12fa0526c24b72a015878fad08"
-  integrity sha512-ALrDtoGqNHZ6I/KOUWfrHTpZINlxBR/SFl7uG/pZNR/mWZqO1BBPKPseAyTr04r2uT3eYkLzozzzoFB5MMtZig==
-  dependencies:
-    "@hyperledger/cactus-common" "0.5.0"
-    "@hyperledger/cactus-core" "0.5.0"
-    "@hyperledger/cactus-core-api" "0.5.0"
-    "@hyperledger/cactus-plugin-consortium-manual" "0.5.0"
-
-"@hyperledger/cactus-cockpit@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.npmjs.org/@hyperledger/cactus-cockpit/-/cactus-cockpit-0.5.0.tgz"
-  integrity sha512-5XiWesg6+5NRCybNsV2CXnLwMkv42DSQ3DUVC6DFKRZAi+Hf1i28JyavMHW9lBX8cRfar54p/AtBnaPS5tDd9g==
-  dependencies:
-    "@angular/common" "11.2.1"
-    "@angular/core" "11.2.1"
-    "@angular/forms" "11.2.1"
-    "@angular/platform-browser" "11.2.1"
-    "@angular/platform-browser-dynamic" "11.2.1"
-    "@angular/router" "11.2.1"
-    "@hyperledger/cactus-api-client" "0.5.0"
-    "@hyperledger/cactus-common" "0.5.0"
-    "@hyperledger/cactus-plugin-consortium-manual" "0.5.0"
-    "@ionic-native/core" "5.0.0"
-    "@ionic-native/splash-screen" "5.0.0"
-    "@ionic-native/status-bar" "5.0.0"
-    "@ionic/angular" "5.1.1"
-    jwt-decode "2.2.0"
-    rxjs "6.5.5"
-    zone.js "~0.10.2"
-
-"@hyperledger/cactus-common@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@hyperledger/cactus-common/-/cactus-common-0.5.0.tgz#0b0544424db12e06a5c626f235fb832861b652db"
-  integrity sha512-FMWE+9UJUpiaiESbULfbF/Q7GG9CH3jVCl6pqJMU673tsryCL6U/IgYEiRFW4aOFr+g81McG2xiUZ31E52696g==
-  dependencies:
-    json-stable-stringify "1.0.1"
-    key-encoder "2.0.3"
-    loglevel "1.6.7"
-    loglevel-plugin-prefix "0.8.4"
-    secp256k1 "4.0.2"
-    sha3 "2.1.3"
-
-"@hyperledger/cactus-core-api@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@hyperledger/cactus-core-api/-/cactus-core-api-0.5.0.tgz#3a8c47ebb9633b0b07d59c78ad1b01f1900fcc9c"
-  integrity sha512-Ba3vFellXjRoVd25Zw4+CQEZxrKVmjEybfz6jNWcMNHOV/bFTxlgOKtIGUDxH3v3HF5WNuxGzYGK77mPeF0mEg==
-  dependencies:
-    "@hyperledger/cactus-common" "0.5.0"
-    axios "0.21.1"
-    express "4.17.1"
-    typescript-optional "2.0.1"
-
-"@hyperledger/cactus-core@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@hyperledger/cactus-core/-/cactus-core-0.5.0.tgz#4787f9248513a0293245e6acc99919f5f161c3d3"
-  integrity sha512-putWKhR97P4NkddBlZuT/pyP8/1SkoJgXtWBAWxk2m/+DtAoHCqMqHuDaZdc1IOmdPv4ouk5jwrZ36FExYr5ZQ==
-  dependencies:
-    "@hyperledger/cactus-common" "0.5.0"
-    "@hyperledger/cactus-core-api" "0.5.0"
-    express "4.17.1"
-    express-jwt-authz "2.4.1"
-    typescript-optional "2.0.1"
-
-"@hyperledger/cactus-plugin-consortium-manual@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@hyperledger/cactus-plugin-consortium-manual/-/cactus-plugin-consortium-manual-0.5.0.tgz#3ee451fe4ded6b095e3cc237e2d5f28f874e2208"
-  integrity sha512-VajNKMN3Vgvf83fwSAQMQ17e420jJ/Y8mPG9xmdZj8WmTxHuX73H9PH7uQ0nQggFA7/vGFrrhqvBUl5XqLUNdA==
-  dependencies:
-    "@hyperledger/cactus-common" "0.5.0"
-    "@hyperledger/cactus-core" "0.5.0"
-    "@hyperledger/cactus-core-api" "0.5.0"
-    axios "0.21.1"
-    body-parser "1.19.0"
-    express "4.17.1"
-    jose "1.27.2"
-    json-stable-stringify "1.0.1"
-    prom-client "13.0.0"
-    typescript-optional "2.0.1"
-    uuid "8.3.2"
-
-"@ionic-native/core@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/@ionic-native/core/-/core-5.0.0.tgz"
-  integrity sha512-qtshWPo+CMq9ZoDGcg+1XF1+k2ASm0sLtZsIbXmYo5X82Q9cUhjk95X9BqHnjXHOdIWk4J/D3ot0/vzmMTNdbA==
-  dependencies:
-    "@types/cordova" latest
-
 "@ionic-native/core@5.34.0":
   version "5.34.0"
   resolved "https://registry.npmjs.org/@ionic-native/core/-/core-5.34.0.tgz"
@@ -2088,24 +1957,10 @@
   dependencies:
     "@types/cordova" latest
 
-"@ionic-native/splash-screen@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/@ionic-native/splash-screen/-/splash-screen-5.0.0.tgz"
-  integrity sha512-+7QfXPkaosGsR3ohEiL/WJn23NHVDZYvnilYNrOMF7oohnj5ngH46fCNYp1Tpybe5GCV1iP++RzDvE5jghWLZg==
-  dependencies:
-    "@types/cordova" latest
-
 "@ionic-native/splash-screen@5.34.0":
   version "5.34.0"
   resolved "https://registry.npmjs.org/@ionic-native/splash-screen/-/splash-screen-5.34.0.tgz"
   integrity sha512-ZSeT7v19fqhcyuvImhiXoTz2st82pUK99XxnZeUIa9U9zDu2zTkKI8ctNkBrSnFdVGjdKr8JA+aoOxWiQCzxOA==
-  dependencies:
-    "@types/cordova" latest
-
-"@ionic-native/status-bar@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/@ionic-native/status-bar/-/status-bar-5.0.0.tgz"
-  integrity sha512-mJfj+VXTOgf9Og0S7QDlT9I8UVI+Wj4kpZUHdQizovA/R0m1HG2hLKtEMy00iDVbOBjRsXGcD6JXCOeyVjg7LA==
   dependencies:
     "@types/cordova" latest
 
@@ -2128,14 +1983,6 @@
     tslib "^1.9.0"
     ws "^7.0.1"
 
-"@ionic/angular@5.1.1":
-  version "5.1.1"
-  resolved "https://registry.npmjs.org/@ionic/angular/-/angular-5.1.1.tgz"
-  integrity sha512-/39Z3DnmdbTM3pIGJRLWG+rVI7jrDWkDL8Cds2ziZbGLwhbd3jjEXVbSeR62RiEpMCL2FSHtLUKhd6/OIDD1fQ==
-  dependencies:
-    "@ionic/core" "5.1.1"
-    tslib "^1.9.3"
-
 "@ionic/angular@5.6.11":
   version "5.6.11"
   resolved "https://registry.npmjs.org/@ionic/angular/-/angular-5.6.11.tgz"
@@ -2143,14 +1990,6 @@
   dependencies:
     "@ionic/core" "5.6.11"
     tslib "^1.9.3"
-
-"@ionic/core@5.1.1":
-  version "5.1.1"
-  resolved "https://registry.npmjs.org/@ionic/core/-/core-5.1.1.tgz"
-  integrity sha512-mmQL7hzwwReqFCJlRyxo3sNoI7r63GYnZD6QBXbYmCp83POvL89fQYegUfURM1Fcw0JiAZ3BsCoMYxuFXa7+cA==
-  dependencies:
-    ionicons "^5.0.1"
-    tslib "^1.10.0"
 
 "@ionic/core@5.6.11":
   version "5.6.11"
@@ -11252,7 +11091,7 @@ io-ts@1.10.4:
   dependencies:
     fp-ts "^1.0.0"
 
-ionicons@^5.0.1, ionicons@^5.5.1:
+ionicons@^5.5.1:
   version "5.5.2"
   resolved "https://registry.npmjs.org/ionicons/-/ionicons-5.5.2.tgz"
   integrity sha512-SHVBBtzNVQjY4jtcqKEHkqL5nIQwA/o2MIdU9JtMz8kQAB0NRVJFv5AxwmVbXXKDpxz57SiEjeLp8Uzt7jirpw==
@@ -12626,11 +12465,6 @@ jws@^4.0.0:
     jwa "^2.0.0"
     safe-buffer "^5.0.1"
 
-jwt-decode@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz"
-  integrity sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=
-
 karma-chrome-launcher@3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.1.0.tgz"
@@ -13531,11 +13365,6 @@ loglevel-plugin-prefix@0.8.4:
   version "0.8.4"
   resolved "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz"
   integrity sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==
-
-loglevel@1.6.7:
-  version "1.6.7"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.7.tgz#b3e034233188c68b889f5b862415306f565e2c56"
-  integrity sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==
 
 loglevel@1.7.1, loglevel@^1.6.8:
   version "1.7.1"
@@ -22468,7 +22297,7 @@ zone.js@0.11.4:
   dependencies:
     tslib "^2.0.0"
 
-zone.js@~0.10.2, zone.js@~0.10.3:
+zone.js@~0.10.3:
   version "0.10.3"
   resolved "https://registry.npmjs.org/zone.js/-/zone.js-0.10.3.tgz"
   integrity sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg==


### PR DESCRIPTION
1. The ./tools/sync-npm-deps-to-tsc-projects.ts script
had a missing part in it which would fill the root
tsconfig.json file with the references to the packages
of the monorepo.

2. Point 1 could not be achieved without removing the
cactus-cockpit package from the dependencies of
cmd-api-server because the script mentioned above fails
if there are dependencies declared which do not exist
on the file-system anymore (which is exactly what
happened when we deprecated the cockpit package and then
forgot to remove it from the list of dependencies.

3. All the tsconfig.json files are updated by the sync
script (from point 1.)

4. Adds skip lib check true to the ipfs package's tsconfig
file so that the issue with uint8array dependency's own typings
don't break the build. For reference, the errors look like this:

- Error: node_modules/uint8arrays/dist/to-string.d.ts(20,24): error TS2307:
  Cannot find module './util/bases' or its corresponding type declarations.

- Error: node_modules/uint8arrays/dist/to-string.d.ts(21,34): error TS2307:
  Cannot find module './util/bases' or its corresponding type declarations.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>