### PR TITLE
fix(plugin-consortium-manual): drop repo constructor arg #1199

### DIFF
--- a/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
+++ b/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
@@ -15,7 +15,7 @@ import {
   LedgerType,
 } from "@hyperledger/cactus-core-api";
 
-import { PluginRegistry, ConsortiumRepository } from "@hyperledger/cactus-core";
+import { PluginRegistry } from "@hyperledger/cactus-core";
 
 import {
   LogLevelDesc,
@@ -210,8 +210,6 @@ export class SupplyChainApp {
     const connectionProfile = await this.ledgers.fabric.getConnectionProfileOrg1();
     const sshConfig = await this.ledgers.fabric.getSshConfig();
 
-    const consortiumRepo = new ConsortiumRepository({ db: consortiumDatabase });
-
     const registryA = new PluginRegistry({
       plugins: [
         new PluginConsortiumManual({
@@ -219,7 +217,6 @@ export class SupplyChainApp {
           consortiumDatabase,
           keyPairPem: keyPairPemA,
           logLevel: this.options.logLevel,
-          consortiumRepo,
         }),
         new SupplyChainCactusPlugin({
           logLevel: this.options.logLevel,
@@ -259,7 +256,6 @@ export class SupplyChainApp {
           consortiumDatabase,
           keyPairPem: keyPairPemB,
           logLevel: this.options.logLevel,
-          consortiumRepo,
         }),
         new SupplyChainCactusPlugin({
           logLevel: this.options.logLevel,
@@ -298,7 +294,6 @@ export class SupplyChainApp {
           consortiumDatabase,
           keyPairPem: keyPairPemC,
           logLevel: "INFO",
-          consortiumRepo,
         }),
         new SupplyChainCactusPlugin({
           logLevel: "INFO",

--- a/packages/cactus-plugin-consortium-manual/src/test/typescript/unit/consortium/get-node-jws-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-consortium-manual/src/test/typescript/unit/consortium/get-node-jws-endpoint-v1.test.ts
@@ -13,17 +13,12 @@ import {
   Configuration,
 } from "@hyperledger/cactus-core-api";
 
-import { ConsortiumRepository } from "@hyperledger/cactus-core";
-
 import {
   PluginConsortiumManual,
   IPluginConsortiumManualOptions,
-} from "../../../../main/typescript/plugin-consortium-manual";
-
-import {
-  GetNodeJwsEndpoint,
-  //  IGetNodeJwsEndpointOptions,
 } from "../../../../main/typescript/public-api";
+
+import { GetNodeJwsEndpoint } from "../../../../main/typescript/public-api";
 
 import { v4 as uuidv4 } from "uuid";
 
@@ -44,14 +39,12 @@ test("Can provide JWS", async (t: Test) => {
     ledger: [],
     pluginInstance: [],
   };
-  const consortiumRepo = new ConsortiumRepository({ db });
 
   // Creating the PluginConsortiumManual object to observe the prometheus metrics.
   const options: IPluginConsortiumManualOptions = {
     instanceId: uuidv4(),
     keyPairPem: keyPairPem,
     consortiumDatabase: db,
-    consortiumRepo,
   };
 
   const pluginConsortiumManual: PluginConsortiumManual = new PluginConsortiumManual(
@@ -138,7 +131,7 @@ test("Can provide JWS", async (t: Test) => {
     publicKeyPem: "",
   };
 
-  consortiumRepo.consortiumDatabase.cactusNode.push(dummyCactusNode);
+  db.cactusNode.push(dummyCactusNode);
   // The invocation of the node JWS endpoint internally triggers the update
   // of the metrics so after it has executed we can expect the metrics to
   // show the new values for our assertions below

--- a/packages/cactus-test-api-client/src/test/typescript/integration/api-client-routing-node-to-node.test.ts
+++ b/packages/cactus-test-api-client/src/test/typescript/integration/api-client-routing-node-to-node.test.ts
@@ -20,7 +20,7 @@ import {
   Ledger,
   LedgerType,
 } from "@hyperledger/cactus-core-api";
-import { PluginRegistry, ConsortiumRepository } from "@hyperledger/cactus-core";
+import { PluginRegistry } from "@hyperledger/cactus-core";
 import {
   DefaultApi as QuorumApi,
   PluginLedgerConnectorQuorum,
@@ -128,8 +128,6 @@ test(testCase, async (t: Test) => {
     pluginInstance: [],
   };
 
-  const consortiumRepo = new ConsortiumRepository({ db: consortiumDatabase });
-
   const config = new Configuration({ basePath: consortium.mainApiHost });
   const mainApiClient = new ApiClient(config);
 
@@ -176,7 +174,6 @@ test(testCase, async (t: Test) => {
         keyPairPem: keyPair1.toPEM(true),
         consortiumDatabase,
         logLevel,
-        consortiumRepo,
       };
       const pluginConsortiumManual = new PluginConsortiumManual(options);
 
@@ -219,7 +216,6 @@ test(testCase, async (t: Test) => {
         keyPairPem: keyPair2.toPEM(true),
         consortiumDatabase,
         logLevel,
-        consortiumRepo,
       };
       const pluginConsortiumManual = new PluginConsortiumManual(options);
 

--- a/packages/cactus-test-plugin-consortium-manual/src/test/typescript/integration/plugin-consortium-manual/get-consortium-jws-endpoint.test.ts
+++ b/packages/cactus-test-plugin-consortium-manual/src/test/typescript/integration/plugin-consortium-manual/get-consortium-jws-endpoint.test.ts
@@ -22,7 +22,7 @@ import {
   ConsortiumDatabase,
   ConsortiumMember,
 } from "@hyperledger/cactus-core-api";
-import { PluginRegistry, ConsortiumRepository } from "@hyperledger/cactus-core";
+import { PluginRegistry } from "@hyperledger/cactus-core";
 
 test("member node public keys and hosts are pre-shared", async (t: Test) => {
   const consortiumId = uuidV4();
@@ -138,7 +138,6 @@ test("member node public keys and hosts are pre-shared", async (t: Test) => {
     pluginInstance: [],
   };
 
-  const consortiumRepo = new ConsortiumRepository({ db: consortiumDatabase });
   t.comment(`Setting up first node...`);
   {
     // 2. Instantiate plugin registry which will provide the web service plugin with the key value storage plugin
@@ -151,7 +150,6 @@ test("member node public keys and hosts are pre-shared", async (t: Test) => {
       keyPairPem: keyPair1.toPEM(true),
       consortiumDatabase,
       logLevel: "trace",
-      consortiumRepo,
     };
     const pluginConsortiumManual = new PluginConsortiumManual(options);
 
@@ -205,8 +203,7 @@ test("member node public keys and hosts are pre-shared", async (t: Test) => {
       pluginRegistry,
       keyPairPem: keyPair2.toPEM(true),
       consortiumDatabase,
-      logLevel: "trace",
-      consortiumRepo,
+      logLevel: "TRACE",
     };
     const pluginConsortiumManual = new PluginConsortiumManual(options);
 
@@ -261,8 +258,7 @@ test("member node public keys and hosts are pre-shared", async (t: Test) => {
       pluginRegistry,
       keyPairPem: keyPair3.toPEM(true),
       consortiumDatabase,
-      logLevel: "trace",
-      consortiumRepo,
+      logLevel: "TRACE",
     };
     const pluginConsortiumManual = new PluginConsortiumManual(options);
 

--- a/packages/cactus-test-plugin-consortium-manual/src/test/typescript/integration/plugin-consortium-manual/security-isolation-via-api-server-ports.ts
+++ b/packages/cactus-test-plugin-consortium-manual/src/test/typescript/integration/plugin-consortium-manual/security-isolation-via-api-server-ports.ts
@@ -15,7 +15,7 @@ import {
   Consortium,
   ConsortiumDatabase,
 } from "@hyperledger/cactus-core-api";
-import { PluginRegistry, ConsortiumRepository } from "@hyperledger/cactus-core";
+import { PluginRegistry } from "@hyperledger/cactus-core";
 
 import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory";
 import {
@@ -83,8 +83,6 @@ tap.test(
       consortium: [consortium],
     };
 
-    const consortiumRepo = new ConsortiumRepository({ db: consortiumDatabase });
-
     // 3. Instantiate the web service consortium plugin which will host itself on a new TCP port for isolation/security
     // Note that if we omitted the `webAppOptions` object that the web service plugin would default to installing itself
     // on the default port of the API server. This allows for flexibility in deployments.
@@ -98,7 +96,6 @@ tap.test(
         hostname: "127.0.0.1",
         port: 0,
       },
-      consortiumRepo,
     };
     const pluginConsortiumManual = new PluginConsortiumManual(options);
 


### PR DESCRIPTION
Removes the non-serializable consortiumRepo argument from the
constructor of the consortium plugin manual class's options.

Refactors the constructor and the internals of the plugin  to initialize
the consortium repo from the consortium database at runtime
instead of expecting it passed in via the constructor.
Refactors the internal code previously using the options.consoritumRepo
object to use this.repo instead which is what gets initalized in
the constructor as explained above.

All this leads to equivalent functionality but less boilerplate and now
thanks to this the plugin can be (should be - more tests needed)
initialized by the API server purely based on the static configuration
file when necessary.

Fixes #1199

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>