### PR TITLE
test(cmd-api-server): randomize port in config service test

### DIFF
--- a/packages/cactus-cmd-api-server/src/test/typescript/unit/config/config-service-example-config-validity.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/unit/config/config-service-example-config-validity.test.ts
@@ -19,6 +19,8 @@ test("Generates valid example config for the API server", async (t: Test) => {
   ) as unknown) as IAuthorizationConfig;
 
   exampleConfig.configFile = "";
+  exampleConfig.apiPort = 0;
+  exampleConfig.cockpitPort = 0;
 
   const convictConfig = configService.newExampleConfigConvict(exampleConfig);
   t.ok(convictConfig, "configService.newExampleConfigConvict() truthy OK");


### PR DESCRIPTION
If you don't specify port zero for the API and the cockpit then they
will default to 3000 and 4000 instead which is bad for
parallel test execution where we need guarantees not to
use potentially conflicting port numbers.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>