### PR TITLE
deprecate rotateEncryptionKeys method #1108 #2

### DIFF
--- a/packages/cactus-plugin-keychain-google-sm/src/main/typescript/plugin-keychain-google-sm.ts
+++ b/packages/cactus-plugin-keychain-google-sm/src/main/typescript/plugin-keychain-google-sm.ts
@@ -110,10 +110,6 @@ export class PluginKeychainGoogleSm
   public getPackageName(): string {
     return `@hyperledger/cactus-plugin-keychain-vault`;
   }
-
-   async rotateEncryptionKeys(): Promise<void> {
-    throw new Error("Method not implemented.");
-  }
     
   public getEncryptionAlgorithm(): string {
     return "AES-256";

--- a/packages/cactus-plugin-keychain-google-sm/src/main/typescript/plugin-keychain-google-sm.ts
+++ b/packages/cactus-plugin-keychain-google-sm/src/main/typescript/plugin-keychain-google-sm.ts
@@ -111,6 +111,10 @@ export class PluginKeychainGoogleSm
     return `@hyperledger/cactus-plugin-keychain-vault`;
   }
 
+   async rotateEncryptionKeys(): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+    
   public getEncryptionAlgorithm(): string {
     return "AES-256";
   }

--- a/packages/cactus-plugin-keychain-google-sm/src/main/typescript/plugin-keychain-google-sm.ts
+++ b/packages/cactus-plugin-keychain-google-sm/src/main/typescript/plugin-keychain-google-sm.ts
@@ -111,10 +111,6 @@ export class PluginKeychainGoogleSm
     return `@hyperledger/cactus-plugin-keychain-vault`;
   }
 
-  async rotateEncryptionKeys(): Promise<void> {
-    throw new Error("Method not implemented.");
-  }
-
   public getEncryptionAlgorithm(): string {
     return "AES-256";
   }


### PR DESCRIPTION
refactor(keychain): deprecate rotateEncryptionKeys method hyperledger#1108

used:
grep -r rotateEncryptionKeys *

Found 8 locations of the method:
This pull request removes the method from 1/8 locations