### PR TITLE
deprecate rotateEncryptionKeys method #1108

### DIFF
--- a/packages/cactus-plugin-keychain-aws-sm/src/main/typescript/plugin-keychain-aws-sm.ts
+++ b/packages/cactus-plugin-keychain-aws-sm/src/main/typescript/plugin-keychain-aws-sm.ts
@@ -184,10 +184,6 @@ export class PluginKeychainAwsSm
     return `@hyperledger/cactus-plugin-keychain-aws-sm`;
   }
 
-  async rotateEncryptionKeys(): Promise<void> {
-    throw new Error("Method not implemented.");
-  }
-
   public getEncryptionAlgorithm(): string {
     return (null as unknown) as string;
   }

--- a/packages/cactus-plugin-keychain-azure-kv/src/main/typescript/plugin-keychain-azure-kv.ts
+++ b/packages/cactus-plugin-keychain-azure-kv/src/main/typescript/plugin-keychain-azure-kv.ts
@@ -180,10 +180,6 @@ export class PluginKeychainAzureKv
     return `@hyperledger/cactus-plugin-keychain-vault`;
   }
 
-  async rotateEncryptionKeys(): Promise<void> {
-    throw new Error("Method not implemented.");
-  }
-
   public getEncryptionAlgorithm(): string {
     return (null as unknown) as string;
   }

--- a/packages/cactus-plugin-keychain-google-sm/src/main/typescript/plugin-keychain-google-sm.ts
+++ b/packages/cactus-plugin-keychain-google-sm/src/main/typescript/plugin-keychain-google-sm.ts
@@ -111,10 +111,6 @@ export class PluginKeychainGoogleSm
     return `@hyperledger/cactus-plugin-keychain-vault`;
   }
 
-  async rotateEncryptionKeys(): Promise<void> {
-    throw new Error("Method not implemented.");
-  }
-
   public getEncryptionAlgorithm(): string {
     return "AES-256";
   }

--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/plugin-keychain-vault-remote-adapter.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/plugin-keychain-vault-remote-adapter.ts
@@ -94,10 +94,6 @@ export class PluginKeychainVaultRemoteAdapter
     return;
   }
 
-  public rotateEncryptionKeys(): Promise<void> {
-    throw new Error("Method not implemented.");
-  }
-
   public getEncryptionAlgorithm(): string {
     throw new Error("Method not implemented.");
   }

--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/plugin-keychain-vault.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/plugin-keychain-vault.ts
@@ -206,10 +206,6 @@ export class PluginKeychainVault implements IPluginWebService, IPluginKeychain {
     return;
   }
 
-  async rotateEncryptionKeys(): Promise<void> {
-    throw new Error("Method not implemented.");
-  }
-
   public getEncryptionAlgorithm(): string {
     return "AES256";
   }

--- a/packages/cactus-plugin-keychain-vault/src/test/typescript/integration/plugin-keychain-vault.test.ts
+++ b/packages/cactus-plugin-keychain-vault/src/test/typescript/integration/plugin-keychain-vault.test.ts
@@ -320,22 +320,6 @@ test("API client get,set,has,delete alters state", async (t: Test) => {
   t.end();
 });
 
-test("rotateEncryptionKeys() fails fast", async (t: Test) => {
-  const options: IPluginKeychainVaultOptions = {
-    instanceId: uuidv4(),
-    keychainId: uuidv4(),
-    endpoint: "http://127.0.0.1:9200",
-    token: "root",
-  };
-  const plugin = new PluginKeychainVault(options);
-
-  const promise = plugin.rotateEncryptionKeys();
-  const expected = /not implemented/;
-  await t.rejects(promise, expected, "rotateEncryptionKeys() rejects OK");
-
-  t.end();
-});
-
 test("getEncryptionAlgorithm() returns null", (t: Test) => {
   const options: IPluginKeychainVaultOptions = {
     instanceId: uuidv4(),


### PR DESCRIPTION
refactor(keychain): deprecate rotateEncryptionKeys method #1108

Found 6 locations of the method:
This pull request removes the method from 6/6 locations