### PR TITLE
refactor(api-server): instantiate plugins in api-server without install them

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -163,6 +163,8 @@ files:
   - ./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-unprotected-endpoint-authz.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-endpoint-authorization.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-unprotected-endpoint-authz-ops-confirm.test.ts
+  - ./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-from-github.test.ts
+  - ./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-without-install.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-keychain-memory.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-ledger-connector-quorum-0-7-0.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-ledger-connector-fabric-0-7-0.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -169,6 +169,8 @@ module.exports = {
     `./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-unprotected-endpoint-authz.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-endpoint-authorization.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-unprotected-endpoint-authz-ops-confirm.test.ts`,
+    `./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-from-github.test.ts`,
+    `./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-without-install.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-keychain-memory.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-ledger-connector-quorum-0-7-0.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-ledger-connector-fabric-0-7-0.test.ts`,

--- a/packages/cactus-cmd-api-server/README.md
+++ b/packages/cactus-cmd-api-server/README.md
@@ -102,7 +102,7 @@ if (require.main === module) {
 ### Remote Plugin Imports at Runtime Example
 
 ```typescript
-import { PluginImportType } from "@hyperledger/cactus-core-api";
+import { PluginImportType, PluginImportAction } from "@hyperledger/cactus-core-api";
 import { ApiServer } from "@hyperledger/cactus-cmd-api-server";
 import { ConfigService } from "@hyperledger/cactus-cmd-api-server";
 import { Logger, LoggerProvider } from "@hyperledger/cactus-common";
@@ -131,6 +131,9 @@ const main = async () => {
       // being imported by the API server regardless of the language the plugin
       // was written in.
       type: PluginImportType.REMOTE,
+      // The INSTALL value means that the plugin will be installed instead of
+      // only instantiate it
+      action: PluginImportAction.INSTALL,
       // The options that will be passed in to the plugin factory
       options: {
         keychainId: "_keychainId_",
@@ -250,7 +253,7 @@ Once you've built the container, the following commands should work:
     --publish 4000:4000 \
     cas \
       ./node_modules/.bin/cactusapi \
-      --plugins='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-fabric", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": { "connectionProfile": {}, "instanceId": "some-unique-instance-id"}}]'
+      --plugins='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-fabric", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": { "connectionProfile": {}, "instanceId": "some-unique-instance-id"}}]'
   ```
 
 - Launch container with plugin configuration as an **environment variable**:
@@ -259,7 +262,7 @@ Once you've built the container, the following commands should work:
     --rm \
     --publish 3000:3000 \
     --publish 4000:4000 \
-    --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]' \
+    --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]' \
     cas
   ```
 
@@ -271,13 +274,13 @@ Once you've built the container, the following commands should work:
     --publish 4000:4000 \
     cas \
       ./node_modules/.bin/cactusapi \
-      --plugins='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]'
+      --plugins='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]'
   ```
 
 - Launch container with **configuration file** mounted from host machine:
   ```sh
 
-  echo '[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]' > cactus.json
+  echo '[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]' > cactus.json
 
   docker run \
     --rm \
@@ -305,7 +308,7 @@ Don't have a Besu network on hand to test with? Test or develop against our Besu
       --rm \
       --publish 3000:3000 \
       --publish 4000:4000 \
-      --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]' \
+      --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]' \
       cas
     ```
 

--- a/packages/cactus-cmd-api-server/src/test/typescript/benchmark/artillery-api-benchmark.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/benchmark/artillery-api-benchmark.test.ts
@@ -13,6 +13,7 @@ import { LogLevelDesc, LoggerProvider } from "@hyperledger/cactus-common";
 import {
   PluginImportType,
   ConsortiumDatabase,
+  PluginImportAction,
 } from "@hyperledger/cactus-core-api";
 
 import {
@@ -71,6 +72,7 @@ test("Start API server, and run Artillery benchmark test.", async (t: Test) => {
     {
       packageName: "@hyperledger/cactus-plugin-keychain-memory",
       type: PluginImportType.Local,
+      action: PluginImportAction.Install,
       options: {
         instanceId: uuidv4(),
         keychainId: uuidv4(),
@@ -80,6 +82,7 @@ test("Start API server, and run Artillery benchmark test.", async (t: Test) => {
     {
       packageName: "@hyperledger/cactus-plugin-consortium-manual",
       type: PluginImportType.Local,
+      action: PluginImportAction.Install,
       options: {
         instanceId: uuidv4(),
         keyPairPem: keyPairPem,

--- a/packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-endpoint-authorization.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-endpoint-authorization.test.ts
@@ -14,6 +14,7 @@ import { LoggerProvider, LogLevelDesc } from "@hyperledger/cactus-common";
 import {
   Configuration,
   ConsortiumDatabase,
+  PluginImportAction,
   PluginImportType,
 } from "@hyperledger/cactus-core-api";
 import { AuthorizationProtocol } from "../../../main/typescript/config/authorization-protocol";
@@ -88,6 +89,7 @@ test(testCase, async (t: Test) => {
       {
         packageName: "@hyperledger/cactus-plugin-keychain-memory",
         type: PluginImportType.Local,
+        action: PluginImportAction.Install,
         options: {
           instanceId: uuidv4(),
           keychainId: uuidv4(),
@@ -97,6 +99,7 @@ test(testCase, async (t: Test) => {
       {
         packageName: "@hyperledger/cactus-plugin-consortium-manual",
         type: PluginImportType.Local,
+        action: PluginImportAction.Install,
         options: {
           instanceId: uuidv4(),
           keyPairPem: keyPairPem,

--- a/packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-from-github.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-from-github.test.ts
@@ -1,34 +1,33 @@
 import path from "path";
 import test, { Test } from "tape-promise/tape";
 import { v4 as uuidv4 } from "uuid";
-
 import { LogLevelDesc } from "@hyperledger/cactus-common";
-
-import {
-  ApiServer,
-  AuthorizationProtocol,
-  ConfigService,
-} from "@hyperledger/cactus-cmd-api-server";
 import {
   PluginImportAction,
   PluginImportType,
 } from "@hyperledger/cactus-core-api";
+import {
+  ApiServer,
+  AuthorizationProtocol,
+  ConfigService,
+} from "../../../main/typescript/public-api";
 
 const logLevel: LogLevelDesc = "TRACE";
 
-test("can import plugins at runtime (CLI)", async (t: Test) => {
+test("can install plugins at runtime with specified version based on imports", async (t: Test) => {
   const pluginsPath = path.join(
-    __dirname, // start at the current file's path
+    __dirname,
     "../../../../../../", // walk back up to the project root
-    ".tmp/test/cmd-api-server/runtime-plugin-imports_test", // the dir path from the root
+    ".tmp/test/test-cmd-api-server/plugin-import-from-github_test/", // the dir path from the root
     uuidv4(), // then a random directory to ensure proper isolation
   );
   const pluginManagerOptionsJson = JSON.stringify({ pluginsPath });
 
   const configService = new ConfigService();
+
   const apiServerOptions = configService.newExampleConfig();
-  apiServerOptions.authorizationProtocol = AuthorizationProtocol.NONE;
   apiServerOptions.pluginManagerOptionsJson = pluginManagerOptionsJson;
+  apiServerOptions.authorizationProtocol = AuthorizationProtocol.NONE;
   apiServerOptions.configFile = "";
   apiServerOptions.apiCorsDomainCsv = "*";
   apiServerOptions.apiPort = 0;
@@ -37,13 +36,15 @@ test("can import plugins at runtime (CLI)", async (t: Test) => {
   apiServerOptions.apiTlsEnabled = false;
   apiServerOptions.plugins = [
     {
-      packageName: "@hyperledger/cactus-plugin-keychain-memory",
+      packageName: "@hyperledger/cactus-dummy-package",
       type: PluginImportType.Local,
       action: PluginImportAction.Install,
       options: {
         instanceId: uuidv4(),
         keychainId: uuidv4(),
         logLevel,
+        packageSrc:
+          "https://gitpkg.now.sh/hyperledger/cactus/packages/cactus-cmd-api-server/src/test/resources/cactus-dummy-package?main",
       },
     },
   ];
@@ -53,9 +54,28 @@ test("can import plugins at runtime (CLI)", async (t: Test) => {
     config: config.getProperties(),
   });
 
+  const startResponse = apiServer.start();
   await t.doesNotReject(
-    apiServer.start(),
+    startResponse,
     "failed to start API server with dynamic plugin imports configured for it...",
   );
+  t.ok(startResponse, "startResponse truthy OK");
+
+  const packageFilePath = path.join(
+    pluginsPath,
+    apiServerOptions.plugins[0].options.instanceId,
+    "node_modules",
+    `${apiServerOptions.plugins[0].packageName}`,
+    "package.json",
+  );
+  const { name, version } = await import(packageFilePath);
+  t.comment(name);
+  t.comment(version);
+  t.strictEquals(
+    name,
+    apiServerOptions.plugins[0].packageName,
+    `Package name strictly equal to ${apiServerOptions.plugins[0].packageName}`,
+  );
+
   test.onFinish(() => apiServer.shutdown());
 });

--- a/packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-without-install.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-without-install.test.ts
@@ -1,0 +1,238 @@
+import path from "path";
+import test, { Test } from "tape-promise/tape";
+import { v4 as uuidv4 } from "uuid";
+import { LogLevelDesc } from "@hyperledger/cactus-common";
+import {
+  PluginImportAction,
+  PluginImportType,
+} from "@hyperledger/cactus-core-api";
+import {
+  ApiServer,
+  AuthorizationProtocol,
+  ConfigService,
+} from "../../../main/typescript/public-api";
+import lmify from "lmify";
+import fs from "fs-extra";
+
+const logLevel: LogLevelDesc = "TRACE";
+
+test("can instantiate plugins at runtime without install them", async (t: Test) => {
+  test("if plugin is not already installed and we set action to instantiate, server starting will fail", async (t2: Test) => {
+    const pluginsPath = path.join(
+      __dirname,
+      "../../../../../../", // walk back up to the project root
+      ".tmp/test/cmd-api-server/plugin-import-without-install/", // the dir path from the root
+      uuidv4(), // then a random directory to ensure proper isolation
+    );
+    const pluginManagerOptionsJson = JSON.stringify({ pluginsPath });
+
+    const configService = new ConfigService();
+
+    const apiServerOptions = configService.newExampleConfig();
+    apiServerOptions.pluginManagerOptionsJson = pluginManagerOptionsJson;
+    apiServerOptions.authorizationProtocol = AuthorizationProtocol.NONE;
+    apiServerOptions.configFile = "";
+    apiServerOptions.apiCorsDomainCsv = "*";
+    apiServerOptions.apiPort = 0;
+    apiServerOptions.cockpitPort = 0;
+    apiServerOptions.grpcPort = 0;
+    apiServerOptions.apiTlsEnabled = false;
+
+    const instanceId = uuidv4();
+    const keychainId = uuidv4();
+    const plugin = {
+      packageName: "@hyperledger/cactus-plugin-keychain-memory",
+      type: PluginImportType.Local,
+      action: PluginImportAction.Instantiate,
+      options: {
+        instanceId,
+        keychainId,
+        logLevel,
+        version: "0.9.0",
+      },
+    };
+
+    apiServerOptions.plugins = [plugin];
+
+    const config = configService.newExampleConfigConvict(apiServerOptions);
+
+    const apiServer = new ApiServer({
+      config: config.getProperties(),
+    });
+
+    await t2.rejects(apiServer.start());
+
+    t2.end();
+  });
+
+  test("if plugin is already installed and we send a different version, it keeps using plugin installed before call apiServer", async (t2: Test) => {
+    const pluginsPath = path.join(
+      __dirname,
+      "../../../../../../", // walk back up to the project root
+      ".tmp/test/cmd-api-server/plugin-import-without-install/", // the dir path from the root
+      uuidv4(), // then a random directory to ensure proper isolation
+    );
+    const pluginManagerOptionsJson = JSON.stringify({ pluginsPath });
+
+    const configService = new ConfigService();
+
+    const apiServerOptions = configService.newExampleConfig();
+    apiServerOptions.pluginManagerOptionsJson = pluginManagerOptionsJson;
+    apiServerOptions.authorizationProtocol = AuthorizationProtocol.NONE;
+    apiServerOptions.configFile = "";
+    apiServerOptions.apiCorsDomainCsv = "*";
+    apiServerOptions.apiPort = 0;
+    apiServerOptions.cockpitPort = 0;
+    apiServerOptions.grpcPort = 0;
+    apiServerOptions.apiTlsEnabled = false;
+
+    const versionToSendServer = "0.7.0";
+    const instanceId = uuidv4();
+    const keychainId = uuidv4();
+    const plugin = {
+      packageName: "@hyperledger/cactus-plugin-keychain-memory",
+      type: PluginImportType.Local,
+      action: PluginImportAction.Instantiate,
+      options: {
+        instanceId,
+        keychainId,
+        logLevel,
+        version: versionToSendServer,
+      },
+    };
+    apiServerOptions.plugins = [plugin];
+
+    const pluginPackageDir = path.join(pluginsPath, instanceId);
+    const versionToInstall = "0.10.0";
+
+    await fs.mkdirp(pluginPackageDir);
+    lmify.setPackageManager("npm");
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    lmify.setRootDir(pluginPackageDir);
+    const out = await lmify.install([
+      `${plugin.packageName}@${versionToInstall}`,
+      "--production",
+      "--audit=false",
+      "--progress=false",
+      "--fund=false",
+      `--prefix=${pluginPackageDir}`,
+      // "--ignore-workspace-root-check",
+    ]);
+    t2.equal(out.exitCode, 0, "Plugin installed correctly");
+
+    const config = configService.newExampleConfigConvict(
+      apiServerOptions,
+      true,
+    );
+    const apiServer = new ApiServer({
+      config: config.getProperties(),
+    });
+
+    await t2.doesNotReject(
+      apiServer.start(),
+      "apiServer was starting instantiating a plugin previously installed",
+    );
+
+    const packageFilePath = path.join(
+      pluginsPath,
+      plugin.options.instanceId,
+      "node_modules",
+      `${plugin.packageName}`,
+      "package.json",
+    );
+
+    const { version } = await import(packageFilePath);
+
+    t2.strictEquals(
+      version,
+      versionToInstall,
+      "apiServer did not overwrite package",
+    );
+
+    const pluginsCount = apiServer.getPluginImportsCount();
+    t2.equal(pluginsCount, 1, "apiServer instantiated 1 plugin");
+
+    await t2.doesNotReject(
+      apiServer.shutdown(),
+      "apiServer was stopped instantiating a plugin previously installed",
+    );
+
+    t2.end();
+  });
+
+  test("if we send action as Installation, apiServer will install the plugin", async (t2: Test) => {
+    const pluginsPath = path.join(
+      __dirname,
+      "../../../../../../", // walk back up to the project root
+      ".tmp/test/cmd-api-server/plugin-import-without-install/", // the dir path from the root
+      uuidv4(), // then a random directory to ensure proper isolation
+    );
+    const pluginManagerOptionsJson = JSON.stringify({ pluginsPath });
+
+    const configService = new ConfigService();
+
+    const apiServerOptions = configService.newExampleConfig();
+    apiServerOptions.pluginManagerOptionsJson = pluginManagerOptionsJson;
+    apiServerOptions.authorizationProtocol = AuthorizationProtocol.NONE;
+    apiServerOptions.configFile = "";
+    apiServerOptions.apiCorsDomainCsv = "*";
+    apiServerOptions.apiPort = 0;
+    apiServerOptions.cockpitPort = 0;
+    apiServerOptions.grpcPort = 0;
+    apiServerOptions.apiTlsEnabled = false;
+    const versionToInstall = "0.8.0";
+    apiServerOptions.plugins = [
+      {
+        packageName: "@hyperledger/cactus-plugin-keychain-memory",
+        type: PluginImportType.Local,
+        action: PluginImportAction.Install,
+        options: {
+          instanceId: uuidv4(),
+          keychainId: uuidv4(),
+          logLevel,
+          version: versionToInstall,
+        },
+      },
+    ];
+
+    const config = configService.newExampleConfigConvict(
+      apiServerOptions,
+      true,
+    );
+
+    const apiServer = new ApiServer({
+      config: config.getProperties(),
+    });
+
+    await t2.doesNotReject(
+      apiServer.start(),
+      "apiServer was starting instantiating a plugin previously installed",
+    );
+
+    const packageFilePath = path.join(
+      pluginsPath,
+      apiServerOptions.plugins[0].options.instanceId,
+      "node_modules",
+      `${apiServerOptions.plugins[0].packageName}`,
+      "package.json",
+    );
+
+    const { version } = await import(packageFilePath);
+
+    t2.strictEquals(
+      version,
+      versionToInstall,
+      "apiServer installed the package",
+    );
+
+    const pluginsCount = apiServer.getPluginImportsCount();
+    t2.equal(pluginsCount, 1, "apiServer instantiated 1 plugin");
+
+    await t2.doesNotReject(apiServer.shutdown(), "apiServer was stopped");
+
+    t2.end();
+  });
+
+  t.end();
+});

--- a/packages/cactus-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
@@ -16,7 +16,11 @@ import {
 } from "@hyperledger/cactus-test-tooling";
 
 import { DefaultApi } from "@hyperledger/cactus-plugin-keychain-vault";
-import { Configuration, PluginImportType } from "@hyperledger/cactus-core-api";
+import {
+  Configuration,
+  PluginImportAction,
+  PluginImportType,
+} from "@hyperledger/cactus-core-api";
 import path from "path";
 
 test("NodeJS API server + Rust plugin work together", async (t: Test) => {
@@ -80,6 +84,7 @@ test("NodeJS API server + Rust plugin work together", async (t: Test) => {
     {
       packageName: "@hyperledger/cactus-plugin-keychain-vault",
       type: PluginImportType.Remote,
+      action: PluginImportAction.Install,
       options: {
         keychainId: "_keychainId_",
         instanceId: "_instanceId_",

--- a/packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-consortium-manual.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-consortium-manual.test.ts
@@ -11,6 +11,7 @@ import {
   ICactusPlugin,
   Configuration,
   IPluginConsortium,
+  PluginImportAction,
 } from "@hyperledger/cactus-core-api";
 
 import {
@@ -65,6 +66,7 @@ test("can install plugin-consortium-manual", async (t: Test) => {
     {
       packageName: "@hyperledger/cactus-plugin-keychain-memory",
       type: PluginImportType.Local,
+      action: PluginImportAction.Install,
       options: {
         instanceId: uuidv4(),
         keychainId,
@@ -74,6 +76,7 @@ test("can install plugin-consortium-manual", async (t: Test) => {
     {
       packageName: "@hyperledger/cactus-plugin-consortium-manual",
       type: PluginImportType.Local,
+      action: PluginImportAction.Install,
       options: {
         instanceId: consortiumPluginInstanceId,
         keyPairPem: keyPairPem,

--- a/packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-keychain-memory.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-keychain-memory.test.ts
@@ -3,7 +3,11 @@ import { v4 as uuidv4 } from "uuid";
 
 import { LogLevelDesc } from "@hyperledger/cactus-common";
 
-import { Configuration, PluginImportType } from "@hyperledger/cactus-core-api";
+import {
+  Configuration,
+  PluginImportAction,
+  PluginImportType,
+} from "@hyperledger/cactus-core-api";
 
 import {
   ApiServer,
@@ -45,6 +49,7 @@ test("can import plugins at runtime (CLI)", async (t: Test) => {
     {
       packageName: "@hyperledger/cactus-plugin-keychain-memory",
       type: PluginImportType.Local,
+      action: PluginImportAction.Install,
       options: {
         instanceId: uuidv4(),
         keychainId: uuidv4(),

--- a/packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-ledger-connector-fabric-0-7-0.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-ledger-connector-fabric-0-7-0.test.ts
@@ -3,7 +3,11 @@ import { v4 as uuidv4 } from "uuid";
 
 import { LogLevelDesc } from "@hyperledger/cactus-common";
 
-import { Configuration, PluginImportType } from "@hyperledger/cactus-core-api";
+import {
+  Configuration,
+  PluginImportAction,
+  PluginImportType,
+} from "@hyperledger/cactus-core-api";
 
 import {
   ApiServer,
@@ -43,6 +47,7 @@ test("can install plugin-ledger-connector-fabric", async (t: Test) => {
     {
       packageName: "@hyperledger/cactus-plugin-ledger-connector-fabric",
       type: PluginImportType.Local,
+      action: PluginImportAction.Install,
       options: {
         instanceId: uuidv4(),
         logLevel,

--- a/packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-ledger-connector-quorum-0-7-0.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-ledger-connector-quorum-0-7-0.test.ts
@@ -4,7 +4,11 @@ import { v4 as uuidv4 } from "uuid";
 
 import { LogLevelDesc } from "@hyperledger/cactus-common";
 
-import { Configuration, PluginImportType } from "@hyperledger/cactus-core-api";
+import {
+  Configuration,
+  PluginImportAction,
+  PluginImportType,
+} from "@hyperledger/cactus-core-api";
 
 import {
   ApiServer,
@@ -48,6 +52,7 @@ test("can import plugins at runtime (CLI)", async (t: Test) => {
     {
       packageName: "@hyperledger/cactus-plugin-ledger-connector-quorum",
       type: PluginImportType.Local,
+      action: PluginImportAction.Install,
       options: {
         instanceId: uuidv4(),
         logLevel,

--- a/packages/cactus-core-api/src/main/json/openapi.json
+++ b/packages/cactus-core-api/src/main/json/openapi.json
@@ -24,7 +24,8 @@
                 "type": "object",
                 "required": [
                     "packageName",
-                    "type"
+                    "type",
+                    "action"
                 ],
                 "properties": {
                     "packageName": {
@@ -38,6 +39,11 @@
                         "description": "",
                         "$ref": "#/components/schemas/PluginImportType"
                     },
+                    "action": {
+                        "nullable": false,
+                        "description": "",
+                        "$ref": "#/components/schemas/PluginImportAction"
+                    },
                     "options": {}
                 }
             },
@@ -46,6 +52,13 @@
                 "enum": [
                     "org.hyperledger.cactus.plugin_import_type.LOCAL",
                     "org.hyperledger.cactus.plugin_import_type.REMOTE"
+                ]
+            },
+            "PluginImportAction": {
+                "type": "string",
+                "enum": [
+                    "org.hyperledger.cactus.plugin_import_action.INSTANTIATE",
+                    "org.hyperledger.cactus.plugin_import_action.INSTALL"
                 ]
             },
             "ConsensusAlgorithmFamily": {

--- a/packages/cactus-core-api/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-core-api/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -534,11 +534,28 @@ export interface PluginImport {
     type: PluginImportType;
     /**
      * 
+     * @type {PluginImportAction}
+     * @memberof PluginImport
+     */
+    action: PluginImportAction;
+    /**
+     * 
      * @type {any}
      * @memberof PluginImport
      */
     options?: any | null;
 }
+/**
+ * 
+ * @export
+ * @enum {string}
+ */
+
+export enum PluginImportAction {
+    Instantiate = 'org.hyperledger.cactus.plugin_import_action.INSTANTIATE',
+    Install = 'org.hyperledger.cactus.plugin_import_action.INSTALL'
+}
+
 /**
  * 
  * @export

--- a/packages/cactus-plugin-ledger-connector-besu/README.md
+++ b/packages/cactus-plugin-ledger-connector-besu/README.md
@@ -149,7 +149,7 @@ docker run \
   --rm \
   --publish 3000:3000 \
   --publish 4000:4000 \
-  --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]' \
+  --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]' \
   cplcb
 ```
 
@@ -161,13 +161,13 @@ docker run \
    --publish 4000:4000 \
   cplcb \
     ./node_modules/.bin/cactusapi \
-    --plugins='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]'
+    --plugins='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]'
 ```
 
 Launch container with **configuration file** mounted from host machine:
 ```sh
 
-echo '[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]' > cactus.json
+echo '[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]' > cactus.json
 
 docker run \
   --rm \
@@ -195,7 +195,7 @@ docker run \
   --rm \
   --publish 3000:3000 \
   --publish 4000:4000 \
-  --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]' \
+  --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]' \
   cplcb
 ```
 

--- a/packages/cactus-plugin-ledger-connector-fabric/README.md
+++ b/packages/cactus-plugin-ledger-connector-fabric/README.md
@@ -262,7 +262,7 @@ docker run \
   --rm \
   --publish 3000:3000 \
   --publish 4000:4000 \
-  --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-fabric", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"instanceId": "some-unique-fabric-connector-instance-id", "dockerBinary": "usr/local/bin/docker","cliContainerEnv": {
+  --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-fabric", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"instanceId": "some-unique-fabric-connector-instance-id", "dockerBinary": "usr/local/bin/docker","cliContainerEnv": {
     "CORE_PEER_LOCALMSPID": "Org1MSP",
     "CORE_PEER_ADDRESS": "peer0.org1.example.com:7051",
     "CORE_PEER_MSPCONFIGPATH":
@@ -288,7 +288,7 @@ docker run \
    --publish 4000:4000 \
   cplcb \
     ./node_modules/.bin/cactusapi \
-    --plugins='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-fabric", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"instanceId": "some-unique-fabric-connector-instance-id", "dockerBinary": "usr/local/bin/docker","cliContainerEnv": {
+    --plugins='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-fabric", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"instanceId": "some-unique-fabric-connector-instance-id", "dockerBinary": "usr/local/bin/docker","cliContainerEnv": {
     "CORE_PEER_LOCALMSPID": "Org1MSP",
     "CORE_PEER_ADDRESS": "peer0.org1.example.com:7051",
     "CORE_PEER_MSPCONFIGPATH":
@@ -308,7 +308,7 @@ docker run \
 Launch container with **configuration file** mounted from host machine:
 ```sh
 
-echo '[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-fabric", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"instanceId": "some-unique-fabric-connector-instance-id", "dockerBinary": "usr/local/bin/docker","cliContainerEnv": {
+echo '[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-fabric", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"instanceId": "some-unique-fabric-connector-instance-id", "dockerBinary": "usr/local/bin/docker","cliContainerEnv": {
     "CORE_PEER_LOCALMSPID": "Org1MSP",
     "CORE_PEER_ADDRESS": "peer0.org1.example.com:7051",
     "CORE_PEER_MSPCONFIGPATH":
@@ -350,7 +350,7 @@ docker run \
   --rm \
   --publish 3000:3000 \
   --publish 4000:4000 \
-  --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-fabric", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"instanceId": "some-unique-fabric-connector-instance-id", "dockerBinary": "usr/local/bin/docker","cliContainerEnv": {
+  --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-fabric", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"instanceId": "some-unique-fabric-connector-instance-id", "dockerBinary": "usr/local/bin/docker","cliContainerEnv": {
     "CORE_PEER_LOCALMSPID": "Org1MSP",
     "CORE_PEER_ADDRESS": "peer0.org1.example.com:7051",
     "CORE_PEER_MSPCONFIGPATH":

--- a/packages/cactus-plugin-ledger-connector-iroha/README.md
+++ b/packages/cactus-plugin-ledger-connector-iroha/README.md
@@ -126,7 +126,7 @@ docker run \
   --publish 3000:3000 \
   --publish 4000:4000 \
   --publish 5000:5000 \
-  --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-iroha", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-iroha-connector-instance-id"}}]' \
+  --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-iroha", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-iroha-connector-instance-id"}}]' \
   cplcb
 ```
 
@@ -139,13 +139,13 @@ docker run \
   --publish 5000:5000 \
   cplcb \
     ./node_modules/.bin/cactusapi \
-    --plugins='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-iroha", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-iroha-connector-instance-id"}}]'
+    --plugins='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-iroha", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-iroha-connector-instance-id"}}]'
 ```
 
 Launch container with **configuration file** mounted from host machine:
 ```sh
 
-echo '[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-iroha", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-iroha-connector-instance-id"}}]' > cactus.json
+echo '[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-iroha", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL", "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-iroha-connector-instance-id"}}]' > cactus.json
 
 docker run \
   --rm \
@@ -175,7 +175,7 @@ docker run \
   --publish 3000:3000 \
   --publish 4000:4000 \
   --publish 5000:5000 \
-  --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-iroha", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-iroha-connector-instance-id"}}]' \
+  --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-iroha", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL", "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-iroha-connector-instance-id"}}]' \
   cplcb
 ```
 

--- a/packages/cactus-plugin-ledger-connector-quorum/README.md
+++ b/packages/cactus-plugin-ledger-connector-quorum/README.md
@@ -108,7 +108,7 @@ docker run \
   --rm \
   --publish 3000:3000 \
   --publish 4000:4000 \
-  --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-quorum", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-quorum-connector-instance-id"}}]' \
+  --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-quorum", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-quorum-connector-instance-id"}}]' \
   cplcb
 ```
 
@@ -120,13 +120,13 @@ docker run \
    --publish 4000:4000 \
   cplcb \
     ./node_modules/.bin/cactusapi \
-    --plugins='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-quorum", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-quorum-connector-instance-id"}}]'
+    --plugins='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-quorum", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-quorum-connector-instance-id"}}]'
 ```
 
 Launch container with **configuration file** mounted from host machine:
 ```sh
 
-echo '[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-quorum", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-quorum-connector-instance-id"}}]' > cactus.json
+echo '[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-quorum", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-quorum-connector-instance-id"}}]' > cactus.json
 
 docker run \
   --rm \
@@ -154,7 +154,7 @@ docker run \
   --rm \
   --publish 3000:3000 \
   --publish 4000:4000 \
-  --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-quorum", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-quorum-connector-instance-id"}}]' \
+  --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-quorum", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-quorum-connector-instance-id"}}]' \
   cplcb
 ```
 

--- a/packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install-version-selection.test.ts
+++ b/packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install-version-selection.test.ts
@@ -2,7 +2,10 @@ import path from "path";
 import test, { Test } from "tape-promise/tape";
 import { v4 as uuidv4 } from "uuid";
 import { LogLevelDesc } from "@hyperledger/cactus-common";
-import { PluginImportType } from "@hyperledger/cactus-core-api";
+import {
+  PluginImportAction,
+  PluginImportType,
+} from "@hyperledger/cactus-core-api";
 import {
   ApiServer,
   AuthorizationProtocol,
@@ -35,6 +38,7 @@ test("can install plugins at runtime with specified version based on imports", a
     {
       packageName: "@hyperledger/cactus-plugin-keychain-memory",
       type: PluginImportType.Local,
+      action: PluginImportAction.Install,
       options: {
         instanceId: uuidv4(),
         keychainId: uuidv4(),

--- a/packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install.test.ts
+++ b/packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install.test.ts
@@ -8,6 +8,7 @@ import { LogLevelDesc } from "@hyperledger/cactus-common";
 import {
   PluginImportType,
   ConsortiumDatabase,
+  PluginImportAction,
 } from "@hyperledger/cactus-core-api";
 
 import {
@@ -53,6 +54,7 @@ test("can instal plugins at runtime based on imports", async (t: Test) => {
     {
       packageName: "@hyperledger/cactus-plugin-keychain-memory",
       type: PluginImportType.Local,
+      action: PluginImportAction.Install,
       options: {
         instanceId: uuidv4(),
         keychainId: uuidv4(),
@@ -62,6 +64,7 @@ test("can instal plugins at runtime based on imports", async (t: Test) => {
     {
       packageName: "@hyperledger/cactus-plugin-consortium-manual",
       type: PluginImportType.Local,
+      action: PluginImportAction.Install,
       options: {
         instanceId: uuidv4(),
         keyPairPem: keyPairPem,


### PR DESCRIPTION
Added parameter action to PluginImport to determine if the plugin
should be installed.

Enabled feature to instantiate plugins from cactus-cmd-api-server
without install it.

Enabled feature to install packages from github

Added method create in class ConfigService to override old configuration.
Method newExampleConfigConvict accepts a boolean parameter to force
configuration override.

Closes #1210

Depends on #1527 

Signed-off-by: Elena Izaguirre <e.izaguirre.equiza@accenture.com>