### PR TITLE
feat(substrate-aio): add ws-port argument

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -110,6 +110,7 @@ files:
   - ./packages/cactus-test-tooling/src/test/typescript/integration/quorum/quorum-test-ledger/constructor-validates-options.test.ts
   - ./packages/cactus-test-tooling/src/test/typescript/integration/fabric/fabric-test-ledger-v1/constructor-validates-options.test.ts
   - ./packages/cactus-test-tooling/src/test/typescript/integration/substrate/substrate-test-ledger-constructor.test.ts
+  - ./packages/cactus-test-tooling/src/test/typescript/integration/substrate/substrate-test-ledger-multiple-concurrent.test.ts
   - ./packages/cactus-test-tooling/src/test/typescript/integration/iroha/iroha-test-ledger/constructor-validates-options.test.ts
   - ./packages/cactus-test-tooling/src/test/typescript/integration/rustc-container/rustc-container-target-bundler.test.ts
   - ./packages/cactus-test-tooling/src/test/typescript/integration/common/containers.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -115,6 +115,7 @@ module.exports = {
     `./packages/cactus-test-tooling/src/test/typescript/integration/quorum/quorum-test-ledger/constructor-validates-options.test.ts`,
     `./packages/cactus-test-tooling/src/test/typescript/integration/fabric/fabric-test-ledger-v1/constructor-validates-options.test.ts`,
     `./packages/cactus-test-tooling/src/test/typescript/integration/substrate/substrate-test-ledger-constructor.test.ts`,
+    `./packages/cactus-test-tooling/src/test/typescript/integration/substrate/substrate-test-ledger-multiple-concurrent.test.ts`,
     `./packages/cactus-test-tooling/src/test/typescript/integration/iroha/iroha-test-ledger/constructor-validates-options.test.ts`,
     `./packages/cactus-test-tooling/src/test/typescript/integration/rustc-container/rustc-container-target-bundler.test.ts`,
     `./packages/cactus-test-tooling/src/test/typescript/integration/common/containers.test.ts`,

--- a/packages/cactus-test-tooling/src/test/typescript/integration/substrate/substrate-test-ledger-multiple-concurrent.test.ts
+++ b/packages/cactus-test-tooling/src/test/typescript/integration/substrate/substrate-test-ledger-multiple-concurrent.test.ts
@@ -3,7 +3,7 @@ import { LogLevelDesc } from "@hyperledger/cactus-common";
 import { SubstrateTestLedger } from "../../../../main/typescript/substrate-test-ledger/substrate-test-ledger";
 import { pruneDockerAllIfGithubAction } from "../../../../main/typescript/github-actions/prune-docker-all-if-github-action";
 
-const testCase = "Instantiate plugin";
+const testCase = "Runs multiple test ledgers concurrently";
 const logLevel: LogLevelDesc = "TRACE";
 
 test("BEFORE " + testCase, async (t: Test) => {
@@ -22,22 +22,43 @@ test(testCase, async (t: Test) => {
     envVars: new Map([
       ["WORKING_DIR", "/var/www/node-template"],
       ["CONTAINER_NAME", "contracts-node-template-cactus"],
-      ["WS_PORT", "9944"],
+      ["WS_PORT", "9945"],
       ["PORT", "9944"],
-      ["DOCKER_PORT", "9944"],
+      ["DOCKER_PORT", "9945"],
       ["CARGO_HOME", "/var/www/node-template/.cargo"],
     ]),
   };
 
   const ledger = new SubstrateTestLedger(options);
+
+  const optionsSecondLedger = {
+    publishAllPorts: true,
+    logLevel: logLevel,
+    emitContainerLogs: true,
+    imageName: "ghcr.io/hyperledger/cactus-substrate-all-in-one",
+    imageTag: "2022-03-29--1496",
+    envVars: new Map([
+      ["WORKING_DIR", "/var/www/node-template"],
+      ["CONTAINER_NAME", "contracts-node-template-cactus"],
+      ["WS_PORT", "9947"],
+      ["PORT", "9946"],
+      ["DOCKER_PORT", "9947"],
+      ["CARGO_HOME", "/var/www/node-template/.cargo"],
+    ]),
+  };
+
+  const secondLedger = new SubstrateTestLedger(optionsSecondLedger);
+
   const tearDown = async () => {
     await ledger.stop();
+    await secondLedger.stop();
     await pruneDockerAllIfGithubAction({ logLevel });
   };
 
   test.onFinish(tearDown);
   await ledger.start();
+  await secondLedger.start();
   t.ok(ledger);
-
+  t.ok(secondLedger);
   t.end();
 });

--- a/tools/docker/substrate-all-in-one/Dockerfile
+++ b/tools/docker/substrate-all-in-one/Dockerfile
@@ -1,17 +1,24 @@
 FROM paritytech/ci-linux:production
-LABEL AUTHORS="Rafael Belchior, Catarina Pedreira" 
-LABEL VERSION="2021-09-10"
+LABEL AUTHORS="Rafael Belchior, Catarina Pedreira"
+LABEL VERSION="2021-11-01"
 LABEL org.opencontainers.image.source=https://github.com/hyperledger/cactus
 
 WORKDIR /
-ARG WORKING_DIR=/var/www/node-template
-ARG CONTAINER_NAME=contracts-node-template-cactus
-ARG PORT=9944
-ARG DOCKER_PORT=9944
-ARG CARGO_HOME=/var/www/node-template/.cargo
+ENV WORKING_DIR=/var/www/node-template
+ENV CONTAINER_NAME=contracts-node-template-cactus
+# Specify p2p protocol TCP port
+ENV PORT=9614
 
-ENV CARGO_HOME=${CARGO_HOME}
+# Specify HTTP RPC server TCP port
+ENV RPC_PORT=9618
+
+#Specify WebSockets RPC server TCP port
+ENV WS_PORT=9944
+
+ENV DOCKER_PORT=9944
+ENV CARGO_HOME=/var/www/node-template/.cargo
 ENV CACTUS_CFG_PATH=/etc/hyperledger/cactus
+
 VOLUME .:/var/www/node-template
 
 RUN apt update
@@ -35,5 +42,7 @@ RUN rustup target add wasm32-unknown-unknown --toolchain nightly
 RUN echo "*** Installing Substrate node environment ***"
 RUN cargo install contracts-node --git https://github.com/paritytech/substrate-contracts-node.git --force --locked
 
+COPY start.sh /
+
 RUN echo "*** Start Substrate node template ***"
-CMD [ "/var/www/node-template/.cargo/bin/substrate-contracts-node", "--dev"]
+CMD /start.sh

--- a/tools/docker/substrate-all-in-one/README.md
+++ b/tools/docker/substrate-all-in-one/README.md
@@ -3,18 +3,34 @@
 A container image that can holds the default Substrate test ledger (and the corresponding front-end).
 This image can be used for development of Substrate-based chains (including but not limited to pallets, smart contracts) and connectors.
 
+This is the test ledger used by the `polkadot-connector` package.
+
 ## Table of Contents<!-- omit in toc -->
 
 - [Usage](#usage)
 - [Build](#build)
 
 ## Usage
+To run the test ledger, use:
+
 ```sh
-docker run -t -p 9944:9944 --name substrate-contracts-node saio:latest
+docker run --expose HOST_PORT --env WS_PORT=WS_PORT --env WORKING_DIR=/var/www/node-template --env CONTAINER_NAME=contracts-node-template-ovl --env CARGO_HOME=/var/www/node-template/.cargo -p HOST_PORT:WS_PORT rafaelapb/cactus-substrate-aio:2021-11-02-fix
+
+
+
+```
+
+Example:
+
+
+```
+docker run --expose 9946 --env WS_PORT=9947 --env WORKING_DIR=/var/www/node-template --env CONTAINER_NAME=contracts-node-template-ovl --env CARGO_HOME=/var/www/node-template/.cargo -p 9940:9947 rafaelapb/cactus-substrate-aio:2021-11-02-fix
+
+
 ```
 
 ## Build
 
 ```sh
-DOCKER_BUILDKIT=1 docker build -f ./tools/docker/substrate-all-in-one/Dockerfile . --tag saio
+DOCKER_BUILDKIT=1 docker build ./tools/docker/substrate-all-in-one/ -f ./tools/docker/substrate-all-in-one/Dockerfile --tag saio
 ```

--- a/tools/docker/substrate-all-in-one/start.sh
+++ b/tools/docker/substrate-all-in-one/start.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+echo "ENV:PORT=${PORT}"
+echo "ENV:WS_PORT=${WS_PORT}"
+
+exec /var/www/node-template/.cargo/bin/substrate-contracts-node --dev --port ${PORT} --ws-port ${WS_PORT}


### PR DESCRIPTION
This PR allows developers to choose the port where the saio exposes.

However, there is a bug: the substrate connector cannot connect to the saio running on the custom port. Perhaps it is an issue with port exposing?
