### PR TITLE
feat(example): make cartrade support more environments

### DIFF
--- a/tools/docker/fabric-minifabric/how_to_use_minifabric.md
+++ b/tools/docker/fabric-minifabric/how_to_use_minifabric.md
@@ -1,0 +1,70 @@
+# How to Use minifabric
+
+### Reference
+
+- [hyperledger-labs/minifabric: Do fabric network the right and easy way. (github.com)](https://github.com/hyperledger-labs/minifabric)
+
+  
+
+### System Requirements
+
+- CentOS7 in no proxy network
+
+  - Note: I did the test using CentOS 7 running on virtualbox on windows 10 in no proxy network.
+  
+  
+
+### How to Install
+
+1. Create the directory `mywork` under the home directory and stores the minifabic execution environment.
+
+   - `$ mkdir -p ~/mywork && cd ~/mywork && curl -o minifab -sL https://tinyurl.com/yxa2q6yr && chmod +x minifab`
+
+   - TIPS: If your minifab installation doesn't work, you can try again as follows;
+     - `$ curl -o minifab -L https://tinyurl.com/twrt8zv && chmod +x minifab`
+     - `$ docker pull hyperledgerlabs/minifab:latest`
+
+2. Clone fabcar chaincode (go version) to `mywork/vars/chaincode/fabcar/go`.
+
+   - `$ cd ~`
+
+   - `$ git clone https://github.com/hyperledger/fabric-samples.git`
+
+   - `$ cd mywork/vars`
+
+   - `$ mkdir -p chaincode/fabcar/go`
+
+   - `$ cd chaincode/fabcar/go`
+
+   - `$ cp -r ~/fabric-samples/chaincode/fabcar/go/* ./`
+
+3. Create `spec.yaml`
+
+   - You need to create a file `spec.yaml` that shows the minifabric system configuration. Quoting `spec.yaml` from the minifabic repository below, change the `ca1.org0.example.com` and `ca1.org1.example.com` in the `fabric: cas:` part to `ca.org0.example.com` and `ca.org0.example.com` and place them under `mywork`.
+
+      - [minifabric/spec.yaml at main · hyperledger-labs/minifabric (github.com)](https://github.com/hyperledger-labs/minifabric/blob/main/spec.yaml)
+      - The first five lines are:
+
+      ```
+      fabric:
+       cas:
+       - "ca.org0.example.com"
+       - "ca.org1.example.com"
+       peers: 
+      ```
+
+4. Start minifabric deploying fabcar chaincode (go version) of fabric-samples v1.4.8.
+
+   - `minifab up -i 1.4.8 -e true -n fabcar -l go -o org1.example.com -s couchdb -p`
+
+
+
+
+### How to use fabcar chaincode
+
+- You can execute functions in `mywork/vars/chaincode/fabcar/go/fabcar.go`, for example;
+  - `minifab invoke -p '"InitLedger",""'`
+  - `minifab invoke -p '"QueryAllCars",""'`
+  - `minifab invoke -p '"ChangeCarOwner","CAR0","Yasushi"'`
+  - `minifab invoke -p '"QueryAllCars",""'`
+

--- a/tools/docker/fabric14-fabcar-testnet/how_to_containerize_fabcar.md
+++ b/tools/docker/fabric14-fabcar-testnet/how_to_containerize_fabcar.md
@@ -1,0 +1,184 @@
+# How to Containerize Fabcar
+
+#### Background
+
+- You need to work fabcar to use cartrade, but it may not work outside centos.
+
+#### Goal
+
+- make fabcar work regardless of the environment by making it a docker container,
+  - where "work fabcar" means "use registerUser, query, invoke".
+
+#### System Requirement
+
+- node version: 14.18.0 (node image version of validator container: 14.18.1)
+
+#### Abstruct of modification
+
+- change to fabcar v1.4.12
+- add validator container (modify docker-compose and use node image)
+- change `localhost` to the IP address of your environment
+
+#### Detail of modification
+
+- Change the specified version on line 4 of `/ cactus/tools/docker/fabric 14 -fabcar-testnet/script-start-docker.sh` from` 1.4.1 1.4.1 0.4.22 `to` 1.4.12 1.4.9 0.4.22 `,
+
+  - i.e. `curl -sSL https://bit.ly/2ysbOFE | bash -s -- 1.4.12 1.4.9 0.4.22`.
+
+- Add the following to the end of `/cactus/tools/docker/fabric14-fabcar-testnet/fabric-samples/first-network/docker-compose-cli.yml`;
+
+  - ```
+    validator:
+        container_name: validator
+        image: node:14.18.1
+        tty: true
+        stdin_open: true
+        environment: 
+          - http_proxy=$http_proxy
+          - https_proxy=$https_proxy
+          - HTTP_PROXY=$HTTP_PROXY
+          - HTTPS_PROXY=$HTTPS_PROXY
+          - ftp_proxy=$ftp_proxy
+          - FTP_PROXY=$FTP_PROXY
+          - no_proxy=localhost,127.0.0.1
+          - NO_PROXY=localhost,127.0.0.1
+        volumes:
+          - ./:/app/first-network
+          - ../fabcar:/app/fabcar
+        working_dir: /app
+        command: /bin/bash
+        depends_on:
+          - cli
+          - orderer.example.com
+          - peer0.org1.example.com
+          - peer1.org1.example.com
+          - peer0.org2.example.com
+          - peer1.org2.example.com
+        networks:
+          - byfn
+    ```
+
+- Result
+
+  ```
+  [user002@earth fabric14-fabcar-testnet]$ cd fabric-samples/fabcar
+  [user002@earth fabcar]$ ./startFabric.sh
+  Stopping for channel 'mychannel' with CLI timeout of '10' seconds and CLI delay of '3' seconds
+  proceeding ...
+  WARNING: The BYFN_CA1_PRIVATE_KEY variable is not set. Defaulting to a blank string.
+  WARNING: The BYFN_CA2_PRIVATE_KEY variable is not set. Defaulting to a blank string.
+  Removing network net_byfn
+  ...
+  [user002@earth fabcar]$ docker ps -a
+  CONTAINER ID   IMAGE                                                                                                    COMMAND                  CREATED          STATUS          PORTS                                        NAMES
+  7f87865737b7   dev-peer0.org2.example.com-fabcar-1.0-264b0a1cb5efbecaac5cf8990339c24474dc8435c6e10f10f2be565d555d0e94   "chaincode -peer.add…"   15 minutes ago   Up 15 minutes                                                dev-peer0.org2.example.com-fabcar-1.0
+  79c4ab074f16   dev-peer0.org1.example.com-fabcar-1.0-5c906e402ed29f20260ae42283216aa75549c571e2e380f3615826365d8269ba   "chaincode -peer.add…"   16 minutes ago   Up 16 minutes                                                dev-peer0.org1.example.com-fabcar-1.0
+  c34598d33a61   node:14.18.1                                                                                             "docker-entrypoint.s…"   16 minutes ago   Up 16 minutes                                                validator
+  d83d2777ca8d   hyperledger/fabric-tools:latest                                                                          "/bin/bash"              16 minutes ago   Up 16 minutes                                                cli
+  ac599af0ee86   hyperledger/fabric-peer:latest                                                                           "peer node start"        16 minutes ago   Up 16 minutes   0.0.0.0:8051->8051/tcp                       peer1.org1.example.com
+  06e59d7e665a   hyperledger/fabric-peer:latest                                                                           "peer node start"        16 minutes ago   Up 16 minutes   0.0.0.0:9051->9051/tcp                       peer0.org2.example.com
+  a656edbcf22a   hyperledger/fabric-peer:latest                                                                           "peer node start"        16 minutes ago   Up 16 minutes   0.0.0.0:10051->10051/tcp                     peer1.org2.example.com
+  965b3de2cef7   hyperledger/fabric-peer:latest                                                                           "peer node start"        16 minutes ago   Up 16 minutes   0.0.0.0:7051->7051/tcp                       peer0.org1.example.com
+  5c5ce4f71f24   hyperledger/fabric-orderer:latest                                                                        "orderer"                17 minutes ago   Up 16 minutes   0.0.0.0:7050->7050/tcp                       orderer.example.com
+  a981e8ba06ad   hyperledger/fabric-couchdb                                                                               "tini -- /docker-ent…"   17 minutes ago   Up 16 minutes   4369/tcp, 9100/tcp, 0.0.0.0:7984->5984/tcp   couchdb2
+  56004756bf8d   hyperledger/fabric-ca:latest                                                                             "sh -c 'fabric-ca-se…"   17 minutes ago   Up 16 minutes   0.0.0.0:7054->7054/tcp                       ca_peerOrg1
+  c6710b0cec7e   hyperledger/fabric-couchdb                                                                               "tini -- /docker-ent…"   17 minutes ago   Up 16 minutes   4369/tcp, 9100/tcp, 0.0.0.0:5984->5984/tcp   couchdb0
+  2fb0d56b57fb   hyperledger/fabric-couchdb                                                                               "tini -- /docker-ent…"   17 minutes ago   Up 16 minutes   4369/tcp, 9100/tcp, 0.0.0.0:8984->5984/tcp   couchdb3
+  dc1f036103a8   hyperledger/fabric-couchdb                                                                               "tini -- /docker-ent…"   17 minutes ago   Up 16 minutes   4369/tcp, 9100/tcp, 0.0.0.0:6984->5984/tcp   couchdb1
+  e736ce4fcb65   hyperledger/fabric-ca:latest                                                                             "sh -c 'fabric-ca-se…"   17 minutes ago   Up 16 minutes   7054/tcp, 0.0.0.0:8054->8054/tcp             ca_peerOrg2
+  [user002@earth fabcar]$ docker exec -it validator bash
+  root@c34598d33a61:/app# ls
+  fabcar  first-network
+  root@c34598d33a61:/app# cd fabcar
+  root@c34598d33a61:/app/fabcar# ls
+  java  javascript  javascript-low-level  startFabric.sh  stopFabric.sh  typescript
+  root@c34598d33a61:/app/fabcar# cd javascript
+  root@c34598d33a61:/app/fabcar/javascript# ls
+  enrollAdmin.js  invoke.js  package.json  query.js  registerUser
+  root@c34598d33a61:/app/fabcar/javascript# npm config set proxy $http_proxy
+  root@c34598d33a61:/app/fabcar/javascript# npm config set https-proxy $https_proxy
+  root@c34598d33a61:/app/fabcar/javascript# npm config set no-proxy localhost,127.0.0.1                      root@c34598d33a61:/app/fabcar/javascript# npm install
+  npm WARN deprecated mkdirp@0.5.1: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
+  npm WARN deprecated grpc@1.24.3: This library will not receive further updates other than security fixes. We recommend using @grpc/grpc-js instead.
+  ...
+  root@c34598d33a61:/app/fabcar/javascript# ls
+  enrollAdmin.js  invoke.js  node_modules  package-lock.json  package.json  query.js  registerUser.js  wallet
+  root@c34598d33a61:/app/fabcar/javascript# node enrollAdmin
+  Wallet path: /app/fabcar/javascript/wallet
+  2021-11-05T23:08:11.341Z - error: [FabricCAClientService.js]: Failed to enroll admin, error:%o message=Calling enrollment endpoint failed with error [Error: connect ECONNREFUSED 127.0.0.1:7054
+      at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1159:16) {
+    errno: -111,
+    code: 'ECONNREFUSED',
+    syscall: 'connect',
+    address: '127.0.0.1',
+    port: 7054
+  }], stack=Error: Calling enrollment endpoint failed with error [Error: connect ECONNREFUSED 127.0.0.1:7054
+      at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1159:16) {
+    errno: -111,
+    code: 'ECONNREFUSED',
+    syscall: 'connect',
+    address: '127.0.0.1',
+    port: 7054
+  }]
+      at ClientRequest.<anonymous> (/app/fabcar/javascript/node_modules/fabric-ca-client/lib/FabricCAClient.js:487:12)
+      at ClientRequest.emit (events.js:400:28)
+      at TLSSocket.socketErrorListener (_http_client.js:475:9)
+      at TLSSocket.emit (events.js:400:28)
+      at emitErrorNT (internal/streams/destroy.js:106:8)
+      at emitErrorCloseNT (internal/streams/destroy.js:74:3)
+      at processTicksAndRejections (internal/process/task_queues.js:82:21)
+  Failed to enroll admin user "admin": Error: Calling enrollment endpoint failed with error [Error: connect ECONNREFUSED 127.0.0.1:7054
+      at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1159:16) {
+    errno: -111,
+    code: 'ECONNREFUSED',
+    syscall: 'connect',
+    address: '127.0.0.1',
+    port: 7054
+  }]
+  root@c34598d33a61:/app/fabcar/javascript# 
+  ```
+
+  - A connection error should occur.
+
+- Then, change the following parts of `/cactus/tools/docker/fabric14-fabcar-testnet/fabric-samples/fabcar/javascript`の `registerUser.js`, `query.js`, `invole.js` ;
+
+  - `registerUser.js`
+    - line 37: `await gateway.connect(ccpPath, { wallet, identity: 'admin', discovery: { enabled: true, asLocalhost: true } });`
+    - --> `await gateway.connect(ccpPath, { wallet, identity: 'admin', discovery: { enabled: true, asLocalhost: false } });`
+  - `query.js`
+    - line 30: `await gateway.connect(ccpPath, { wallet, identity: 'user1', discovery: { enabled: true, asLocalhost: true } });`
+    - --> `await gateway.connect(ccpPath, { wallet, identity: 'user1', discovery: { enabled: true, asLocalhost: false } });`
+  - `invoke.js`
+    - line 30: `await gateway.connect(ccpPath, { wallet, identity: 'user1', discovery: { enabled: true, asLocalhost: true } });`
+    - --> `await gateway.connect(ccpPath, { wallet, identity: 'user1', discovery: { enabled: true, asLocalhost: false } });`
+
+- Also, change `localhost` in the following files in `/cactus/tools/docker/fabric14-fabcar-testnet/fabric-samples/first-network` to the IP address of your environment;
+
+  - `ccp-template.json`, `ccp-template.yaml`, `connection-org1.json`, `connection-org1.yaml`, `connection-org2.json`, `connection-org2.yaml`, `connection-org3.json`, `connection-org3.yaml` 
+
+- Then you will get success as the following;
+
+  ```
+  root@c34598d33a61:/app/fabcar/javascript# ls
+  enrollAdmin.js  invoke.js  node_modules  package-lock.json  package.json  query.js 
+  root@c34598d33a61:/app/fabcar/javascript# node enrollAdmin
+  Wallet path: /app/fabcar/javascript/wallet
+  Successfully enrolled admin user "admin" and imported it into the wallet
+   registerUser.js  wallet
+  root@c34598d33a61:/app/fabcar/javascript# node registerUser.js 
+  Wallet path: /app/fabcar/javascript/wallet
+  Successfully registered and enrolled admin user "user1" and imported it into the wallet
+  root@c34598d33a61:/app/fabcar/javascript# node query.js 
+  Wallet path: /app/fabcar/javascript/wallet
+  Transaction has been evaluated, result is: [{"Key":"CAR0", "Record":{"colour":"blue","make":"Toyota","model":"Prius","owner":"Tomoko"}},{"Key":"CAR1", "Record":{"colour":"red","make":"Ford","model":"Mustang","owner":"Brad"}},{"Key":"CAR2", "Record":{"colour":"green","make":"Hyundai","model":"Tucson","owner":"Jin Soo"}},{"Key":"CAR3", "Record":{"colour":"yellow","make":"Volkswagen","model":"Passat","owner":"Max"}},{"Key":"CAR4", "Record":{"colour":"black","make":"Tesla","model":"S","owner":"Adriana"}},{"Key":"CAR5", "Record":{"colour":"purple","make":"Peugeot","model":"205","owner":"Michel"}},{"Key":"CAR6", "Record":{"colour":"white","make":"Chery","model":"S22L","owner":"Aarav"}},{"Key":"CAR7", "Record":{"colour":"violet","make":"Fiat","model":"Punto","owner":"Pari"}},{"Key":"CAR8", "Record":{"colour":"indigo","make":"Tata","model":"Nano","owner":"Valeria"}},{"Key":"CAR9", "Record":{"colour":"brown","make":"Holden","model":"Barina","owner":"Shotaro"}}]
+  root@c34598d33a61:/app/fabcar/javascript# node invoke.js 
+  Wallet path: /app/fabcar/javascript/wallet
+  Transaction has been submitted
+  root@c34598d33a61:/app/fabcar/javascript# node query.js 
+  Wallet path: /app/fabcar/javascript/wallet
+  Transaction has been evaluated, result is: [{"Key":"CAR0", "Record":{"colour":"blue","make":"Toyota","model":"Prius","owner":"Tomoko"}},{"Key":"CAR1", "Record":{"colour":"red","make":"Ford","model":"Mustang","owner":"Brad"}},{"Key":"CAR12", "Record":{"colour":"Black","make":"Honda","model":"Accord","owner":"Tom"}},{"Key":"CAR2", "Record":{"colour":"green","make":"Hyundai","model":"Tucson","owner":"Jin Soo"}},{"Key":"CAR3", "Record":{"colour":"yellow","make":"Volkswagen","model":"Passat","owner":"Max"}},{"Key":"CAR4", "Record":{"colour":"black","make":"Tesla","model":"S","owner":"Adriana"}},{"Key":"CAR5", "Record":{"colour":"purple","make":"Peugeot","model":"205","owner":"Michel"}},{"Key":"CAR6", "Record":{"colour":"white","make":"Chery","model":"S22L","owner":"Aarav"}},{"Key":"CAR7", "Record":{"colour":"violet","make":"Fiat","model":"Punto","owner":"Pari"}},{"Key":"CAR8", "Record":{"colour":"indigo","make":"Tata","model":"Nano","owner":"Valeria"}},{"Key":"CAR9", "Record":{"colour":"brown","make":"Holden","model":"Barina","owner":"Shotaro"}}]
+  root@c34598d33a61:/app/fabcar/javascript# 
+  ```
+
+  
+

--- a/tools/docker/fabric14-fabcar-testnet/script-start-docker.sh
+++ b/tools/docker/fabric14-fabcar-testnet/script-start-docker.sh
@@ -1,7 +1,7 @@
 # Copyright 2020-2021 Hyperledger Cactus Contributors
 # SPDX-License-Identifier: Apache-2.0
 echo "[process] start docker environment for Fabric testnet"
-curl -sSL https://bit.ly/2ysbOFE | bash -s -- 1.4.1 1.4.1 0.4.22
+curl -sSL https://bit.ly/2ysbOFE | bash -s -- 1.4.12 1.4.9 0.4.22
 
 if [ -d fabric-samples/fabcar/javascript/wallet ]; then
   rm -r fabric-samples/fabcar/javascript/wallet


### PR DESCRIPTION
This PR resolves Issue #1512 .
Some environments (ex. not centos) have problems with fabcar operation, so I want to make cartrade applications available in more environments. To do this, I first introduce minifabric:<https://github.com/hyperledger-labs/minifabric>.

Signed-off-by: Yasushi Takahashi <t-yasushi@fujitsu.com>