### PR TITLE
test: supply-chain-backend-api-calls fails without config file #1516

### DIFF
--- a/examples/cactus-example-supply-chain-backend/src/test/typescript/integration/supply-chain-backend-api-calls.test.ts
+++ b/examples/cactus-example-supply-chain-backend/src/test/typescript/integration/supply-chain-backend-api-calls.test.ts
@@ -28,6 +28,11 @@ test("Supply chain backend API calls can be executed", async (t: Test) => {
   const exampleConfig = configService.newExampleConfig();
   t.ok(exampleConfig, "configService.newExampleConfig() truthy OK");
 
+  // TODO: Investigate the explanation for this when we have more time, for
+  // now I just hacked it so that it does not look for a .config file on the FS.
+  // @see: https://github.com/hyperledger/cactus/issues/1516
+  exampleConfig.configFile = "";
+
   // FIXME - this hack should not be necessary, we need to re-think how we
   // do configuration parsing. The convict library may not be the path forward.
   exampleConfig.authorizationConfigJson = (JSON.stringify(


### PR DESCRIPTION
Made it so that the test uses a config that does not specify a config
file path to be parsed by the config service so that it does not depend
on one existing on the file system when the test gets executed.
It works fine without the .config.json file because we anyway configure
everything via code within the test.

This test started failing while I was working on the Jest/Tap co-existence
pull request so it might have something to do with the migration, but it
does not look like it.

Fixes #1516

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>