### PR TITLE
feat(connector-corda): enable Flow Database Access CorDapp

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -40,6 +40,7 @@
         "execa",
         "faio",
         "fidm",
+        "flowdb",
         "fsouza",
         "GETHKEYCHAINPASSWORD",
         "ghcr",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,18 @@ jobs:
     - name: Print Disk Usage Reports
       run: df ; echo "" ; docker system df
 
+    - name: ghcr.io/hyperledger/cactus-corda-all-in-one-obligation
+      run: DOCKER_BUILDKIT=1 docker build ./tools/docker/corda-all-in-one/ -f ./tools/docker/corda-all-in-one/corda-v4_8/Dockerfile
+
+    - name: Print Disk Usage Reports
+      run: df ; echo "" ; docker system df
+
+    - name: ghcr.io/hyperledger/cactus-corda-all-in-one-flowdb
+      run: DOCKER_BUILDKIT=1 docker build ./tools/docker/corda-all-in-one/corda-v4_8-flowdb/
+
+    - name: Print Disk Usage Reports
+      run: df ; echo "" ; docker system df
+
     # Skipping this one for now because it keeps making the CI fail most likely due to DockerHub rate limits.
     # TODO: Recommend the Fabric maintainers that they publish their images to ghcr.io as well or ask how can the
     # image registry be overridden in Fabric samples.

--- a/.taprc
+++ b/.taprc
@@ -58,6 +58,7 @@ files:
   - ./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server-v4.8.test.ts
   - ./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes.test.ts
   - ./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes-v4.8.test.ts
+  - ./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/flow-database-access-v4.8.test.ts
   - ./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
   - ./packages/cactus-plugin-keychain-google-sm/src/test/typescript/integration/plugin-factory-keychain.test.ts
   - ./packages/cactus-plugin-keychain-google-sm/src/test/typescript/integration/plugin-keychain-google-sm.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -64,6 +64,7 @@ module.exports = {
     `./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server-v4.8.test.ts`,
     `./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes.test.ts`,
     `./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes-v4.8.test.ts`,
+    `./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/flow-database-access-v4.8.test.ts`,
     `./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts`,
     `./packages/cactus-plugin-keychain-google-sm/src/test/typescript/integration/plugin-factory-keychain.test.ts`,
     `./packages/cactus-plugin-keychain-google-sm/src/test/typescript/integration/plugin-keychain-google-sm.test.ts`,

--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/build.gradle.kts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/build.gradle.kts
@@ -2,8 +2,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val corda_release_group = "net.corda"
 val corda_core_release_group =  "net.corda"
-val corda_release_version = "4.5"
-val corda_core_release_version = "4.5"
+val corda_release_version = "4.6"
+val corda_core_release_version = "4.6"
 val corda_platform_version = 5
 
 tasks.named<Test>("test") {

--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/InvokeContractV1Response.kt
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/model/InvokeContractV1Response.kt
@@ -14,7 +14,8 @@ import javax.validation.Valid
 /**
  * 
  * @param success 
- * @param callOutput 
+ * @param callOutput Data returned from the JVM when no transaction is running
+ * @param flowId The id for the flow handle
  * @param transactionId The net.corda.core.flows.StateMachineRunId value returned by the flow execution.
  * @param progress An array of strings representing the aggregated stream of progress updates provided by a *tracked* flow invocation. If the flow invocation was not tracked, this array is still returned, but as empty.
  */
@@ -25,8 +26,10 @@ data class InvokeContractV1Response(
     @field:Valid
     @field:JsonProperty("callOutput", required = true) val callOutput: kotlin.Any,
 
+    @field:JsonProperty("flowId", required = true) val flowId: kotlin.String,
+
     @get:Size(min=1,max=1024)
-    @field:JsonProperty("transactionId", required = true) val transactionId: kotlin.String,
+    @field:JsonProperty("transactionId") val transactionId: kotlin.String? = null,
 
     @field:JsonProperty("progress") val progress: kotlin.collections.List<kotlin.String>? = null
 ) {

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/json/openapi.json
@@ -455,8 +455,8 @@
                 "type": "object",
                 "required": [
                     "success",
-                    "transactionId",
-                    "callOutput"
+                    "callOutput",
+                    "flowId"                    
                 ],
                 "properties": {
                     "success": {
@@ -464,7 +464,8 @@
                         "nullable": false
                     },
                     "callOutput": {
-                        "type": "object"
+                        "type": "object",
+                        "description": "Data returned from the JVM when no transaction is running"
                     },
                     "transactionId": {
                         "type": "string",
@@ -482,6 +483,10 @@
                             "maxItems": 10e6
                         },
                         "default": []
+                    },
+                    "flowId": {
+                        "type": "string",
+                        "description": "The id for the flow handle"
                     }
                 }
             },

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -368,7 +368,7 @@ export interface InvokeContractV1Response {
      */
     success: boolean;
     /**
-     * 
+     * Data returned from the JVM when no transaction is running
      * @type {object}
      * @memberof InvokeContractV1Response
      */
@@ -378,13 +378,19 @@ export interface InvokeContractV1Response {
      * @type {string}
      * @memberof InvokeContractV1Response
      */
-    transactionId: string;
+    transactionId?: string;
     /**
      * An array of strings representing the aggregated stream of progress updates provided by a *tracked* flow invocation. If the flow invocation was not tracked, this array is still returned, but as empty.
      * @type {Array<string>}
      * @memberof InvokeContractV1Response
      */
     progress?: Array<string>;
+    /**
+     * The id for the flow handle
+     * @type {string}
+     * @memberof InvokeContractV1Response
+     */
+    flowId: string;
 }
 /**
  * 

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes-v4.7.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes-v4.7.test.ts
@@ -106,7 +106,7 @@ test.skip("Tests are passing on the JVM side", async (t: Test) => {
   const connector = new CordaConnectorContainer({
     logLevel,
     imageName: "ghcr.io/hyperledger/cactus-connector-corda-server",
-    imageVersion: "2021-11-11",
+    imageVersion: "2021-11-23--feat-1493",
     envVars: [envVarSpringAppJson],
   });
   t.ok(CordaConnectorContainer, "CordaConnectorContainer instantiated OK");

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes-v4.8-express.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes-v4.8-express.test.ts
@@ -111,7 +111,7 @@ test.skip("Tests are passing on the JVM side", async (t: Test) => {
   const connector = new CordaConnectorContainer({
     logLevel,
     imageName: "ghcr.io/hyperledger/cactus-connector-corda-server",
-    imageVersion: "2021-11-11",
+    imageVersion: "2021-11-23--feat-1493",
     envVars: [envVarSpringAppJson],
   });
   t.ok(CordaConnectorContainer, "CordaConnectorContainer instantiated OK");

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes-v4.8.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes-v4.8.test.ts
@@ -107,7 +107,7 @@ test.skip("Tests are passing on the JVM side", async (t: Test) => {
   const connector = new CordaConnectorContainer({
     logLevel,
     imageName: "ghcr.io/hyperledger/cactus-connector-corda-server",
-    imageVersion: "2021-11-11",
+    imageVersion: "2021-11-23--feat-1493",
     envVars: [envVarSpringAppJson],
   });
   t.ok(CordaConnectorContainer, "CordaConnectorContainer instantiated OK");

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes.test.ts
@@ -106,9 +106,7 @@ test.skip("Tests are passing on the JVM side", async (t: Test) => {
   const connector = new CordaConnectorContainer({
     logLevel,
     imageName: "ghcr.io/hyperledger/cactus-connector-corda-server",
-    imageVersion: "2021-11-11",
-    // imageName: "cccs",
-    // imageVersion: "latest",
+    imageVersion: "2021-11-23--feat-1493",
     envVars: [envVarSpringAppJson],
   });
   t.ok(CordaConnectorContainer, "CordaConnectorContainer instantiated OK");

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/flow-database-access-v4.8.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/flow-database-access-v4.8.test.ts
@@ -1,0 +1,241 @@
+import test, { Test } from "tape-promise/tape";
+import { v4 as internalIpV4 } from "internal-ip";
+
+import {
+  Containers,
+  CordaTestLedger,
+  pruneDockerAllIfGithubAction,
+} from "@hyperledger/cactus-test-tooling";
+import { LogLevelDesc } from "@hyperledger/cactus-common";
+import {
+  SampleCordappEnum,
+  CordaConnectorContainer,
+} from "@hyperledger/cactus-test-tooling";
+
+import {
+  CordappDeploymentConfig,
+  DefaultApi as CordaApi,
+  DeployContractJarsV1Request,
+  FlowInvocationType,
+  InvokeContractV1Request,
+  JvmTypeKind,
+} from "../../../main/typescript/generated/openapi/typescript-axios/index";
+import { Configuration } from "@hyperledger/cactus-core-api";
+
+const testCase = "Tests are passing on the JVM side";
+const logLevel: LogLevelDesc = "TRACE";
+
+test.onFailure(async () => {
+  await Containers.logDiagnostics({ logLevel });
+});
+
+test("BEFORE " + testCase, async (t: Test) => {
+  const pruning = pruneDockerAllIfGithubAction({ logLevel });
+  await t.doesNotReject(pruning, "Pruning didn't throw OK");
+  t.end();
+});
+
+test(testCase, async (t: Test) => {
+  const ledger = new CordaTestLedger({
+    imageName: "ghcr.io/hyperledger/cactus-corda-4-8-all-in-one-flowdb",
+    imageVersion: "2021-11-23--feat-1493",
+    logLevel,
+  });
+  t.ok(ledger, "CordaTestLedger v4.8 instantaited OK");
+
+  test.onFinish(async () => {
+    await ledger.stop();
+    await ledger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
+  });
+  const ledgerContainer = await ledger.start();
+  t.ok(
+    ledgerContainer,
+    "CordaTestLedger v4.8 container truthy post-start() OK",
+  );
+
+  await ledger.logDebugPorts();
+  const partyARpcPort = await ledger.getRpcAPublicPort();
+
+  const jarFiles = await ledger.pullCordappJars(SampleCordappEnum.BASIC_FLOW);
+  t.comment(`Fetched ${jarFiles.length} cordapp jars OK`);
+
+  const internalIpOrUndefined = await internalIpV4();
+  t.ok(internalIpOrUndefined, "Determined LAN IPv4 address successfully OK");
+  const internalIp = internalIpOrUndefined as string;
+  t.comment(`Internal IP (based on default gateway): ${internalIp}`);
+
+  const partyARpcUsername = "user1";
+  const partyARpcPassword = "password";
+  const springAppConfig = {
+    logging: {
+      level: {
+        root: "INFO",
+        "net.corda": "INFO",
+        "org.hyperledger.cactus": "DEBUG",
+      },
+    },
+    cactus: {
+      corda: {
+        node: { host: internalIp },
+        rpc: {
+          port: partyARpcPort,
+          username: partyARpcUsername,
+          password: partyARpcPassword,
+        },
+      },
+    },
+  };
+  const springApplicationJson = JSON.stringify(springAppConfig);
+  const envVarSpringAppJson = `SPRING_APPLICATION_JSON=${springApplicationJson}`;
+  t.comment(envVarSpringAppJson);
+
+  const connector = new CordaConnectorContainer({
+    logLevel,
+    imageName: "ghcr.io/hyperledger/cactus-connector-corda-server",
+    imageVersion: "2021-11-23--feat-1493",
+    envVars: [envVarSpringAppJson],
+  });
+  t.ok(CordaConnectorContainer, "CordaConnectorContainer instantiated OK");
+
+  test.onFinish(async () => {
+    try {
+      await connector.stop();
+    } finally {
+      await connector.destroy();
+    }
+  });
+
+  const connectorContainer = await connector.start();
+  t.ok(connectorContainer, "CordaConnectorContainer started OK");
+
+  await connector.logDebugPorts();
+  const apiUrl = await connector.getApiLocalhostUrl();
+  const config = new Configuration({ basePath: apiUrl });
+  const apiClient = new CordaApi(config);
+
+  const flowsRes = await apiClient.listFlowsV1();
+  t.ok(flowsRes.status === 200, "flowsRes.status === 200 OK");
+  t.ok(flowsRes.data, "flowsRes.data truthy OK");
+  t.ok(flowsRes.data.flowNames, "flowsRes.data.flowNames truthy OK");
+  t.comment(`apiClient.listFlowsV1() => ${JSON.stringify(flowsRes.data)}`);
+
+  const cordappDeploymentConfigs: CordappDeploymentConfig[] = [];
+  const depReq: DeployContractJarsV1Request = {
+    jarFiles,
+    cordappDeploymentConfigs,
+  };
+  const depRes = await apiClient.deployContractJarsV1(depReq);
+  t.ok(depRes, "Jar deployment response truthy OK");
+  t.equal(depRes.status, 200, "Jar deployment status code === 200 OK");
+  t.ok(depRes.data, "Jar deployment response body truthy OK");
+  t.ok(depRes.data.deployedJarFiles, "Jar deployment body deployedJarFiles OK");
+  t.equal(
+    depRes.data.deployedJarFiles.length,
+    jarFiles.length,
+    "Deployed jar file count equals count in request OK",
+  );
+
+  const myToken = "myToken";
+  const initialValue = 42;
+  const finalValue = 11;
+
+  // add a new token value
+  const reqAdd: InvokeContractV1Request = ({
+    timeoutMs: 60000,
+    flowFullClassName: "net.corda.samples.flowdb.AddTokenValueFlow",
+    flowInvocationType: FlowInvocationType.FlowDynamic,
+    params: [
+      {
+        jvmTypeKind: JvmTypeKind.Primitive,
+        jvmType: {
+          fqClassName: "java.lang.String",
+        },
+        primitiveValue: myToken,
+      },
+      {
+        jvmTypeKind: JvmTypeKind.Primitive,
+        jvmType: {
+          fqClassName: "java.lang.Integer",
+        },
+        primitiveValue: initialValue,
+      },
+    ],
+  } as unknown) as InvokeContractV1Request;
+
+  const resAdd = await apiClient.invokeContractV1(reqAdd);
+  t.ok(resAdd, "InvokeContractV1Request truthy OK");
+  t.equal(resAdd.status, 200, "InvokeContractV1Request status code === 200 OK");
+
+  // query a token value
+  const reqQuery: InvokeContractV1Request = ({
+    timeoutMs: 60000,
+    flowFullClassName: "net.corda.samples.flowdb.QueryTokenValueFlow",
+    flowInvocationType: FlowInvocationType.FlowDynamic,
+    params: [
+      {
+        jvmTypeKind: JvmTypeKind.Primitive,
+        jvmType: {
+          fqClassName: "java.lang.String",
+        },
+        primitiveValue: myToken,
+      },
+    ],
+  } as unknown) as InvokeContractV1Request;
+
+  const resQuery = await apiClient.invokeContractV1(reqQuery);
+  t.ok(resQuery, "InvokeContractV1Request truthy OK");
+  t.equal(
+    resQuery.status,
+    200,
+    "InvokeContractV1Request status code === 200 OK",
+  );
+  t.equal(
+    resQuery.data.callOutput,
+    initialValue.toString(),
+    "token value is equal to initialValue OK",
+  );
+
+  // update a token value
+  const reqUpd: InvokeContractV1Request = ({
+    timeoutMs: 60000,
+    flowFullClassName: "net.corda.samples.flowdb.UpdateTokenValueFlow",
+    flowInvocationType: FlowInvocationType.FlowDynamic,
+    params: [
+      {
+        jvmTypeKind: JvmTypeKind.Primitive,
+        jvmType: {
+          fqClassName: "java.lang.String",
+        },
+        primitiveValue: myToken,
+      },
+      {
+        jvmTypeKind: JvmTypeKind.Primitive,
+        jvmType: {
+          fqClassName: "java.lang.Integer",
+        },
+        primitiveValue: finalValue,
+      },
+    ],
+  } as unknown) as InvokeContractV1Request;
+
+  const resUpd = await apiClient.invokeContractV1(reqUpd);
+  t.ok(resUpd, "InvokeContractV1Request truthy OK");
+  t.equal(resUpd.status, 200, "InvokeContractV1Request status code === 200 OK");
+
+  // query a token value
+  const resQueryFinal = await apiClient.invokeContractV1(reqQuery);
+  t.ok(resQueryFinal, "InvokeContractV1Request truthy OK");
+  t.equal(
+    resQueryFinal.status,
+    200,
+    "InvokeContractV1Request status code === 200 OK",
+  );
+  t.equal(
+    resQueryFinal.data.callOutput,
+    finalValue.toString(),
+    "token value is equal to finalValue OK",
+  );
+
+  t.end();
+});

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server-v4.7.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server-v4.7.test.ts
@@ -86,9 +86,7 @@ test(testCase, async (t: Test) => {
   const connector = new CordaConnectorContainer({
     logLevel,
     imageName: "ghcr.io/hyperledger/cactus-connector-corda-server",
-    imageVersion: "2021-11-11",
-    // imageName: "cccs",
-    // imageVersion: "latest",
+    imageVersion: "2021-11-23--feat-1493",
     envVars: [envVarSpringAppJson],
   });
   t.ok(CordaConnectorContainer, "CordaConnectorContainer instantiated OK");

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server-v4.8.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server-v4.8.test.ts
@@ -89,9 +89,7 @@ test(testCase, async (t: Test) => {
   const connector = new CordaConnectorContainer({
     logLevel,
     imageName: "ghcr.io/hyperledger/cactus-connector-corda-server",
-    imageVersion: "2021-11-11",
-    // imageName: "cccs",
-    // imageVersion: "latest",
+    imageVersion: "2021-11-23--feat-1493",
     envVars: [envVarSpringAppJson],
   });
   t.ok(CordaConnectorContainer, "CordaConnectorContainer instantiated OK");

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server.test.ts
@@ -86,9 +86,7 @@ test(testCase, async (t: Test) => {
   const connector = new CordaConnectorContainer({
     logLevel,
     imageName: "ghcr.io/hyperledger/cactus-connector-corda-server",
-    imageVersion: "2021-11-11",
-    // imageName: "cccs",
-    // imageVersion: "latest",
+    imageVersion: "2021-11-23--feat-1493",
     envVars: [envVarSpringAppJson],
   });
   t.ok(CordaConnectorContainer, "CordaConnectorContainer instantiated OK");

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/openapi/openapi-validation.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/openapi/openapi-validation.test.ts
@@ -90,7 +90,7 @@ test(testCase, async (t: Test) => {
   const connector = new CordaConnectorContainer({
     logLevel,
     imageName: "ghcr.io/hyperledger/cactus-connector-corda-server",
-    imageVersion: "2021-11-11",
+    imageVersion: "2021-11-23--feat-1493",
     envVars: [envVarSpringAppJson],
   });
   t.ok(CordaConnectorContainer, "CordaConnectorContainer instantiated OK");

--- a/packages/cactus-test-tooling/src/main/typescript/corda/sample-cordapp-enum.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/corda/sample-cordapp-enum.ts
@@ -7,16 +7,49 @@
 export const enum SampleCordappEnum {
   ADVANCED_OBLIGATION = "ADVANCED_OBLIGATION",
   BASIC_CORDAPP = "BASIC_CORDAPP",
+  BASIC_FLOW = "BASIC_FLOW",
 }
 
 /**
  * Stores the mapping between the samples and their project
  * roots on the file-system within the samples-kotlin git
- * repository.
+ * repository and the jars location.
  * @see https://github.com/corda/samples-kotlin
  */
-export const SAMPLE_CORDAPP_ROOT_DIRS = Object.freeze({
-  [SampleCordappEnum.ADVANCED_OBLIGATION]:
-    "/samples-kotlin/Advanced/obligation-cordapp/",
-  [SampleCordappEnum.BASIC_CORDAPP]: "/samples-kotlin/Basic/cordapp-example/",
+export const SAMPLE_CORDAPP_DATA = Object.freeze({
+  [SampleCordappEnum.ADVANCED_OBLIGATION]: {
+    rootDir: "/samples-kotlin/Advanced/obligation-cordapp/",
+    jars: [
+      {
+        jarRelativePath: "contracts/build/libs/contracts-1.0.jar",
+        fileName: "_contracts-1.0.jar",
+      },
+      {
+        jarRelativePath: "workflows/build/libs/workflows-1.0.jar",
+        fileName: "_workflows-1.0.jar",
+      },
+    ],
+  },
+  [SampleCordappEnum.BASIC_CORDAPP]: {
+    rootDir: "/samples-kotlin/Basic/cordapp-example/",
+    jars: [
+      {
+        jarRelativePath: "contracts/build/libs/contracts-1.0.jar",
+        fileName: "_contracts-1.0.jar",
+      },
+      {
+        jarRelativePath: "workflows/build/libs/workflows-1.0.jar",
+        fileName: "_workflows-1.0.jar",
+      },
+    ],
+  },
+  [SampleCordappEnum.BASIC_FLOW]: {
+    rootDir: "/samples-kotlin/Basic/flow-database-access/",
+    jars: [
+      {
+        jarRelativePath: "workflows/build/libs/workflows-0.1.jar",
+        fileName: "_workflows-0.1.jar",
+      },
+    ],
+  },
 });

--- a/packages/cactus-test-tooling/src/main/typescript/public-api.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/public-api.ts
@@ -130,7 +130,7 @@ export {
 } from "./go-ipfs/go-ipfs-test-container";
 
 export {
-  SAMPLE_CORDAPP_ROOT_DIRS,
+  SAMPLE_CORDAPP_DATA,
   SampleCordappEnum,
 } from "./corda/sample-cordapp-enum";
 

--- a/tools/docker/corda-all-in-one/README.md
+++ b/tools/docker/corda-all-in-one/README.md
@@ -22,6 +22,28 @@ docker run --rm --privileged caio
 ### Build and Run Image Locally
 
 ```sh
-docker build ./tools/docker/corda-all-in-one/ -f ./tools/docker/corda-all-in-one/corda-v4_8/Dockerfile -t caio48
+DOCKER_BUILDKIT=1 docker build ./tools/docker/corda-all-in-one/ -f ./tools/docker/corda-all-in-one/corda-v4_8/Dockerfile -t caio48
 docker run --rm --privileged caio48
+```
+
+# cactus-corda-4-8-all-in-one-flowdb
+
+> This docker image is for `testing` and `development` only.
+> Do NOT use in production!
+
+## Customization
+
+`build.gradle` file from this sample has defined a single node called PartyA. It was modified to deploy the same nodes as in the obligation sample to make it work with our CordaTestLedger:
+- Notary
+- ParticipantA
+- ParticipantB
+- ParticipantC
+
+## Usage
+
+### Build and Run Image Locally
+
+```sh
+DOCKER_BUILDKIT=1 docker build ./tools/docker/corda-all-in-one/corda-v4_8-flowdb/ -t caio48-flowdb
+docker run --rm --privileged caio48-flowdb
 ```

--- a/tools/docker/corda-all-in-one/corda-v4_8-flowdb/Dockerfile
+++ b/tools/docker/corda-all-in-one/corda-v4_8-flowdb/Dockerfile
@@ -1,0 +1,139 @@
+FROM docker:20.10.2-dind
+
+ARG SAMPLES_KOTLIN_SHA=30fd841dd035934bae75ab8910da3b6e3d5d6ee7
+ARG SAMPLES_KOTLIN_FLOWDB_SUB_DIR_PATH="./Basic/flow-database-access/"
+ARG CORDA_TOOLS_SHELL_CLI_VERSION=4.8
+
+WORKDIR /
+
+RUN apk update
+
+# Install dependencies of Docker Compose
+RUN apk add py-pip python3-dev libffi-dev openssl-dev gcc libc-dev make
+
+# Install git so we can check out the kotlin-samples repo of Corda
+RUN apk add --no-cache git
+
+# Fabric Samples needs bash, sh is not good enough here
+RUN apk add --no-cache bash
+
+# Need curl to run healthchecks
+RUN apk add --no-cache curl
+
+# The file binary is used to inspect exectubles when debugging container image issues
+RUN apk add --no-cache file
+
+RUN apk add --no-cache openjdk8
+
+# Need gradle to execute the corda sample app setup commands
+RUN apk add --no-cache gradle
+
+ENV CACTUS_CFG_PATH=/etc/hyperledger/cactus
+RUN mkdir -p $CACTUS_CFG_PATH
+
+# OpenSSH - need to have it so we can shell in and install/instantiate contracts and troubleshoot
+RUN apk add --no-cache openssh augeas
+
+# Configure the OpenSSH server we just installed
+RUN augtool 'set /files/etc/ssh/sshd_config/AuthorizedKeysFile ".ssh/authorized_keys /etc/authorized_keys/%u"'
+RUN augtool 'set /files/etc/ssh/sshd_config/PermitRootLogin yes'
+RUN augtool 'set /files/etc/ssh/sshd_config/PasswordAuthentication yes'
+RUN augtool 'set /files/etc/ssh/sshd_config/PermitEmptyPasswords yes'
+RUN augtool 'set /files/etc/ssh/sshd_config/Port 22'
+RUN augtool 'set /files/etc/ssh/sshd_config/LogLevel DEBUG2'
+RUN augtool 'set /files/etc/ssh/sshd_config/LoginGraceTime 10'
+# Create the server's key - without this sshd will refuse to start
+RUN ssh-keygen -A
+
+# Generate an RSA keypair on the fly to avoid having to hardcode one in the image
+# which technically does not pose a security threat since this is only a development
+# image, but we do it like this anyway.
+RUN mkdir ~/.ssh
+RUN chmod 700 ~/.ssh/
+RUN touch ~/.ssh/authorized_keys
+RUN ["/bin/bash", "-c", "ssh-keygen -t rsa -N '' -f $CACTUS_CFG_PATH/corda-aio-image <<< y"]
+RUN mv $CACTUS_CFG_PATH/corda-aio-image $CACTUS_CFG_PATH/corda-aio-image.key
+RUN cp $CACTUS_CFG_PATH/corda-aio-image.pub ~/.ssh/authorized_keys
+
+# RUN tr -dc A-Za-z0-9 </dev/urandom | head -c 20 > /root-password.txt
+# RUN cat /root-password.txt | chpasswd
+RUN echo "root:root" | chpasswd
+
+RUN curl https://software.r3.com/artifactory/corda-releases/net/corda/corda-tools-shell-cli/${CORDA_TOOLS_SHELL_CLI_VERSION}/corda-tools-shell-cli-${CORDA_TOOLS_SHELL_CLI_VERSION}-all.jar --output /corda-tools-shell-cli-all.jar
+# This is what makes the "corda-shell" alias avaialble on the terminal
+RUN java -jar /corda-tools-shell-cli-all.jar install-shell-extensions
+
+RUN git clone https://github.com/corda/samples-kotlin.git
+WORKDIR /samples-kotlin
+RUN git checkout ${SAMPLES_KOTLIN_SHA}
+
+COPY build.gradle /samples-kotlin/${SAMPLES_KOTLIN_FLOWDB_SUB_DIR_PATH}/build.gradle
+
+WORKDIR /samples-kotlin/${SAMPLES_KOTLIN_FLOWDB_SUB_DIR_PATH}
+
+# Install supervisord because we need to run the docker daemon and also the corda network
+# meaning that we have multiple processes to run.
+RUN apk add --no-cache supervisor
+
+RUN ./gradlew clean deployNodes
+# RUN ./build/nodes/runnodes
+
+# OpenSSH server
+EXPOSE 22
+
+# supervisord web ui/dashboard
+EXPOSE 9001
+
+# Notary RPC
+EXPOSE 10003
+
+# Party A RPC
+EXPOSE 10008
+
+# Party B RPC
+EXPOSE 10011
+
+# Party C RPC
+EXPOSE 10014
+
+# Corda IOU Web GUIs for Node A,B,C
+# EXPOSE 10009 10012 10015
+
+# Jolokia for Party A,B,C and Notary
+EXPOSE 7005 7006 7007 7008
+
+
+COPY supervisord.conf /etc/supervisord.conf
+COPY run-party-a-server.sh /
+COPY run-party-b-server.sh /
+COPY run-party-c-server.sh /
+COPY run-party-a-node.sh /
+COPY run-party-b-node.sh /
+COPY run-party-c-node.sh /
+COPY run-notary-node.sh /
+COPY healthcheck.sh /
+
+# By default we only run the absolute minimum which is a single party's node.
+# For more complex tests everything else can also be enabled via the env vars
+# below so that if needed there is 2 parties, a notary and a dedicated web server
+# for all 3 of those nodes.
+# "Web server" => the same one as in the official corda samples-kotlin repo
+ENV PARTY_A_NODE_ENABLED="true"
+ENV PARTY_A_WEB_SRV_ENABLED="false"
+
+ENV PARTY_B_NODE_ENABLED="true"
+ENV PARTY_B_WEB_SRV_ENABLED="false"
+
+ENV PARTY_C_NODE_ENABLED="true"
+ENV PARTY_C_WEB_SRV_ENABLED="false"
+
+ENV NOTARY_NODE_ENABLED="true"
+
+# Extend the parent image's entrypoint
+# https://superuser.com/questions/1459466/can-i-add-an-additional-docker-entrypoint-script
+ENTRYPOINT ["/usr/bin/supervisord"]
+CMD ["--configuration", "/etc/supervisord.conf", "--nodaemon"]
+
+# We consider the container healthy once the default example fabcar contract has been deployed
+# and is responsive to queries as well
+HEALTHCHECK --interval=1s --timeout=5s --start-period=5s --retries=180 CMD /healthcheck.sh

--- a/tools/docker/corda-all-in-one/corda-v4_8-flowdb/build.gradle
+++ b/tools/docker/corda-all-in-one/corda-v4_8-flowdb/build.gradle
@@ -1,0 +1,139 @@
+buildscript { //properties that you need to build the project
+
+    Properties constants = new Properties()
+    file("$projectDir/../constants.properties").withInputStream { constants.load(it) }
+
+    ext {
+        corda_release_group = constants.getProperty("cordaReleaseGroup")
+        corda_core_release_group =  constants.getProperty("cordaCoreReleaseGroup")
+        corda_release_version = constants.getProperty("cordaVersion")
+        corda_core_release_version = constants.getProperty("cordaCoreVersion")
+        corda_gradle_plugins_version = constants.getProperty("gradlePluginsVersion")
+        kotlin_version = constants.getProperty("kotlinVersion")
+        junit_version = constants.getProperty("junitVersion")
+        quasar_version = constants.getProperty("quasarVersion")
+        log4j_version = constants.getProperty("log4jVersion")
+        slf4j_version = constants.getProperty("slf4jVersion")
+        corda_platform_version = constants.getProperty("platformVersion").toInteger()
+    }
+
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        jcenter()
+        maven { url 'https://software.r3.com/artifactory/corda-releases' }
+    }
+
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "net.corda.plugins:cordapp:$corda_gradle_plugins_version"
+        classpath "net.corda.plugins:cordformation:$corda_gradle_plugins_version"
+        classpath "net.corda.plugins:quasar-utils:$corda_gradle_plugins_version"
+    }
+}
+
+allprojects { //Properties that you need to compile your project (The application)
+    apply plugin: 'kotlin'
+
+    repositories {
+        mavenLocal()
+        jcenter()
+        mavenCentral()
+        maven { url 'https://software.r3.com/artifactory/corda' }
+        maven { url 'https://jitpack.io' }
+    }
+
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
+        kotlinOptions {
+            languageVersion = "1.2"
+            apiVersion = "1.2"
+            jvmTarget = "1.8"
+            javaParameters = true   // Useful for reflection.
+        }
+    }
+
+    jar {
+        // This makes the JAR's SHA-256 hash repeatable.
+        preserveFileTimestamps = false
+        reproducibleFileOrder = true
+    }
+}
+
+apply plugin: 'net.corda.plugins.cordapp'
+apply plugin: 'net.corda.plugins.cordformation'
+apply plugin: 'net.corda.plugins.quasar-utils'
+
+sourceSets {
+    main {
+        resources {
+            srcDir rootProject.file("config/dev")
+        }
+    }
+}
+
+//Module dependencis
+dependencies {
+    // Corda dependencies.
+    cordaCompile "$corda_core_release_group:corda-core:$corda_core_release_version"
+    cordaRuntime "$corda_release_group:corda-node-api:$corda_release_version"
+    cordaRuntime "$corda_release_group:corda:$corda_release_version"
+
+    // CorDapp dependencies.
+    cordapp project(":workflows")
+
+    cordaCompile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"
+    cordaCompile "org.apache.logging.log4j:log4j-web:${log4j_version}"
+    cordaCompile "org.slf4j:jul-to-slf4j:$slf4j_version"
+}
+
+task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
+    nodeDefaults {
+        projectCordapp {
+            deploy = false
+        }
+        cordapp project(':workflows')
+        rpcUsers = [[ user: "user1", "password": "password", "permissions": ["ALL"]]]
+        runSchemaMigration = true
+    }
+    node {
+        name "O=Notary,L=London,C=GB"
+        notary = [validating: false]
+        p2pPort 10002
+        rpcSettings {
+            useSsl false
+            standAloneBroker false
+            address "0.0.0.0:10003"
+            adminAddress "0.0.0.0:10103"
+        }
+    }
+    node {
+        name "O=ParticipantA,L=London,C=GB"
+        p2pPort 10007
+        rpcSettings {
+            useSsl false
+            standAloneBroker false
+            address "0.0.0.0:10008"
+            adminAddress "0.0.0.0:10108"
+        }
+    }
+    node {
+        name "O=ParticipantB,L=New York,C=US"
+        p2pPort 10010
+        rpcSettings {
+            useSsl false
+            standAloneBroker false
+            address "0.0.0.0:10011"
+            adminAddress "0.0.0.0:10111"
+        }
+    }
+    node {
+        name "O=ParticipantC,L=Paris,C=FR"
+        p2pPort 10013
+        rpcSettings {
+            useSsl false
+            standAloneBroker false
+            address "0.0.0.0:10014"
+            adminAddress "0.0.0.0:10114"
+        }
+    }
+}

--- a/tools/docker/corda-all-in-one/corda-v4_8-flowdb/healthcheck.sh
+++ b/tools/docker/corda-all-in-one/corda-v4_8-flowdb/healthcheck.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+if [ "$PARTY_A_WEB_SRV_ENABLED" = "true" ]
+then
+  curl -vv -i -X OPTIONS http://127.0.0.1:10009/web/iou/
+fi
+
+if [ "$PARTY_B_WEB_SRV_ENABLED" = "true" ]
+then
+  curl -vv -i -X OPTIONS http://127.0.0.1:10012/web/iou/
+fi
+
+if [ "$PARTY_C_WEB_SRV_ENABLED" = "true" ]
+then
+  curl -vv -i -X OPTIONS http://127.0.0.1:10015/web/iou/
+fi
+
+
+if [ "$PARTY_A_NODE_ENABLED" = "true" ]
+then
+  curl -v 'http://localhost:7005/jolokia/exec/org.apache.activemq.artemis:address=%22rpc.server%22,broker=%22RPC%22,component=addresses,queue=%22rpc.server%22,routing-type=%22multicast%22,subcomponent=queues/countMessages()/'
+fi
+
+if [ "$PARTY_B_NODE_ENABLED" = "true" ]
+then
+  curl -v 'http://localhost:7006/jolokia/exec/org.apache.activemq.artemis:address=%22rpc.server%22,broker=%22RPC%22,component=addresses,queue=%22rpc.server%22,routing-type=%22multicast%22,subcomponent=queues/countMessages()/'
+fi
+
+if [ "$PARTY_C_NODE_ENABLED" = "true" ]
+then
+  curl -v 'http://localhost:7007/jolokia/exec/org.apache.activemq.artemis:address=%22rpc.server%22,broker=%22RPC%22,component=addresses,queue=%22rpc.server%22,routing-type=%22multicast%22,subcomponent=queues/countMessages()/'
+fi

--- a/tools/docker/corda-all-in-one/corda-v4_8-flowdb/run-notary-node.sh
+++ b/tools/docker/corda-all-in-one/corda-v4_8-flowdb/run-notary-node.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+if [ "$NOTARY_NODE_ENABLED" = "true" ]
+then
+  java \
+    -Dcapsule.jvm.args="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5008 -javaagent:drivers/jolokia-jvm-1.6.0-agent.jar=port=7008,logHandlerClass=net.corda.node.JolokiaSlf4jAdapter" \
+    -Dname=Notary \
+    -jar \
+    /samples-kotlin/Basic/flow-database-access/build/nodes/Notary/corda.jar
+else
+  sleep infinity
+fi

--- a/tools/docker/corda-all-in-one/corda-v4_8-flowdb/run-party-a-node.sh
+++ b/tools/docker/corda-all-in-one/corda-v4_8-flowdb/run-party-a-node.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+if [ "$PARTY_A_NODE_ENABLED" = "true" ]
+then
+  java -Dcapsule.jvm.args="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005 -javaagent:drivers/jolokia-jvm-1.6.0-agent.jar=port=7005,logHandlerClass=net.corda.node.JolokiaSlf4jAdapter" -Dname=ParticipantA -jar /samples-kotlin/Basic/flow-database-access/build/nodes/ParticipantA/corda.jar
+else
+  sleep infinity
+fi

--- a/tools/docker/corda-all-in-one/corda-v4_8-flowdb/run-party-a-server.sh
+++ b/tools/docker/corda-all-in-one/corda-v4_8-flowdb/run-party-a-server.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+if [ "$PARTY_A_WEB_SRV_ENABLED" = "true" ]
+then
+  ./gradlew runPartyAServer
+else
+  sleep infinity
+fi

--- a/tools/docker/corda-all-in-one/corda-v4_8-flowdb/run-party-b-node.sh
+++ b/tools/docker/corda-all-in-one/corda-v4_8-flowdb/run-party-b-node.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+if [ "$PARTY_B_NODE_ENABLED" = "true" ]
+then
+  java -Dcapsule.jvm.args="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5006 -javaagent:drivers/jolokia-jvm-1.6.0-agent.jar=port=7006,logHandlerClass=net.corda.node.JolokiaSlf4jAdapter" -Dname=ParticipantB -jar /samples-kotlin/Basic/flow-database-access/build/nodes/ParticipantB/corda.jar
+else
+  sleep infinity
+fi

--- a/tools/docker/corda-all-in-one/corda-v4_8-flowdb/run-party-b-server.sh
+++ b/tools/docker/corda-all-in-one/corda-v4_8-flowdb/run-party-b-server.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+if [ "$PARTY_B_WEB_SRV_ENABLED" = "true" ]
+then
+  ./gradlew runPartyBServer
+else
+  sleep infinity
+fi

--- a/tools/docker/corda-all-in-one/corda-v4_8-flowdb/run-party-c-node.sh
+++ b/tools/docker/corda-all-in-one/corda-v4_8-flowdb/run-party-c-node.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+if [ "$PARTY_C_NODE_ENABLED" = "true" ]
+then
+  java \
+  -Dcapsule.jvm.args="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5007 -javaagent:drivers/jolokia-jvm-1.6.0-agent.jar=port=7007,logHandlerClass=net.corda.node.JolokiaSlf4jAdapter" \
+  -Dname=ParticipantC \
+  -jar \
+  /samples-kotlin/Basic/flow-database-access/build/nodes/ParticipantC/corda.jar
+else
+  sleep infinity
+fi

--- a/tools/docker/corda-all-in-one/corda-v4_8-flowdb/run-party-c-server.sh
+++ b/tools/docker/corda-all-in-one/corda-v4_8-flowdb/run-party-c-server.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+if [ "$PARTY_C_WEB_SRV_ENABLED" = "true" ]
+then
+  ./gradlew runPartyCServer
+else
+  sleep infinity
+fi

--- a/tools/docker/corda-all-in-one/corda-v4_8-flowdb/supervisord.conf
+++ b/tools/docker/corda-all-in-one/corda-v4_8-flowdb/supervisord.conf
@@ -1,0 +1,108 @@
+[supervisord]
+logfile = /var/log/supervisord.log
+logfile_maxbytes = 50MB
+logfile_backups=10
+loglevel = info
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=http://127.0.0.1:9001
+
+[inet_http_server]
+port = 0.0.0.0:9001
+
+[program:sshd]
+command=/usr/sbin/sshd -D -ddd
+autostart=true
+autorestart=true
+stdout_logfile=/var/log/sshd.out.log
+stderr_logfile=/var/log/sshd.err.log
+# stdout_logfile=/dev/stdout
+# stdout_logfile_maxbytes=0
+# stderr_logfile=/dev/stderr
+# stderr_logfile_maxbytes=0
+
+[program:dockerd]
+command=dockerd-entrypoint.sh
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:corda-a]
+directory=/samples-kotlin/Basic/flow-database-access/build/nodes/ParticipantA/
+command=/run-party-a-node.sh
+autostart=true
+autorestart=false
+exitcodes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:corda-b]
+directory=/samples-kotlin/Basic/flow-database-access/build/nodes/ParticipantB
+command=/run-party-b-node.sh
+autostart=true
+autorestart=false
+exitcodes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:corda-c]
+directory=/samples-kotlin/Basic/flow-database-access/build/nodes/ParticipantC
+command=/run-party-c-node.sh
+autostart=true
+autorestart=false
+exitcodes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:corda-n]
+directory=/samples-kotlin/Basic/flow-database-access/build/nodes/Notary
+command=/run-notary-node.sh
+autostart=true
+autorestart=false
+exitcodes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:corda-run-party-a-server]
+directory=/samples-kotlin/Basic/flow-database-access/
+command=/run-party-a-server.sh
+autostart=true
+autorestart=unexpected
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:corda-run-party-b-server]
+directory=/samples-kotlin/Basic/flow-database-access/
+command=/run-party-b-server.sh
+autostart=true
+autorestart=unexpected
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:corda-run-party-c-server]
+directory=/samples-kotlin/Basic/flow-database-access/
+command=/run-party-c-server.sh
+autostart=true
+autorestart=unexpected
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
Added new corda-all-in-one image for flow-database-access sample

Modified Corda main-server image to allow calls to invoke without
executing any transaction.

Modified Corda InvokeContractV1Response to add the new flowId
field to return the flow handle id instead of use the callOutput
field, which now is used for the data returned by the flow. The
transactionId is not required because we can call invoke without
executing any transaction.

Resolves #1493

Signed-off-by: Elena Izaguirre <e.izaguirre.equiza@accenture.com>