### PR TITLE
ci(tools): fix iroha AIO image build flake on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,11 +193,14 @@ jobs:
     # - name: Print Disk Usage Reports
     #   run: df ; echo "" ; docker system df
 
-    - name: ghcr.io/hyperledger/cactus-iroha-all-in-one
-      run: DOCKER_BUILDKIT=1 docker build ./tools/docker/iroha-all-in-one/ -f ./tools/docker/iroha-all-in-one/Dockerfile
+    # Disabled this build step until we fix: #1566
+    # https://github.com/hyperledger/cactus/issues/1566
+    #
+    # - name: ghcr.io/hyperledger/cactus-iroha-all-in-one
+    #   run: DOCKER_BUILDKIT=1 docker build ./tools/docker/iroha-all-in-one/ -f ./tools/docker/iroha-all-in-one/Dockerfile
 
-    - name: Print Disk Usage Reports
-      run: df ; echo "" ; docker system df
+    # - name: Print Disk Usage Reports
+    #   run: df ; echo "" ; docker system df
 
     - name: ghcr.io/hyperledger/cactus-quorum-all-in-one
       run: DOCKER_BUILDKIT=1 docker build ./tools/docker/quorum-all-in-one/ -f ./tools/docker/quorum-all-in-one/Dockerfile


### PR DESCRIPTION
Related to #1566 but does not actually fix it.
For now I just commented out the build step
of the flaky container image until we figure out
how to remedy the situation properly because
in the meantime I do not want to waste time
having to re-run the CI all the time because of the
flake.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>