### PR TITLE
test: jestify model-type-guards test

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -42,7 +42,6 @@ files:
   - ./packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-invoke-contract.test.ts
   - ./packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/openapi/openapi-validation.test.ts
   - ./packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-invoke-contract-json-object.test.ts
-  - ./packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/unit/model-type-guards.test.ts
   - ./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/new-contract-endpoint.test.ts
   - ./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/get-status-endpoint.test.ts
   - ./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/initialize-endpoint.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -47,7 +47,6 @@ module.exports = {
     `./packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-invoke-contract.test.ts`,
     `./packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/openapi/openapi-validation.test.ts`,
     `./packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-invoke-contract-json-object.test.ts`,
-    `./packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/unit/model-type-guards.test.ts`,
     `./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/new-contract-endpoint.test.ts`,
     `./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/get-status-endpoint.test.ts`,
     `./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/initialize-endpoint.test.ts`,

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/unit/model-type-guards.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/unit/model-type-guards.test.ts
@@ -1,4 +1,4 @@
-import test, { Test } from "tape";
+import "jest-extended";
 import {
   isWeb3SigningCredentialGethKeychainPassword,
   isWeb3SigningCredentialNone,
@@ -11,58 +11,35 @@ import {
   Web3SigningCredentialNone,
 } from "../../../main/typescript/public-api";
 
-test("Type guards for OpenAPI spec model type definitions", (t1: Test) => {
-  test("isWeb3SigningCredentialGethKeychainPassword()", (t2: Test) => {
+describe("Type guards for OpenAPI spec model type definitions", () => {
+  test("isWeb3SigningCredentialGethKeychainPassword()", () => {
     const valid: Web3SigningCredentialGethKeychainPassword = {
       secret: "yes",
       ethAccount: "fake-account",
       type: Web3SigningCredentialType.GethKeychainPassword,
     };
 
-    t2.true(
-      isWeb3SigningCredentialGethKeychainPassword(valid),
-      "Valid Web3SigningCredentialGethKeychainPassword recognized",
-    );
-    t2.false(
-      isWeb3SigningCredentialGethKeychainPassword({}),
-      "Invalid Web3SigningCredentialGethKeychainPassword not recognized",
-    );
-    t2.end();
+    expect(isWeb3SigningCredentialGethKeychainPassword(valid)).toBe(true);
+    expect(isWeb3SigningCredentialGethKeychainPassword({})).not.toBe(true);
   });
 
-  test("isWeb3SigningCredentialPrivateKeyHex()", (t2: Test) => {
+  test("isWeb3SigningCredentialPrivateKeyHex()", () => {
     const valid: Web3SigningCredentialPrivateKeyHex = {
       secret: "yes",
       ethAccount: "fake-account",
       type: Web3SigningCredentialType.PrivateKeyHex,
     };
 
-    t2.true(
-      isWeb3SigningCredentialPrivateKeyHex(valid),
-      "Valid Web3SigningCredentialPrivateKeyHex recognized",
-    );
-    t2.false(
-      isWeb3SigningCredentialPrivateKeyHex({}),
-      "Invalid Web3SigningCredentialPrivateKeyHex not recognized",
-    );
-    t2.end();
+    expect(isWeb3SigningCredentialPrivateKeyHex(valid)).toBe(true);
+    expect(isWeb3SigningCredentialPrivateKeyHex({})).not.toBe(true);
   });
 
-  test("isWeb3SigningCredentialNone()", (t2: Test) => {
+  test("isWeb3SigningCredentialNone()", () => {
     const valid: Web3SigningCredentialNone = {
       type: Web3SigningCredentialType.None,
     };
 
-    t2.true(
-      isWeb3SigningCredentialNone(valid),
-      "Valid Web3SigningCredentialNone recognized",
-    );
-    t2.false(
-      isWeb3SigningCredentialNone({}),
-      "Invalid Web3SigningCredentialNone not recognized",
-    );
-    t2.end();
+    expect(isWeb3SigningCredentialNone(valid)).toBe(true);
+    expect(isWeb3SigningCredentialNone({})).not.toBe(true);
   });
-
-  t1.end();
 });


### PR DESCRIPTION
Migrated test from Tap to Jest.

File Path:
packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/unit/model-type-guards.test.ts

This is a PARTIAL resolution to issue #238

Signed-off-by: awadhana <awadhana0825@gmail.com>