### PR TITLE
test: jestify rustc-container-target-nodejs

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -136,7 +136,6 @@ files:
   - ./packages/cactus-test-tooling/src/test/typescript/integration/iroha/iroha-test-ledger/constructor-validates-options.test.ts
   - ./packages/cactus-test-tooling/src/test/typescript/integration/corda/corda-test-ledger/corda-test-ledger-constructor.test.ts
   - ./packages/cactus-test-tooling/src/test/typescript/integration/rustc-container/rustc-container-target-bundler.test.ts
-  - ./packages/cactus-test-tooling/src/test/typescript/integration/rustc-container/rustc-container-target-nodejs.test.ts
   - ./packages/cactus-test-tooling/src/test/typescript/integration/common/containers.test.ts
   - ./packages/cactus-test-tooling/src/test/typescript/integration/besu/besu-test-ledger/constructor-validates-options.test.ts
   - ./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-status-endpoint-invalid.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -142,7 +142,6 @@ module.exports = {
     `./packages/cactus-test-tooling/src/test/typescript/integration/iroha/iroha-test-ledger/constructor-validates-options.test.ts`,
     `./packages/cactus-test-tooling/src/test/typescript/integration/corda/corda-test-ledger/corda-test-ledger-constructor.test.ts`,
     `./packages/cactus-test-tooling/src/test/typescript/integration/rustc-container/rustc-container-target-bundler.test.ts`,
-    `./packages/cactus-test-tooling/src/test/typescript/integration/rustc-container/rustc-container-target-nodejs.test.ts`,
     `./packages/cactus-test-tooling/src/test/typescript/integration/common/containers.test.ts`,
     `./packages/cactus-test-tooling/src/test/typescript/integration/besu/besu-test-ledger/constructor-validates-options.test.ts`,
     `./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-status-endpoint-invalid.test.ts`,

--- a/packages/cactus-test-tooling/src/test/typescript/integration/rustc-container/rustc-container-target-nodejs.test.ts
+++ b/packages/cactus-test-tooling/src/test/typescript/integration/rustc-container/rustc-container-target-nodejs.test.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import test, { Test } from "tape-promise/tape";
+import "jest-extended";
 import temp from "temp";
 import fs from "fs-extra";
 import { LogLevelDesc } from "@hyperledger/cactus-common";
@@ -8,117 +8,129 @@ import {
   RustcBuildCmd,
   RustcContainer,
 } from "../../../../main/typescript/public-api";
+const testCase = "compiles Rust code to NodeJS targeted .wasm";
+describe(testCase, () => {
+  type HelloWorldExports = {
+    hello_world: () => string;
+    say_hello: (name: string) => string;
+  };
 
-const logLevel: LogLevelDesc = "TRACE";
+  const logLevel: LogLevelDesc = "TRACE";
 
-type HelloWorldExports = {
-  hello_world: () => string;
-  say_hello: (name: string) => string;
-};
+  let rustcContainer: RustcContainer;
 
-test("compiles Rust code to NodeJS targeted .wasm", async (t: Test) => {
-  const tmpDirAffix = "cactus-test-tooling-rustc-container-test";
-  temp.track();
-  test.onFinish(async () => await temp.cleanup());
-  const hostSourceDir = await temp.mkdir(tmpDirAffix);
-
-  const srcDir = path.join(hostSourceDir, "./src/");
-  await fs.mkdir(srcDir);
-
-  const rustcContainer = new RustcContainer({ logLevel });
-  t.ok(rustcContainer, "RustcContainer instance truthy OK");
-
-  test.onFinish(async () => {
-    await rustcContainer.stop();
+  beforeAll(async () => {
+    rustcContainer = new RustcContainer({ logLevel });
   });
 
-  const dockerodeContainer = await rustcContainer.start();
-  t.ok(dockerodeContainer, "dockerodeContainer truthy OK");
+  afterAll(async () => await rustcContainer.stop());
+  afterAll(async () => await temp.cleanup());
 
-  const containerPkDir = path.join(rustcContainer.cwd, "./pkg/");
+  test(testCase, async () => {
+    const tmpDirAffix = "cactus-test-tooling-rustc-container-test";
+    temp.track();
+    const hostSourceDir = await temp.mkdir(tmpDirAffix);
 
-  const cargoTomlHostDir = path.join(
-    __dirname,
-    "../../../rust/fixtures/wasm-hello-world/",
-  );
-  const putCargoTomlRes = await Containers.putFile({
-    containerOrId: dockerodeContainer,
-    dstFileDir: rustcContainer.cwd,
-    dstFileName: "Cargo.toml",
-    srcFileDir: cargoTomlHostDir,
-    srcFileName: "Cargo.toml",
-  });
-  t.ok(putCargoTomlRes, "putCargoTomlRes truthy OK");
-  t.ok(putCargoTomlRes.statusCode, "putCargoTomlRes.statusCode truthy OK");
-  t.equal(putCargoTomlRes.statusCode, 200, "putCargoTomlRes.statusCode 200 OK");
+    const srcDir = path.join(hostSourceDir, "./src/");
+    await fs.mkdir(srcDir);
 
-  const containerSrcDir = path.join(rustcContainer.cwd, "./src/");
-  await Containers.exec(dockerodeContainer, ["mkdir", containerSrcDir]);
+    expect(rustcContainer).toBeTruthy();
 
-  const libRsHostDir = path.join(
-    __dirname,
-    "../../../rust/fixtures/wasm-hello-world/src/",
-  );
-  const putLibRsRes = await Containers.putFile({
-    containerOrId: dockerodeContainer,
-    dstFileDir: containerSrcDir,
-    dstFileName: "lib.rs",
-    srcFileDir: libRsHostDir,
-    srcFileName: "lib.rs",
-  });
-  t.ok(putLibRsRes, "putLibRsRes truthy OK");
-  t.ok(putLibRsRes.statusCode, "putLibRsRes.statusCode truthy OK");
-  t.equal(putLibRsRes.statusCode, 200, "putLibRsRes.statusCode 200 OK");
+    const dockerodeContainer = await rustcContainer.start();
+    expect(dockerodeContainer).toBeTruthy();
 
-  const wasmPackBuildOut = await Containers.exec(
-    dockerodeContainer,
-    RustcBuildCmd.WASM_PACK_BUILD_NODEJS,
-  );
-  t.ok(wasmPackBuildOut, "wasmPackBuildOut truthy OK");
+    const containerPkDir = path.join(rustcContainer.cwd, "./pkg/");
 
-  // The list of files the wasm-pack NodeJS target produces
-  const expectedFiles = [
-    ".gitignore",
-    "hello_world.d.ts",
-    "hello_world.js",
-    "hello_world_bg.wasm",
-    "hello_world_bg.wasm.d.ts",
-    "package.json",
-  ];
-
-  const filesOnFs = await Containers.ls(dockerodeContainer, containerPkDir);
-  t.ok(filesOnFs, "filesOnFs truthy OK");
-  t.true(Array.isArray(filesOnFs), "Array.isArray(filesOnFs) OK");
-  t.comment(`filesOnFs: ${JSON.stringify(filesOnFs)}`);
-  t.deepEqual(filesOnFs, expectedFiles, "deepEqual filesOnFs, fileNames OK");
-
-  const fileChecks = filesOnFs.map(async (fileName) => {
-    const containerFilePath = path.join(containerPkDir, fileName);
-    const hostFilePath = path.join(hostSourceDir, fileName);
-    const contentsBuffer = await Containers.pullBinaryFile(
-      dockerodeContainer,
-      containerFilePath,
+    const cargoTomlHostDir = path.join(
+      __dirname,
+      "../../../rust/fixtures/wasm-hello-world/",
     );
-    t.ok(contentsBuffer, `contents buffer truthy OK: ${containerFilePath}`);
-    t.true(contentsBuffer.length > 0, `size > 0 OK: ${containerFilePath}`);
-    await fs.writeFile(hostFilePath, contentsBuffer);
-    const { isFile, size } = await fs.stat(hostFilePath);
-    t.true(isFile, `isFile===true OK: ${hostFilePath}`);
-    t.true(size > 0, `size > 0 OK: ${hostFilePath}`);
+    const putCargoTomlRes = await Containers.putFile({
+      containerOrId: dockerodeContainer,
+      dstFileDir: rustcContainer.cwd,
+      dstFileName: "Cargo.toml",
+      srcFileDir: cargoTomlHostDir,
+      srcFileName: "Cargo.toml",
+    });
+    expect(putCargoTomlRes);
+    expect(putCargoTomlRes.statusCode);
+    expect(putCargoTomlRes.statusCode).toEqual(200);
+
+    const containerSrcDir = path.join(rustcContainer.cwd, "./src/");
+    await Containers.exec(dockerodeContainer, ["mkdir", containerSrcDir]);
+
+    const libRsHostDir = path.join(
+      __dirname,
+      "../../../rust/fixtures/wasm-hello-world/src/",
+    );
+    const putLibRsRes = await Containers.putFile({
+      containerOrId: dockerodeContainer,
+      dstFileDir: containerSrcDir,
+      dstFileName: "lib.rs",
+      srcFileDir: libRsHostDir,
+      srcFileName: "lib.rs",
+    });
+    expect(putLibRsRes).toBeTruthy();
+    expect(putLibRsRes.statusCode).toBeTruthy();
+    expect(putLibRsRes.statusCode).toEqual(200);
+
+    const wasmPackBuildOut = await Containers.exec(
+      dockerodeContainer,
+      RustcBuildCmd.WASM_PACK_BUILD_NODEJS,
+    );
+    expect(wasmPackBuildOut).toBeTruthy();
+
+    // The list of files the wasm-pack NodeJS target produces
+    const expectedFiles = [
+      ".gitignore",
+      "hello_world.d.ts",
+      "hello_world.js",
+      "hello_world_bg.wasm",
+      "hello_world_bg.wasm.d.ts",
+      "package.json",
+    ];
+
+    const filesOnFs = await Containers.ls(dockerodeContainer, containerPkDir);
+    expect(filesOnFs).toBeTruthy();
+    expect(Array.isArray(filesOnFs)).toBe(true);
+    expect(filesOnFs).toEqual(expectedFiles);
+
+    const fileChecks = filesOnFs.map(async (fileName) => {
+      const containerFilePath = path.join(containerPkDir, fileName);
+      const hostFilePath = path.join(hostSourceDir, fileName);
+      const contentsBuffer = await Containers.pullBinaryFile(
+        dockerodeContainer,
+        containerFilePath,
+      );
+      await fs.writeFile(hostFilePath, contentsBuffer);
+      const { size } = await fs.stat(hostFilePath);
+      return { contentsBuffer, size };
+    });
+
+    const fileChecksPromise = Promise.all(fileChecks);
+    expect(fileChecksPromise).toBeTruthy();
+    expect(fileChecksPromise).toResolve();
+
+    const fileChecksResults = await fileChecksPromise;
+    expect(fileChecksResults).toBeTruthy();
+    expect(fileChecksResults).toBeArrayOfSize(filesOnFs.length);
+
+    fileChecksResults.forEach(({ contentsBuffer, size }) => {
+      expect(contentsBuffer).toBeTruthy();
+      expect(contentsBuffer.length > 0).toBe(true);
+      // expect(isFile).toBe(true);
+      expect(size).toBeGreaterThan(0);
+    });
+
+    const wasmHostPath = path.join(hostSourceDir, "./hello_world.js");
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const wasmModule = require(wasmHostPath) as HelloWorldExports;
+    const helloWorldOut = wasmModule.hello_world();
+    expect(helloWorldOut).toBeTruthy();
+    expect(helloWorldOut).toEqual("Hello World!");
+
+    const greeting = wasmModule.say_hello("Peter");
+    expect(greeting).toBeTruthy();
+    expect(greeting).toEqual("Hello Peter!");
   });
-
-  await t.doesNotReject(Promise.all(fileChecks), "All WASM build files OK");
-
-  const wasmHostPath = path.join(hostSourceDir, "./hello_world.js");
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const wasmModule = require(wasmHostPath) as HelloWorldExports;
-  const helloWorldOut = wasmModule.hello_world();
-  t.ok(helloWorldOut, "helloWorldOut truthy OK");
-  t.equal(helloWorldOut, "Hello World!", "helloWorldOut EQ Hello World! OK");
-
-  const greeting = wasmModule.say_hello("Peter");
-  t.ok(greeting, "greeting truthy OK");
-  t.equal(greeting, "Hello Peter!", "greeting EQ Hello Peter! OK");
-
-  t.end();
 });


### PR DESCRIPTION
Migrated test from Tap to Jest.

File Path:
packages/cactus-test-tooling/src/test/typescript/integration/rustc-container/
rustc-container-target-nodejs.test.ts

This is a PARTIAL resolution to issue #238

Signed-off-by: awadhana <awadhana0825@gmail.com>