### PR TITLE
test: jestify runtime-plugin-import test

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -41,7 +41,6 @@ files:
   - ./packages/cactus-test-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
   - ./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install.test.ts
   - ./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install-version-selection.test.ts
-  - ./packages/cactus-test-cmd-api-server/src/test/typescript/integration/runtime-plugin-imports.test.ts
   - ./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/openapi/openapi-validation.test.ts
   - ./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes-v4.7.test.ts
   - ./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server-v4.7.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -46,7 +46,6 @@ module.exports = {
     `./packages/cactus-test-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts`,
     `./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install.test.ts`,
     `./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install-version-selection.test.ts`,
-    `./packages/cactus-test-cmd-api-server/src/test/typescript/integration/runtime-plugin-imports.test.ts`,
     `./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/openapi/openapi-validation.test.ts`,
     `./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes-v4.7.test.ts`,
     `./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server-v4.7.test.ts`,

--- a/packages/cactus-test-cmd-api-server/src/test/typescript/integration/runtime-plugin-imports.test.ts
+++ b/packages/cactus-test-cmd-api-server/src/test/typescript/integration/runtime-plugin-imports.test.ts
@@ -1,9 +1,7 @@
 import path from "path";
-import test, { Test } from "tape-promise/tape";
 import { v4 as uuidv4 } from "uuid";
-
+import "jest-extended";
 import { LogLevelDesc } from "@hyperledger/cactus-common";
-
 import {
   ApiServer,
   AuthorizationProtocol,
@@ -15,47 +13,59 @@ import {
 } from "@hyperledger/cactus-core-api";
 
 const logLevel: LogLevelDesc = "TRACE";
-
-test("can import plugins at runtime (CLI)", async (t: Test) => {
-  const pluginsPath = path.join(
-    __dirname, // start at the current file's path
-    "../../../../../../", // walk back up to the project root
-    ".tmp/test/cmd-api-server/runtime-plugin-imports_test", // the dir path from the root
-    uuidv4(), // then a random directory to ensure proper isolation
-  );
-  const pluginManagerOptionsJson = JSON.stringify({ pluginsPath });
-
-  const configService = new ConfigService();
-  const apiServerOptions = await configService.newExampleConfig();
-  apiServerOptions.authorizationProtocol = AuthorizationProtocol.NONE;
-  apiServerOptions.pluginManagerOptionsJson = pluginManagerOptionsJson;
-  apiServerOptions.configFile = "";
-  apiServerOptions.apiCorsDomainCsv = "*";
-  apiServerOptions.apiPort = 0;
-  apiServerOptions.cockpitPort = 0;
-  apiServerOptions.grpcPort = 0;
-  apiServerOptions.apiTlsEnabled = false;
-  apiServerOptions.plugins = [
-    {
-      packageName: "@hyperledger/cactus-plugin-keychain-memory",
-      type: PluginImportType.Local,
-      action: PluginImportAction.Install,
-      options: {
-        instanceId: uuidv4(),
-        keychainId: uuidv4(),
-        logLevel,
+const testCase = "can import plugins at runtime (CLI)";
+describe(testCase, () => {
+  let apiServer: ApiServer;
+  test(testCase, async () => {
+    const pluginsPath = path.join(
+      __dirname, // start at the current file's path
+      "../../../../../../", // walk back up to the project root
+      ".tmp/test/cmd-api-server/runtime-plugin-imports_test", // the dir path from the root
+      uuidv4(), // then a random directory to ensure proper isolation
+    );
+    const pluginManagerOptionsJson = JSON.stringify({ pluginsPath });
+    const configService = new ConfigService();
+    const apiServerOptions = await configService.newExampleConfig();
+    apiServerOptions.authorizationProtocol = AuthorizationProtocol.NONE;
+    apiServerOptions.pluginManagerOptionsJson = pluginManagerOptionsJson;
+    apiServerOptions.configFile = "";
+    apiServerOptions.apiCorsDomainCsv = "*";
+    apiServerOptions.apiPort = 0;
+    apiServerOptions.cockpitPort = 0;
+    apiServerOptions.grpcPort = 0;
+    apiServerOptions.apiTlsEnabled = false;
+    apiServerOptions.plugins = [
+      {
+        packageName: "@hyperledger/cactus-plugin-keychain-memory",
+        type: PluginImportType.Local,
+        action: PluginImportAction.Install,
+        options: {
+          instanceId: uuidv4(),
+          keychainId: uuidv4(),
+          logLevel,
+        },
       },
-    },
-  ];
-  const config = await configService.newExampleConfigConvict(apiServerOptions);
+    ];
+    const config = await configService.newExampleConfigConvict(
+      apiServerOptions,
+    );
 
-  const apiServer = new ApiServer({
-    config: config.getProperties(),
+    apiServer = new ApiServer({
+      config: config.getProperties(),
+    });
+    apiServerOptions.plugins = [
+      {
+        packageName: "@hyperledger/cactus-plugin-keychain-memory",
+        type: PluginImportType.Local,
+        action: PluginImportAction.Install,
+        options: {
+          instanceId: uuidv4(),
+          keychainId: uuidv4(),
+          logLevel,
+        },
+      },
+    ];
+    await expect(apiServer.start()).not.toReject();
   });
-
-  await t.doesNotReject(
-    apiServer.start(),
-    "failed to start API server with dynamic plugin imports configured for it...",
-  );
-  test.onFinish(() => apiServer.shutdown());
+  afterAll(async () => await apiServer.shutdown());
 });


### PR DESCRIPTION
Migrated test from Tap to Jest.

File Path:
packages/cactus-test-cmd-api-server/src/test/typescript/integration/runtime-plugin-imports.test.ts

This is a PARTIAL resolution to issue #238

Signed-off-by: awadhana <awadhana0825@gmail.com>