### PR TITLE
test: jestify transfer-complete test

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -6,7 +6,6 @@ timeout: 900
 ts: true
 files:
   - ./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/openapi/openapi-validation.test.ts
-  - ./packages/cactus-plugin-odap-hermes/src/test/typescript/integration/odap/transfer-complete.test.ts
   - ./packages/cactus-plugin-odap-hermes/src/test/typescript/integration/odap/odap-api-call.test.ts
   - ./packages/cactus-plugin-odap-hermes/src/test/typescript/integration/odap/odap-api-call-with-ledger-connector.test.ts
   - ./packages/cactus-plugin-odap-hermes/src/test/typescript/integration/odap/lock-evidence.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,6 @@ module.exports = {
   // Ignore the tests that are still using tap/tape for as their test runner
   testPathIgnorePatterns: [
     `./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/openapi/openapi-validation.test.ts`,
-    `./packages/cactus-plugin-odap-hermes/src/test/typescript/integration/odap/transfer-complete.test.ts`,
     `./packages/cactus-plugin-odap-hermes/src/test/typescript/integration/odap/odap-api-call.test.ts`,
     `./packages/cactus-plugin-odap-hermes/src/test/typescript/integration/odap/odap-api-call-with-ledger-connector.test.ts`,
     `./packages/cactus-plugin-odap-hermes/src/test/typescript/integration/odap/lock-evidence.test.ts`,

--- a/packages/cactus-plugin-odap-hermes/src/test/typescript/integration/odap/transfer-complete.test.ts
+++ b/packages/cactus-plugin-odap-hermes/src/test/typescript/integration/odap/transfer-complete.test.ts
@@ -1,4 +1,5 @@
-import test, { Test } from "tape";
+import "jest-extended";
+
 import { randomBytes } from "crypto";
 import secp256k1 from "secp256k1";
 import { OdapGateway } from "../../../../main/typescript/gateway/odap-gateway";
@@ -6,7 +7,7 @@ import { TransferCompleteV1Request } from "../../../../main/typescript/generated
 import { v4 as uuidV4 } from "uuid";
 import { SHA256 } from "crypto-js";
 
-test("dummy test for transfer complete flow", async (t: Test) => {
+test("dummy test for transfer complete flow", async () => {
   const odapConstructor = {
     name: "cactus-plugin#odapGateway",
     dltIDs: ["dummy"],
@@ -44,8 +45,7 @@ test("dummy test for transfer complete flow", async (t: Test) => {
     JSON.stringify(transferCompleteReq),
     dummyPrivKeyStr,
   );
-  t.doesNotThrow(
+  await expect(
     async () => await odapGateWay.TransferComplete(transferCompleteReq),
-    "does not throw if lock evidence proccessed",
-  );
+  ).not.toThrow();
 });


### PR DESCRIPTION
Migrated test from Tap to Jest.

File Path:
packages/cactus-plugin-odap-hermes/src/test/typescript/
integration/odap/transfer-complete.test.ts

This is a PARTIAL resolution to issue #238

Signed-off-by: awadhana awadhana0825@gmail.com