### PR TITLE
fix(cmd-api-server): disable validateKeyPairMatch

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/config/config-service.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/config/config-service.ts
@@ -646,7 +646,9 @@ export class ConfigService {
       ConfigService.config.loadFile(configFilePath);
     }
     ConfigService.config.validate();
-    this.validateKeyPairMatch();
+    // this validation fails with supply-chain default configuration
+    // and it will be removed
+    // this.validateKeyPairMatch();
     const level = ConfigService.config.get("logLevel");
     const logger: Logger = LoggerProvider.getOrCreate({
       label: "config-service",


### PR DESCRIPTION
Disable validateKeyPairMatch call from config-service create method
because it fails with supply-chain default configuration and is going to
be removed when cleaning parameters

Signed-off-by: Elena Izaguirre <e.izaguirre.equiza@accenture.com>