### PR TITLE
test: jestify get-all-field-names test

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -93,7 +93,6 @@ files:
   - ./packages/cactus-common/src/test/typescript/unit/key-converter.test.ts
   - ./packages/cactus-common/src/test/typescript/unit/logging/logger.test.ts
   - ./packages/cactus-common/src/test/typescript/unit/js-object-signer.test.ts
-  - ./packages/cactus-common/src/test/typescript/unit/objects/get-all-field-names.test.ts
   - ./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/plugin-keychain-aws-sm.test.ts
   - ./packages/cactus-test-api-client/src/test/typescript/integration/api-client-routing-node-to-node.test.ts
   - ./packages/cactus-plugin-keychain-memory/src/test/typescript/unit/plugin-keychain-memory.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -99,7 +99,6 @@ module.exports = {
     `./packages/cactus-common/src/test/typescript/unit/key-converter.test.ts`,
     `./packages/cactus-common/src/test/typescript/unit/logging/logger.test.ts`,
     `./packages/cactus-common/src/test/typescript/unit/js-object-signer.test.ts`,
-    `./packages/cactus-common/src/test/typescript/unit/objects/get-all-field-names.test.ts`,
     `./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/plugin-keychain-aws-sm.test.ts`,
     `./packages/cactus-test-api-client/src/test/typescript/integration/api-client-routing-node-to-node.test.ts`,
     `./packages/cactus-plugin-keychain-memory/src/test/typescript/unit/plugin-keychain-memory.test.ts`,

--- a/packages/cactus-common/src/test/typescript/unit/objects/get-all-field-names.test.ts
+++ b/packages/cactus-common/src/test/typescript/unit/objects/get-all-field-names.test.ts
@@ -1,7 +1,7 @@
-import test, { Test } from "tape";
 import { Objects } from "../../../../main/typescript/public-api";
+import "jest-extended";
 
-test("tests for get the properties of object", async (assert: Test) => {
+test("tests for get the properties of object", async () => {
   const student = {
     name: "Jack",
     last_name: "Santos",
@@ -21,16 +21,9 @@ test("tests for get the properties of object", async (assert: Test) => {
     "course",
   ];
 
-  assert.ok(Array.isArray(fieldNames), "expect an array of strings returned");
-  assert.ok(
-    fieldNames.length === arrayResultExpected.length,
-    "Arrays have same length",
-  );
-  assert.ok(
-    Object.prototype.hasOwnProperty.call(student, "course"),
-    '"course" property present in object',
-  );
-  assert.ok(fieldNames.includes("course"), '"course" element present in array');
-  assert.deepEqual(fieldNames, arrayResultExpected);
-  assert.end();
+  expect(Array.isArray(fieldNames)).toBeTruthy();
+  expect(fieldNames.length).toBe(arrayResultExpected.length);
+  expect(Object.prototype.hasOwnProperty.call(student, "course")).toBeTruthy();
+  expect(fieldNames.includes("course")).toBeTruthy();
+  expect(fieldNames).toStrictEqual(arrayResultExpected);
 });


### PR DESCRIPTION
Migrated test from Tap to Jest.

File Path:
packages/cactus-common/src/test/typescript/unit/objects/get-all-field-names.test.ts

This is a PARTIAL resolution to issue #238

Signed-off-by: awadhana <awadhana0825@gmail.com>