### PR TITLE
fix: remove jade dependencies

### DIFF
--- a/contribs/Fujitsu-ConnectionChain/connection-chain/environment/base/cc_env/servers/appserver/serviceapi/package.json
+++ b/contribs/Fujitsu-ConnectionChain/connection-chain/environment/base/cc_env/servers/appserver/serviceapi/package.json
@@ -12,7 +12,6 @@
     "debug": "~4.1.1",
     "express": "~4.15.2",
     "express-session": "^1.15.5",
-    "jade": "~1.11.0",
     "mongodb": "^3.6.1",
     "morgan": "~1.9.1",
     "passport": "^0.4.0",

--- a/contribs/Fujitsu-ConnectionChain/connection-chain/environment/base/cc_env/servers/restserver/coreapi/package.json
+++ b/contribs/Fujitsu-ConnectionChain/connection-chain/environment/base/cc_env/servers/restserver/coreapi/package.json
@@ -12,7 +12,6 @@
     "debug": "~4.1.1",
     "express": "~4.15.2",
     "https-proxy-agent": "^2.2.1",
-    "jade": "~1.11.0",
     "log4js": "^3.0.6",
     "morgan": "~1.9.1",
     "request": "^2.81.0",

--- a/examples/cartrade/package.json
+++ b/examples/cartrade/package.json
@@ -23,7 +23,6 @@
     "fabric-ca-client": "2.2.10",
     "fabric-network": "2.2.10",
     "http-errors": "~1.6.3",
-    "jade": "~1.11.0",
     "jsonwebtoken": "^8.5.1",
     "log4js": "^3.0.6",
     "morgan": "~1.9.1",

--- a/examples/discounted-cartrade/package.json
+++ b/examples/discounted-cartrade/package.json
@@ -24,7 +24,6 @@
     "fabric-network": "2.2.10",
     "http-errors": "~1.6.3",
     "indy-sdk": "^1.16.0-dev-1636",
-    "jade": "~1.11.0",
     "jsonwebtoken": "^8.5.1",
     "log4js": "^3.0.6",
     "morgan": "~1.9.1",

--- a/examples/electricity-trade/package.json
+++ b/examples/electricity-trade/package.json
@@ -23,7 +23,6 @@
     "fabric-ca-client": "2.2.10",
     "fabric-network": "2.2.10",
     "http-errors": "~1.6.3",
-    "jade": "~1.11.0",
     "jsonwebtoken": "^8.5.1",
     "log4js": "^3.0.6",
     "morgan": "~1.9.1",

--- a/examples/test-run-transaction/package.json
+++ b/examples/test-run-transaction/package.json
@@ -23,7 +23,6 @@
     "fabric-ca-client": "2.2.10",
     "fabric-network": "2.2.10",
     "http-errors": "~1.6.3",
-    "jade": "~1.11.0",
     "jsonwebtoken": "^8.5.1",
     "log4js": "^3.0.6",
     "morgan": "~1.9.1",

--- a/packages/cactus-cmd-socketio-server/package.json
+++ b/packages/cactus-cmd-socketio-server/package.json
@@ -28,7 +28,6 @@
     "fabric-ca-client": "2.2.10",
     "fabric-network": "2.2.10",
     "http-errors": "~1.6.3",
-    "jade": "~1.11.0",
     "jsonwebtoken": "^8.5.1",
     "log4js": "^3.0.6",
     "morgan": "~1.9.1",


### PR DESCRIPTION
Remove jade dependencies from multiple package.json files because of
reported security flaw

Closes: #1662
Signed-off-by: stepniowskip <piotr.stepniowski@fujitsu.com>