### PR TITLE
test: jestify plugin-import-with-npm-install test

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -49,7 +49,6 @@ files:
   - ./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/refund-endpoint.test.ts
   - ./packages/cactus-plugin-consortium-manual/src/test/typescript/unit/consortium/get-node-jws-endpoint-v1.test.ts
   - ./packages/cactus-test-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
-  - ./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install.test.ts
   - ./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install-version-selection.test.ts
   - ./packages/cactus-test-cmd-api-server/src/test/typescript/integration/runtime-plugin-imports.test.ts
   - ./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/openapi/openapi-validation.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -54,7 +54,6 @@ module.exports = {
     `./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/refund-endpoint.test.ts`,
     `./packages/cactus-plugin-consortium-manual/src/test/typescript/unit/consortium/get-node-jws-endpoint-v1.test.ts`,
     `./packages/cactus-test-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts`,
-    `./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install.test.ts`,
     `./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install-version-selection.test.ts`,
     `./packages/cactus-test-cmd-api-server/src/test/typescript/integration/runtime-plugin-imports.test.ts`,
     `./packages/cactus-cmd-socketio-server/`,

--- a/packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install.test.ts
+++ b/packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install.test.ts
@@ -1,16 +1,15 @@
 import path from "path";
-import test, { Test } from "tape-promise/tape";
 import { v4 as uuidv4 } from "uuid";
+import "jest-extended";
+
 import { generateKeyPair, exportPKCS8 } from "jose";
 
 import { LogLevelDesc } from "@hyperledger/cactus-common";
-
 import {
   PluginImportType,
   ConsortiumDatabase,
   PluginImportAction,
 } from "@hyperledger/cactus-core-api";
-
 import {
   ApiServer,
   AuthorizationProtocol,
@@ -18,80 +17,76 @@ import {
 } from "@hyperledger/cactus-cmd-api-server";
 
 const logLevel: LogLevelDesc = "TRACE";
+const testCase = "can instal plugins at runtime based on imports";
+describe(testCase, () => {
+  let apiServer: ApiServer;
+  afterAll(() => apiServer.shutdown());
 
-test("can instal plugins at runtime based on imports", async (t: Test) => {
-  // Adding a new plugin to update the prometheus metric K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS
-  const keyPair = await generateKeyPair("ES256K");
-  const keyPairPem = await exportPKCS8(keyPair.privateKey);
-  const db: ConsortiumDatabase = {
-    cactusNode: [],
-    consortium: [],
-    consortiumMember: [],
-    ledger: [],
-    pluginInstance: [],
-  };
+  test("can instal plugins at runtime based on imports", async () => {
+    // Adding a new plugin to update the prometheus metric K_CACTUS_API_SERVER_TOTAL_PLUGIN_IMPORTS
+    const keyPair = await generateKeyPair("ES256K");
+    const keyPairPem = await exportPKCS8(keyPair.privateKey);
+    const db: ConsortiumDatabase = {
+      cactusNode: [],
+      consortium: [],
+      consortiumMember: [],
+      ledger: [],
+      pluginInstance: [],
+    };
 
-  const pluginsPath = path.join(
-    __dirname,
-    "../../../../../../", // walk back up to the project root
-    ".tmp/test/test-cmd-api-server/plugin-import-with-npm-install_test/", // the dir path from the root
-    uuidv4(), // then a random directory to ensure proper isolation
-  );
-  const pluginManagerOptionsJson = JSON.stringify({ pluginsPath });
+    const pluginsPath = path.join(
+      __dirname,
+      "../../../../../../", // walk back up to the project root
+      ".tmp/test/test-cmd-api-server/plugin-import-with-npm-install_test/", // the dir path from the root
+      uuidv4(), // then a random directory to ensure proper isolation
+    );
+    const pluginManagerOptionsJson = JSON.stringify({ pluginsPath });
 
-  const configService = new ConfigService();
+    const configService = new ConfigService();
 
-  const apiServerOptions = await configService.newExampleConfig();
-  apiServerOptions.pluginManagerOptionsJson = pluginManagerOptionsJson;
-  apiServerOptions.authorizationProtocol = AuthorizationProtocol.NONE;
-  apiServerOptions.configFile = "";
-  apiServerOptions.apiCorsDomainCsv = "*";
-  apiServerOptions.apiPort = 0;
-  apiServerOptions.cockpitPort = 0;
-  apiServerOptions.grpcPort = 0;
-  apiServerOptions.apiTlsEnabled = false;
-  apiServerOptions.plugins = [
-    {
-      packageName: "@hyperledger/cactus-plugin-keychain-memory",
-      type: PluginImportType.Local,
-      action: PluginImportAction.Install,
-      options: {
-        instanceId: uuidv4(),
-        keychainId: uuidv4(),
-        logLevel,
+    const apiServerOptions = await configService.newExampleConfig();
+    apiServerOptions.pluginManagerOptionsJson = pluginManagerOptionsJson;
+    apiServerOptions.authorizationProtocol = AuthorizationProtocol.NONE;
+    apiServerOptions.configFile = "";
+    apiServerOptions.apiCorsDomainCsv = "*";
+    apiServerOptions.apiPort = 0;
+    apiServerOptions.cockpitPort = 0;
+    apiServerOptions.grpcPort = 0;
+    apiServerOptions.apiTlsEnabled = false;
+    apiServerOptions.plugins = [
+      {
+        packageName: "@hyperledger/cactus-plugin-keychain-memory",
+        type: PluginImportType.Local,
+        action: PluginImportAction.Install,
+        options: {
+          instanceId: uuidv4(),
+          keychainId: uuidv4(),
+          logLevel,
+        },
       },
-    },
-    {
-      packageName: "@hyperledger/cactus-plugin-consortium-manual",
-      type: PluginImportType.Local,
-      action: PluginImportAction.Install,
-      options: {
-        instanceId: uuidv4(),
-        keyPairPem: keyPairPem,
-        consortiumDatabase: db,
+      {
+        packageName: "@hyperledger/cactus-plugin-consortium-manual",
+        type: PluginImportType.Local,
+        action: PluginImportAction.Install,
+        options: {
+          instanceId: uuidv4(),
+          keyPairPem: keyPairPem,
+          consortiumDatabase: db,
+        },
       },
-    },
-  ];
-  const config = await configService.newExampleConfigConvict(apiServerOptions);
+    ];
+    const config = await configService.newExampleConfigConvict(
+      apiServerOptions,
+    );
 
-  const apiServer = new ApiServer({
-    config: config.getProperties(),
+    apiServer = new ApiServer({
+      config: config.getProperties(),
+    });
+
+    const startResponse = apiServer.start();
+    await expect(startResponse).toBeTruthy();
+    expect(startResponse).toBeTruthy();
+
+    await startResponse;
   });
-
-  const startResponse = apiServer.start();
-  await t.doesNotReject(
-    startResponse,
-    "failed to start API server with dynamic plugin imports configured for it...",
-  );
-  t.ok(startResponse, "startResponse truthy OK");
-
-  const addressInfoApi = (await startResponse).addressInfoApi;
-  const protocol = apiServerOptions.apiTlsEnabled ? "https" : "http";
-  const { address, port } = addressInfoApi;
-  const apiHost = `${protocol}://${address}:${port}`;
-  t.comment(
-    `Metrics URL: ${apiHost}/api/v1/api-server/get-prometheus-exporter-metrics`,
-  );
-
-  test.onFinish(() => apiServer.shutdown());
 });


### PR DESCRIPTION
Migrated test from Tap to Jest.

File Path:
packages/cactus-test-cmd-api-server/src/test/typescript
/integration/plugin-import-with-npm-install.test.ts

This is a PARTIAL resolution to issue #238

Signed-off-by: awadhana awadhana0825@gmail.com