### PR TITLE
test: jestify new-contract-endpoint-invalid test

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -127,7 +127,6 @@ files:
   - ./packages/cactus-test-tooling/src/test/typescript/integration/besu/besu-test-ledger/constructor-validates-options.test.ts
   - ./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-status-endpoint-invalid.test.ts
   - ./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-status-endpoint.test.ts
-  - ./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/new-contract-endpoint-invalid.test.ts
   - ./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-single-status-endpoint.test.ts
   - ./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/withdraw-endpoint-invalid.test.ts
   - ./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/openapi/openapi-validation.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -133,7 +133,6 @@ module.exports = {
     `./packages/cactus-test-tooling/src/test/typescript/integration/besu/besu-test-ledger/constructor-validates-options.test.ts`,
     `./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-status-endpoint-invalid.test.ts`,
     `./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-status-endpoint.test.ts`,
-    `./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/new-contract-endpoint-invalid.test.ts`,
     `./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-single-status-endpoint.test.ts`,
     `./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get--status-endpoint-invalid.test.ts`,
     `./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/withdraw-endpoint-invalid.test.ts`,

--- a/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/new-contract-endpoint-invalid.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/new-contract-endpoint-invalid.test.ts
@@ -1,6 +1,6 @@
 import http from "http";
 import type { AddressInfo } from "net";
-import test, { Test } from "tape-promise/tape";
+import "jest-extended";
 import { v4 as uuidv4 } from "uuid";
 import express from "express";
 import bodyParser from "body-parser";
@@ -39,77 +39,8 @@ const connectorId = uuidv4();
 const logLevel: LogLevelDesc = "INFO";
 
 const testCase = "Test invalid new contract";
-
-test("BEFORE " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
-  t.end();
-});
-
-test(testCase, async (t: Test) => {
-  t.comment("Starting Besu Test Ledger");
+describe(testCase, () => {
   const besuTestLedger = new BesuTestLedger({ logLevel });
-
-  test.onFinish(async () => {
-    await besuTestLedger.stop();
-    await besuTestLedger.destroy();
-    await pruneDockerAllIfGithubAction({ logLevel });
-  });
-
-  await besuTestLedger.start();
-
-  const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
-  const rpcApiWsHost = await besuTestLedger.getRpcApiWsHost();
-  const firstHighNetWorthAccount = besuTestLedger.getGenesisAccountPubKey();
-  const privateKey = besuTestLedger.getGenesisAccountPrivKey();
-  const web3SigningCredential: Web3SigningCredential = {
-    ethAccount: firstHighNetWorthAccount,
-    secret: privateKey,
-    type: Web3SigningCredentialType.PrivateKeyHex,
-  } as Web3SigningCredential;
-
-  const keychainId = uuidv4();
-  const keychainPlugin = new PluginKeychainMemory({
-    instanceId: uuidv4(),
-    keychainId,
-    // pre-provision keychain with mock backend holding the private key of the
-    // test account that we'll reference while sending requests with the
-    // signing credential pointing to this keychain entry.
-    backend: new Map([
-      [DemoHelperJSON.contractName, JSON.stringify(DemoHelperJSON)],
-    ]),
-    logLevel,
-  });
-  keychainPlugin.set(
-    HashTimeLockJSON.contractName,
-    JSON.stringify(HashTimeLockJSON),
-  );
-  const factory = new PluginFactoryLedgerConnector({
-    pluginImportType: PluginImportType.Local,
-  });
-
-  const pluginRegistry = new PluginRegistry({});
-  const connector: PluginLedgerConnectorBesu = await factory.create({
-    rpcApiHttpHost,
-    rpcApiWsHost,
-    logLevel,
-    instanceId: connectorId,
-    pluginRegistry: new PluginRegistry({ plugins: [keychainPlugin] }),
-  });
-
-  pluginRegistry.add(connector);
-  const pluginOptions: IPluginHtlcEthBesuOptions = {
-    logLevel,
-    instanceId: uuidv4(),
-    pluginRegistry,
-  };
-
-  const factoryHTLC = new PluginFactoryHtlcEthBesu({
-    pluginImportType: PluginImportType.Local,
-  });
-
-  const pluginHtlc = await factoryHTLC.create(pluginOptions);
-  pluginRegistry.add(pluginHtlc);
 
   const expressApp = express();
   expressApp.use(bodyParser.json({ limit: "250mb" }));
@@ -119,79 +50,138 @@ test(testCase, async (t: Test) => {
     port: 0,
     server,
   };
-  const addressInfo = (await Servers.listen(listenOptions)) as AddressInfo;
-  test.onFinish(async () => await Servers.shutdown(server));
-  const { address, port } = addressInfo;
-  const apiHost = `http://${address}:${port}`;
 
-  const configuration = new Configuration({ basePath: apiHost });
-  const api = new BesuApi(configuration);
-
-  await pluginHtlc.getOrCreateWebServices();
-  await pluginHtlc.registerWebServices(expressApp);
-
-  t.comment("Deploys HashTimeLock via .json file on initialize function");
-  const initRequest: InitializeRequest = {
-    connectorId,
-    keychainId,
-    constructorArgs: [],
-    web3SigningCredential,
-    gas: DataTest.estimated_gas,
-  };
-  const deployOut = await pluginHtlc.initialize(initRequest);
-  t.ok(
-    deployOut.transactionReceipt,
-    "pluginHtlc.initialize() output.transactionReceipt is truthy OK",
-  );
-  t.ok(
-    deployOut.transactionReceipt.contractAddress,
-    "pluginHtlc.initialize() output.transactionReceipt.contractAddress is truthy OK",
-  );
-  const hashTimeLockAddress = deployOut.transactionReceipt
-    .contractAddress as string;
-
-  //Deploy DemoHelpers
-  t.comment("Deploys DemoHelpers via .json file on deployContract function");
-  const deployOutDemo = await connector.deployContract({
-    contractName: DemoHelperJSON.contractName,
-    contractAbi: DemoHelperJSON.abi,
-    bytecode: DemoHelperJSON.bytecode,
-    web3SigningCredential,
-    keychainId,
-    constructorArgs: [],
-    gas: DataTest.estimated_gas,
+  beforeAll(async () => {
+    const pruning = pruneDockerAllIfGithubAction({ logLevel });
+    await expect(pruning).resolves.toBeTruthy();
   });
-  t.ok(deployOutDemo, "deployContract() output is truthy OK");
-  t.ok(
-    deployOutDemo.transactionReceipt,
-    "deployContract() output.transactionReceipt is truthy OK",
-  );
-  t.ok(
-    deployOutDemo.transactionReceipt.contractAddress,
-    "deployContract() output.transactionReceipt.contractAddress is truthy OK",
-  );
 
-  t.comment("Create new contract for HTLC");
-  try {
-    const bodyObj: NewContractObj = {
-      contractAddress: hashTimeLockAddress,
-      inputAmount: 10,
-      outputAmount: 0x04,
-      expiration: DataTest.expiration,
-      hashLock: DataTest.hashLock,
-      receiver: DataTest.receiver,
-      outputNetwork: "BTC",
-      outputAddress: "1AcVYm7M3kkJQH28FXAvyBFQzFRL6xPKu8",
-      connectorId: connectorId,
+  afterAll(async () => {
+    await besuTestLedger.stop();
+    await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
+  });
+
+  beforeAll(async () => {
+    await besuTestLedger.start();
+  });
+
+  afterAll(async () => {
+    const pruning = pruneDockerAllIfGithubAction({ logLevel });
+    await expect(pruning).resolves.toBeTruthy();
+  });
+  afterAll(async () => await Servers.shutdown(server));
+
+  test(testCase, async () => {
+    const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
+    const rpcApiWsHost = await besuTestLedger.getRpcApiWsHost();
+    const firstHighNetWorthAccount = besuTestLedger.getGenesisAccountPubKey();
+    const privateKey = besuTestLedger.getGenesisAccountPrivKey();
+    const web3SigningCredential: Web3SigningCredential = {
+      ethAccount: firstHighNetWorthAccount,
+      secret: privateKey,
+      type: Web3SigningCredentialType.PrivateKeyHex,
+    } as Web3SigningCredential;
+
+    const keychainId = uuidv4();
+    const keychainPlugin = new PluginKeychainMemory({
+      instanceId: uuidv4(),
+      keychainId,
+      // pre-provision keychain with mock backend holding the private key of the
+      // test account that we'll reference while sending requests with the
+      // signing credential pointing to this keychain entry.
+      backend: new Map([
+        [DemoHelperJSON.contractName, JSON.stringify(DemoHelperJSON)],
+      ]),
+      logLevel,
+    });
+    keychainPlugin.set(
+      HashTimeLockJSON.contractName,
+      JSON.stringify(HashTimeLockJSON),
+    );
+    const factory = new PluginFactoryLedgerConnector({
+      pluginImportType: PluginImportType.Local,
+    });
+
+    const pluginRegistry = new PluginRegistry({});
+    const connector: PluginLedgerConnectorBesu = await factory.create({
+      rpcApiHttpHost,
+      rpcApiWsHost,
+      logLevel,
+      instanceId: connectorId,
+      pluginRegistry: new PluginRegistry({ plugins: [keychainPlugin] }),
+    });
+
+    pluginRegistry.add(connector);
+    const pluginOptions: IPluginHtlcEthBesuOptions = {
+      logLevel,
+      instanceId: uuidv4(),
+      pluginRegistry,
+    };
+
+    const factoryHTLC = new PluginFactoryHtlcEthBesu({
+      pluginImportType: PluginImportType.Local,
+    });
+
+    const pluginHtlc = await factoryHTLC.create(pluginOptions);
+    pluginRegistry.add(pluginHtlc);
+    const addressInfo = (await Servers.listen(listenOptions)) as AddressInfo;
+    const { address, port } = addressInfo;
+    const apiHost = `http://${address}:${port}`;
+
+    const configuration = new Configuration({ basePath: apiHost });
+    const api = new BesuApi(configuration);
+
+    await pluginHtlc.getOrCreateWebServices();
+    await pluginHtlc.registerWebServices(expressApp);
+
+    const initRequest: InitializeRequest = {
+      connectorId,
+      keychainId,
+      constructorArgs: [],
       web3SigningCredential,
-      keychainId: "",
       gas: DataTest.estimated_gas,
     };
-    const resp = await api.newContractV1(bodyObj);
-    t.ok(resp, "response newContract is OK");
-    t.equal(resp.status, 200, "response status newContract is OK");
-  } catch (error) {
-    t.equal(error.response.status, 500, "response status is 500");
-  }
-  t.end();
+    const deployOut = await pluginHtlc.initialize(initRequest);
+    expect(deployOut.transactionReceipt).toBeTruthy();
+    expect(deployOut.transactionReceipt.contractAddress).toBeTruthy();
+    const hashTimeLockAddress = deployOut.transactionReceipt
+      .contractAddress as string;
+
+    //Deploy DemoHelpers
+    const deployOutDemo = await connector.deployContract({
+      contractName: DemoHelperJSON.contractName,
+      contractAbi: DemoHelperJSON.abi,
+      bytecode: DemoHelperJSON.bytecode,
+      web3SigningCredential,
+      keychainId,
+      constructorArgs: [],
+      gas: DataTest.estimated_gas,
+    });
+    expect(deployOutDemo).toBeTruthy();
+    expect(deployOutDemo.transactionReceipt).toBeTruthy();
+    expect(deployOutDemo.transactionReceipt.contractAddress).toBeTruthy();
+
+    try {
+      const bodyObj: NewContractObj = {
+        contractAddress: hashTimeLockAddress,
+        inputAmount: 10,
+        outputAmount: 0x04,
+        expiration: DataTest.expiration,
+        hashLock: DataTest.hashLock,
+        receiver: DataTest.receiver,
+        outputNetwork: "BTC",
+        outputAddress: "1AcVYm7M3kkJQH28FXAvyBFQzFRL6xPKu8",
+        connectorId: connectorId,
+        web3SigningCredential,
+        keychainId: "",
+        gas: DataTest.estimated_gas,
+      };
+      const resp = await api.newContractV1(bodyObj);
+      expect(resp).toBeTruthy();
+      expect(resp.status).toEqual(200);
+    } catch (error: any) {
+      expect(error.response.status).toEqual(500);
+    }
+  });
 });


### PR DESCRIPTION
Migrated test from Tap to Jest.

File Path:
packages/cactus-test-plugin-htlc-eth-besu/src/
test/typescript/integration/plugin-htlc-eth-besu/
new-contract-endpoint-invalid.test.ts

This is a PARTIAL resolution to issue #238

Signed-off-by: awadhana <awadhana0825@gmail.com>