### PR TITLE
refactor(cmd-api-server): migrate from convict to yargs

### DIFF
--- a/packages/cactus-cmd-api-server/package.json
+++ b/packages/cactus-cmd-api-server/package.json
@@ -85,6 +85,7 @@
     "compression": "1.7.4",
     "convict": "6.0.0",
     "convict-format-with-validator": "6.2.0",
+    "yargs": "17.3.1",
     "cors": "2.8.5",
     "express": "4.17.1",
     "express-http-proxy": "1.6.2",

--- a/packages/cactus-cmd-api-server/src/main/typescript/config/config-service.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/config/config-service.ts
@@ -1,6 +1,7 @@
 import { SecureVersion } from "tls";
 import { existsSync, readFileSync } from "fs";
 import convict, { Schema, Config, SchemaObj } from "convict";
+//import yargs, { Schema, SchemaObj, Configuration } from "yargs";
 import { ipaddress } from "convict-format-with-validator";
 import { v4 as uuidV4 } from "uuid";
 import {
@@ -27,12 +28,15 @@ import {
 } from "@hyperledger/cactus-core-api";
 
 import { FORMAT_PLUGIN_ARRAY } from "./convict-plugin-array-format";
+//import { FORMAT_PLUGIN_ARRAY } from "./yargs-plugin-array-format";
 import { SelfSignedPkiGenerator, IPki } from "./self-signed-pki-generator";
 import { AuthorizationProtocol } from "./authorization-protocol";
 import { IAuthorizationConfig } from "../authzn/i-authorization-config";
 
 convict.addFormat(FORMAT_PLUGIN_ARRAY);
 convict.addFormat(ipaddress);
+
+//yargs.addFormat(FORMAT_PLUGIN_ARRAY);
 
 export interface ICactusApiServerOptions {
   pluginManagerOptionsJson: string;

--- a/packages/cactus-cmd-api-server/src/main/typescript/config/yargs-plugin-array-format.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/config/yargs-plugin-array-format.ts
@@ -1,0 +1,25 @@
+import yargs from "yargs";
+
+export const validate = (sources: any[], schema?: any) => {
+  if (!Array.isArray(sources)) {
+    throw new Error("must be of type Array");
+  }
+
+  for (const source of sources) {
+    yargs(schema.pluginSchema).config(source);
+  }
+};
+
+export const coerce = (value: string) => {
+  // CLI sends comman separated objects as a JSON string without the array square brackets
+  // ENV sends the proper array that is valid JSON so we have to detect and handle both cases
+  const isJsonArray = value.startsWith("[") && value.endsWith("]");
+  return isJsonArray ? JSON.parse(value) : JSON.parse(`[${value}]`);
+};
+
+//create a interface that uses this format?
+export const FORMAT_PLUGIN_ARRAY = {
+  name: "plugin-array",
+  validate,
+  coerce,
+};


### PR DESCRIPTION
WIP, pls don't worry too much about it 

1) installed the yargs within the `cactus-cmd-api-server`
2) altered the `index.d.ts` file within the root module's `yargs` folder to add the `SchemaObj` `Schema` and `Config` along with `interface Format` and `addFormat` (almost identical to the `index.d.ts` file within the Convict module)
3) added the `packages/cactus-cmd-api-server/src/main/typescript/config/yargs-plugin-array-format.ts `

Fixes 1200

Signed-off-by: Youngone Lee <youngone.lee@accenture.com>