### PR TITLE
test(test-tooling): fix flaky rustc-container-target-nodejs.test

### DIFF
--- a/packages/cactus-test-tooling/src/main/typescript/rustc-container/rustc-container.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/rustc-container/rustc-container.ts
@@ -89,7 +89,7 @@ export class RustcContainer {
     this.hostSourceDir = Optional.ofNullable(opts.hostSourceDir);
     this.imageName =
       opts.imageName || "ghcr.io/hyperledger/cactus-rust-compiler";
-    this.imageTag = opts.imageTag || "1.0.3";
+    this.imageTag = opts.imageTag || "2022-01-12-15d4793c---fix-1646";
     this.imageFqn = `${this.imageName}:${this.imageTag}`;
     this.envVars = opts.envVars || new Map();
     this.emitContainerLogs = Bools.isBooleanStrict(opts.emitContainerLogs)

--- a/tools/docker/rust-compiler/Dockerfile
+++ b/tools/docker/rust-compiler/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.52.1-slim-bullseye
+FROM rust:1.57.0-slim-bullseye
 
 RUN apt update
 


### PR DESCRIPTION
The problem was that the Rust compiler version we were using
(v1.52.x) seem to have gotten outdated and it would no longer
work with wasm-pack.
To provide a fix I upgraded the base image of the container to
come with Rust v1.57.x and now the build error[1] is no longer
present and the test case is passing with the new image that was
pushed to ghcr.io.

The image tag this was pushed as is:
ghcr.io/hyperledger/cactus-rust-compiler:2022-01-12-15d4793c---fix-1646
which is now also the default tag that the RustcContainer class
uses in the test-tooling package.

[1]:
```sh
   Compiling bumpalo v3.9.1
[38;5;9merror[E0658]: arbitrary expressions in key-value attributes are unstable
 [38;5;12m-->
 /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/bumpalo-3.9.1/src/lib.rs:1:10
  [38;5;12m|
[38;5;12m1 [38;5;12m| #![doc = include_str!("../README.md")]
  [38;5;12m|          [38;5;9m^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  [38;5;12m|
  [38;5;12m= note: see issue #78835 <https://github.com/rust-lang/rust/issues/78835>
  for more information

   Compiling wasm-bindgen v0.2.78
[38;5;9merror: aborting due to previous error

For more information about this error, try `rustc --explain E0658`.
error: could not compile `bumpalo`
```

Fixes #1646

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>