### PR TITLE
fix: test tooling exception handling and upgrade TS

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
@@ -43,6 +43,7 @@ import {
   Bools,
   Logger,
   LoggerProvider,
+  LogHelper,
   Servers,
 } from "@hyperledger/cactus-common";
 
@@ -241,7 +242,8 @@ export class ApiServer {
 
       return { addressInfoCockpit, addressInfoApi, addressInfoGrpc };
     } catch (ex) {
-      const errorMessage = `Failed to start ApiServer: ${ex.stack}`;
+      const stack = LogHelper.getExceptionStack(ex);
+      const errorMessage = `Failed to start ApiServer: ${stack}`;
       this.log.error(errorMessage);
       this.log.error(`Attempting shutdown...`);
       try {
@@ -296,9 +298,10 @@ export class ApiServer {
         await this.getPluginImportsCount(),
       );
       return this.pluginRegistry;
-    } catch (e) {
+    } catch (ex) {
       this.pluginRegistry = new PluginRegistry({ plugins: [] });
-      const errorMessage = `Failed init PluginRegistry: ${e.stack}`;
+      const stack = LogHelper.getExceptionStack(ex);
+      const errorMessage = `Failed init PluginRegistry: ${stack}`;
       this.log.error(errorMessage);
       throw new Error(errorMessage);
     }

--- a/packages/cactus-common/package.json
+++ b/packages/cactus-common/package.json
@@ -52,6 +52,11 @@
       "name": "Peter Somogyvari",
       "email": "peter.somogyvari@accenture.com",
       "url": "https://accenture.com"
+    },
+    {
+      "name": "Michael Courtin",
+      "email": "michael.courtin@accenture.com",
+      "url": "https://accenture.com"
     }
   ],
   "license": "Apache-2.0",
@@ -60,6 +65,7 @@
   },
   "homepage": "https://github.com/hyperledger/cactus#readme",
   "dependencies": {
+    "fast-safe-stringify": "2.1.1",
     "json-stable-stringify": "1.0.1",
     "key-encoder": "2.0.3",
     "loglevel": "1.7.1",

--- a/packages/cactus-common/src/main/typescript/logging/log-helper.ts
+++ b/packages/cactus-common/src/main/typescript/logging/log-helper.ts
@@ -1,0 +1,113 @@
+import { RuntimeError } from "run-time-error";
+import stringify from "fast-safe-stringify";
+
+export class LogHelper {
+  public static getExceptionStack(exception: unknown): string {
+    // handle unknown exception input
+    const fallbackStack = "NO_STACK_INFORMATION_INCLUDED_IN_EXCEPTION";
+    const invalidStack = "INVALID_STACK_INFORMATION";
+    const invalidException = "INVALID_EXCEPTION";
+    const customExceptionPrefix = "A CUSTOM EXCEPTION WAS THROWN: ";
+    let stack = fallbackStack;
+    let exceptionHandled = false;
+
+    // 1st need to check that exception is not null or undefined before trying to access the wanted stack information
+    // otherwise the default fallback stack info will be returned
+    if (exception) {
+      if (exception instanceof RuntimeError) {
+        // handling RuntimeError stack inclusive nested / cascaded stacks
+        stack = this.safeJsonStringify(exception);
+        exceptionHandled = true;
+      }
+
+      if (!exceptionHandled && typeof exception === "object") {
+        // 2nd need to check if a stack property is available
+        if (Object.hasOwnProperty.call(exception, "stack")) {
+          // 3rd check if the stack property is already of type string
+          if (
+            typeof (exception as Record<string, unknown>).stack === "string"
+          ) {
+            stack = (exception as { stack: string }).stack;
+          } else {
+            // need to stringify stack information first
+            stack = this.safeJsonStringify(
+              (exception as { stack: unknown }).stack,
+              invalidStack,
+            );
+          }
+          exceptionHandled = true;
+        }
+      }
+
+      if (!exceptionHandled) {
+        // custom exception is of a different type -> need to stringify it
+        stack =
+          customExceptionPrefix +
+          this.safeJsonStringify(exception, invalidException);
+      }
+    }
+    return stack;
+  }
+
+  public static getExceptionMessage(exception: unknown): string {
+    // handle unknown exception input
+    const defaultMessage = "NO_MESSAGE_INCLUDED_IN_EXCEPTION";
+    const invalidException = "INVALID_EXCEPTION";
+    const invalidMessage = "INVALID_EXCEPTION_MESSAGE";
+    const customExceptionPrefix = "A CUSTOM EXCEPTION WAS THROWN: ";
+    let message = defaultMessage;
+    let exceptionHandled = false;
+
+    // 1st need to check that exception is not null or undefined before trying to access the wanted message information
+    if (exception) {
+      if (typeof exception === "object") {
+        // 2nd need to check if a message property is available
+        if (Object.hasOwnProperty.call(exception, "message")) {
+          // 3rd check if the message property is already of type string
+          if (
+            typeof (exception as Record<string, unknown>).message === "string"
+          ) {
+            message = (exception as { message: string }).message;
+          } else {
+            // need to stringify message information first
+            message = this.safeJsonStringify(
+              (exception as { message: unknown }).message,
+              invalidMessage,
+            );
+          }
+          exceptionHandled = true;
+        }
+      }
+
+      // handling of custom exceptions
+      if (!exceptionHandled) {
+        // check if thrown custom exception is a string type only -> directly use it as exception message
+        if (typeof exception === "string") {
+          message = customExceptionPrefix + exception;
+        } else {
+          // custom exception is of a different type -> need to stringify it
+          message =
+            customExceptionPrefix +
+            this.safeJsonStringify(exception, invalidException);
+        }
+      }
+    }
+    return message;
+  }
+
+  private static safeJsonStringify(
+    input: unknown,
+    catchMessage = "INVALID_INPUT",
+  ): string {
+    let message = "";
+
+    try {
+      // use fast-safe-stringify to also handle gracefully circular structures
+      message = stringify(input);
+    } catch (error) {
+      // fast and safe stringify failed
+      message = catchMessage;
+    }
+    return message;
+  }
+}

--- a/packages/cactus-common/src/main/typescript/public-api.ts
+++ b/packages/cactus-common/src/main/typescript/public-api.ts
@@ -1,4 +1,5 @@
 export { LoggerProvider } from "./logging/logger-provider";
+export { LogHelper } from "./logging/log-helper";
 export { Logger, ILoggerOptions } from "./logging/logger";
 export { LogLevelDesc } from "loglevel";
 export { Objects } from "./objects";

--- a/packages/cactus-common/src/test/typescript/unit/logging/log-helper.test.ts
+++ b/packages/cactus-common/src/test/typescript/unit/logging/log-helper.test.ts
@@ -1,0 +1,305 @@
+import "jest-extended";
+import { RuntimeError } from "run-time-error";
+import { LogHelper } from "../../../../main/typescript/logging/log-helper";
+
+describe("log-helper tests", () => {
+  const no_message_available = "NO_MESSAGE_INCLUDED_IN_EXCEPTION";
+  const no_stack_available = "NO_STACK_INFORMATION_INCLUDED_IN_EXCEPTION";
+  const custom_exception_was_thrown = "A CUSTOM EXCEPTION WAS THROWN";
+  const errorMessage = "Oops";
+  const errorNumber = 2468;
+
+  describe("exception stack-tests", () => {
+    it("gets the stack information from a regular Error object", () => {
+      let expectedResult: string | undefined = "";
+      let stack = no_stack_available;
+
+      try {
+        const testError = new Error(errorMessage);
+        expectedResult = testError.stack;
+        throw testError;
+      } catch (error) {
+        stack = LogHelper.getExceptionStack(error);
+      }
+
+      // check stack
+      expect(stack).toBe(expectedResult);
+    });
+
+    it("gets stack information from a faked Error object which is containing stack information as string type", () => {
+      const expectedResult = "Faked stack";
+      let stack = no_stack_available;
+
+      const fakeErrorWithStack = {
+        message:
+          "This is a fake error object with string-type stack information",
+        stack: expectedResult,
+      };
+
+      try {
+        throw fakeErrorWithStack;
+      } catch (error) {
+        stack = LogHelper.getExceptionStack(error);
+      }
+
+      // check stack
+      expect(stack).toBe(expectedResult);
+    });
+
+    it("gets stack information from a faked Error object which is containing stack information as number type and therefore need to be stringified", () => {
+      const expectedResult = "123456";
+      let stack = no_stack_available;
+
+      const fakeErrorWithStack = {
+        message:
+          "This is a fake error object with number-type stack information",
+        stack: 123456,
+      };
+
+      try {
+        throw fakeErrorWithStack;
+      } catch (error) {
+        stack = LogHelper.getExceptionStack(error);
+      }
+
+      // check stack
+      expect(stack).toBe(expectedResult);
+    });
+
+    it("gets stringified exception as custom stack information as the faked Error object is not containing any specific stack information", () => {
+      const msg = "This is a fake error object without stack information";
+      let stack = no_stack_available;
+
+      const fakeErrorWithoutStack = {
+        message: msg,
+      };
+
+      try {
+        throw fakeErrorWithoutStack;
+      } catch (error) {
+        stack = LogHelper.getExceptionStack(error);
+      }
+
+      // check stack
+      expect(stack).toContain(msg);
+      expect(stack).toContain(custom_exception_was_thrown);
+    });
+
+    it("handles throwing null successfully and returns NO_STACK_INFORMATION_INCLUDED_IN_EXCEPTION string", () => {
+      const expectedResult = no_stack_available;
+      let stack = no_stack_available;
+
+      const fakeError = null;
+
+      try {
+        throw fakeError;
+      } catch (error) {
+        stack = LogHelper.getExceptionStack(error);
+      }
+
+      // check stack
+      expect(stack).toBe(expectedResult);
+    });
+
+    it("handles throwing undefined successfully and returns NO_STACK_INFORMATION_INCLUDED_IN_EXCEPTION string", () => {
+      const expectedResult = no_stack_available;
+      let stack = no_stack_available;
+
+      const fakeError = undefined;
+
+      try {
+        throw fakeError;
+      } catch (error) {
+        stack = LogHelper.getExceptionStack(error);
+      }
+
+      // check stack
+      expect(stack).toBe(expectedResult);
+    });
+  });
+
+  describe("exception message-tests", () => {
+    it("gets the exception message from a regular Error object", () => {
+      const expectedResult = errorMessage;
+      let message = no_message_available;
+
+      try {
+        const testError = new Error(errorMessage);
+        throw testError;
+      } catch (error) {
+        message = LogHelper.getExceptionMessage(error);
+      }
+
+      // check message
+      expect(message).toBe(expectedResult);
+    });
+
+    it("gets the exception message from a faked Error object which is containing message as string type", () => {
+      const expectedResult = errorMessage;
+      let message = no_message_available;
+
+      const fakeErrorWithMessage = {
+        message: errorMessage,
+        stack: expectedResult,
+      };
+
+      try {
+        throw fakeErrorWithMessage;
+      } catch (error) {
+        message = LogHelper.getExceptionMessage(error);
+      }
+
+      // check message
+      expect(message).toBe(expectedResult);
+    });
+
+    it("gets exception message from a faked Error object which is containing message information as number type and therefore need to be stringified", () => {
+      const expectedResult = "123456";
+      let message = no_message_available;
+
+      const fakeErrorWithNumberMessage = {
+        message: 123456,
+      };
+
+      try {
+        throw fakeErrorWithNumberMessage;
+      } catch (error) {
+        message = LogHelper.getExceptionMessage(error);
+      }
+
+      // check message
+      expect(message).toBe(expectedResult);
+    });
+
+    it("gets no exception message information as the faked Error object is not containing any message information and therefore tries to stringify the whole exception", () => {
+      const msg = "This is a fake error object without message information";
+      const expectedResultPart2 = msg;
+      let message = no_message_available;
+
+      const fakeErrorWithoutMessage = {
+        stack: "This is a fake error object without message information",
+      };
+
+      try {
+        throw fakeErrorWithoutMessage;
+      } catch (error) {
+        message = LogHelper.getExceptionMessage(error);
+      }
+
+      // check message
+      expect(message).toContain(custom_exception_was_thrown);
+      expect(message).toContain(expectedResultPart2);
+    });
+
+    it("handles throwing null successfully and returning NO_MESSAGE_INCLUDED_IN_EXCEPTION string", () => {
+      const expectedResult = no_message_available;
+      let message = no_message_available;
+
+      const fakeError = null;
+
+      try {
+        throw fakeError;
+      } catch (error) {
+        message = LogHelper.getExceptionMessage(error);
+      }
+
+      // check message
+      expect(message).toBe(expectedResult);
+    });
+
+    it("handles throwing undefined successfully and returning NO_MESSAGE_INCLUDED_IN_EXCEPTION string", () => {
+      const expectedResult = no_message_available;
+      let message = no_message_available;
+
+      const fakeError = undefined;
+
+      try {
+        throw fakeError;
+      } catch (error) {
+        message = LogHelper.getExceptionMessage(error);
+      }
+
+      // check message
+      expect(message).toBe(expectedResult);
+    });
+  });
+
+  describe("handling of custom exceptions", () => {
+    it("handles a thrown string", () => {
+      let message = no_message_available;
+      let stack = no_stack_available;
+
+      try {
+        throw errorMessage;
+      } catch (error) {
+        message = LogHelper.getExceptionMessage(error);
+        stack = LogHelper.getExceptionStack(error);
+      }
+
+      // check message + stack
+      expect(message).toContain(errorMessage);
+      expect(message).toContain(custom_exception_was_thrown);
+      expect(stack).toContain(errorMessage);
+      expect(stack).toContain(custom_exception_was_thrown);
+    });
+
+    it("handles a thrown number", () => {
+      const expectedMessage = `${errorNumber}`;
+      let message = no_message_available;
+      let stack = no_stack_available;
+
+      try {
+        throw errorNumber;
+      } catch (error) {
+        message = LogHelper.getExceptionMessage(error);
+        stack = LogHelper.getExceptionStack(error);
+      }
+
+      // check message + stack
+      expect(message).toContain(expectedMessage);
+      expect(message).toContain(custom_exception_was_thrown);
+      expect(stack).toContain(expectedMessage);
+      expect(stack).toContain(custom_exception_was_thrown);
+    });
+
+    it("handles an arbitrary exception", () => {
+      let message = no_message_available;
+      let stack = no_stack_available;
+      const arbitraryException = { error: errorMessage };
+
+      try {
+        throw arbitraryException;
+      } catch (error) {
+        message = LogHelper.getExceptionMessage(error);
+        stack = LogHelper.getExceptionStack(error);
+      }
+
+      // check message + stack
+      expect(message).toContain(errorMessage);
+      expect(message).toContain(custom_exception_was_thrown);
+      expect(stack).toContain(errorMessage);
+      expect(stack).toContain(custom_exception_was_thrown);
+    });
+
+    it("handles nested exceptions", () => {
+      const expectedErrorMessage = "RTE3";
+      const expectedStackPart = "RTE1";
+      let message = no_message_available;
+      let stack = no_stack_available;
+      const rtE1 = new RuntimeError("RTE1");
+      const rtE2 = new RuntimeError("RTE2", rtE1);
+      const rtE3 = new RuntimeError("RTE3", rtE2);
+
+      try {
+        throw rtE3;
+      } catch (error) {
+        message = LogHelper.getExceptionMessage(error);
+        stack = LogHelper.getExceptionStack(error);
+      }
+
+      // check message + stack
+      expect(message).toBe(expectedErrorMessage);
+      expect(stack).toContain(expectedStackPart);
+    });
+  });
+});

--- a/packages/cactus-test-tooling/src/main/typescript/besu/besu-mp-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/besu/besu-mp-test-ledger.ts
@@ -160,9 +160,17 @@ export class BesuMpTestLedger {
         try {
           await Containers.waitForHealthCheck(this.containerId.get());
           resolve(container);
-        } catch (ex) {
-          this.log.error(ex);
-          reject(ex);
+        } catch (ex: unknown) {
+          if (ex instanceof Error) {
+            this.log.error(ex);
+            reject(ex);
+          } else {
+            reject(ex);
+            throw new RuntimeError(
+              "expected an instanceof Error, but got something else",
+              JSON.stringify(ex),
+            );
+          }
         }
       });
     });

--- a/packages/cactus-test-tooling/src/main/typescript/besu/besu-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/besu/besu-test-ledger.ts
@@ -15,6 +15,7 @@ import { ITestLedger } from "../i-test-ledger";
 import { Streams } from "../common/streams";
 import { IKeyPair } from "../i-key-pair";
 import { Containers } from "../common/containers";
+import { RuntimeError } from "run-time-error";
 
 export interface IBesuTestLedgerConstructorOptions {
   containerImageVersion?: string;
@@ -278,8 +279,15 @@ export class BesuTestLedger implements ITestLedger {
           await this.waitForHealthCheck();
           this.log.debug(`Healthcheck passing OK.`);
           resolve(container);
-        } catch (ex) {
-          reject(ex);
+        } catch (ex: unknown) {
+          if (ex instanceof Error) {
+            reject(ex);
+          } else {
+            throw new RuntimeError(
+              "expected an instanceof Error, got something else",
+              JSON.stringify(ex),
+            );
+          }
         }
       });
     });

--- a/packages/cactus-test-tooling/src/main/typescript/cactus-keychain-vault-server/cactus-keychain-vault-server.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/cactus-keychain-vault-server/cactus-keychain-vault-server.ts
@@ -10,6 +10,7 @@ import {
 } from "@hyperledger/cactus-common";
 
 import { Containers } from "../common/containers";
+import { RuntimeError } from "run-time-error";
 
 export interface ICactusKeychainVaultServerOptions {
   envVars?: string[];
@@ -102,8 +103,16 @@ export class CactusKeychainVaultServer {
         try {
           await Containers.waitForHealthCheck(this.containerId);
           resolve(container);
-        } catch (ex) {
-          reject(ex);
+        } catch (ex: unknown) {
+          if (ex instanceof Error) {
+            reject(ex);
+          } else {
+            reject(ex);
+            throw new RuntimeError(
+              "expected an instanceof Error, got something else",
+              JSON.stringify(ex),
+            );
+          }
         }
       });
     });

--- a/packages/cactus-test-tooling/src/main/typescript/fabric/fabric-test-ledger-v1.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/fabric/fabric-test-ledger-v1.ts
@@ -512,7 +512,7 @@ export class FabricTestLedgerV1 implements ITestLedger {
       return ccp;
     } catch (error) {
       this.log.debug(`error on get connection profile`);
-      throw new Error(error as string);
+      throw new Error(JSON.stringify(error));
     }
   }
 

--- a/packages/cactus-test-tooling/src/test/typescript/integration/common/containers.test.ts
+++ b/packages/cactus-test-tooling/src/test/typescript/integration/common/containers.test.ts
@@ -9,6 +9,7 @@ import {
   HttpEchoContainer,
   Containers,
 } from "../../../../main/typescript/public-api";
+import axios from "axios";
 
 LoggerProvider.setLogLevel("DEBUG");
 const log: Logger = LoggerProvider.getOrCreate({ label: "containers-test" });
@@ -114,12 +115,18 @@ test("Can report error if docker daemon is not accessable", async (t: Test) => {
       },
     });
     t.fail("Containers.getDiagnostics was supposed to fail but did not.");
-  } catch (ex) {
-    t.ok(ex, "exception thrown is truthy OK");
-    t.ok(ex.cause, "ex.cause truthy OK");
-    t.ok(ex.cause.message, "ex.cause.message truthy OK");
-    const causeMsgIsInformative = ex.cause.message.includes(badSocketPath);
-    t.true(causeMsgIsInformative, "causeMsgIsInformative");
+  } catch (ex: unknown) {
+    if (axios.isAxiosError(ex)) {
+      t.ok(ex, "exception thrown is truthy OK");
+      t.ok((ex as any).cause, "ex.cause truthy OK");
+      t.ok((ex as any).cause.message, "ex.cause.message truthy OK");
+      const causeMsgIsInformative = (ex as any).cause.message.includes(
+        badSocketPath,
+      );
+      t.true(causeMsgIsInformative, "causeMsgIsInformative");
+    } else {
+      t.fail("expected an axios error, got something else");
+    }
   }
   t.end();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3998,6 +3998,14 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/bytebuffer@^5.0.34":
+  version "5.0.43"
+  resolved "https://registry.yarnpkg.com/@types/bytebuffer/-/bytebuffer-5.0.43.tgz#b5259fca1412106bcee0cabfbf7c104846d06738"
+  integrity sha512-vQnTYvy4LpSojHjKdmg4nXFI1BAiYPvZ/k3ouczZAQnbDprk1xqxJiFmFHyy8y6MuUq3slz5erNMtn6n87uVKw==
+  dependencies:
+    "@types/long" "*"
+    "@types/node" "*"
+
 "@types/bytebuffer@^5.0.40":
   version "5.0.42"
   resolved "https://registry.yarnpkg.com/@types/bytebuffer/-/bytebuffer-5.0.42.tgz#1c602a77942d34c5c0879ad75c58d5d8c07dfb3b"
@@ -6237,7 +6245,7 @@ bn.js@4.11.6:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
   integrity sha1-UzRK2xRhehP26N0s4okF0cC6MhU=
 
-bn.js@4.12.0, bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.0, bn.js@^4.11.1, bn.js@^4.11.6, bn.js@^4.11.8, bn.js@^4.11.9:
+bn.js@4.12.0, bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.0, bn.js@^4.11.1, bn.js@^4.11.3, bn.js@^4.11.6, bn.js@^4.11.8, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
@@ -6394,6 +6402,11 @@ browser-readablestream-to-it@^1.0.1, browser-readablestream-to-it@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz#ac3e406c7ee6cdf0a502dd55db33bab97f7fba76"
   integrity sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw==
+
+browser-request@~0.3.0:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/browser-request/-/browser-request-0.3.3.tgz#9ece5b5aca89a29932242e18bf933def9876cc17"
+  integrity sha1-ns5bWsqJopkyJC4Yv5M975h2zBc=
 
 browser-stdout@1.3.1:
   version "1.3.1"
@@ -6637,7 +6650,7 @@ byte-size@^7.0.0:
   resolved "https://registry.yarnpkg.com/byte-size/-/byte-size-7.0.1.tgz#b1daf3386de7ab9d706b941a748dbfc71130dee3"
   integrity sha512-crQdqyCwhokxwV1UyDzLZanhkugAgft7vt0qbbdt60C6Zf3CAiGmtUCylbtYwrU6loOUw3euGrNtW1J651ot1A==
 
-bytebuffer@~5:
+bytebuffer@^5.0.1, bytebuffer@~5:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/bytebuffer/-/bytebuffer-5.0.1.tgz#582eea4b1a873b6d020a48d58df85f0bba6cfddd"
   integrity sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=
@@ -7234,6 +7247,15 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
+
+cloudant-follow@~0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/cloudant-follow/-/cloudant-follow-0.17.0.tgz#842513a74e72c440e61dc2b6fd96eedbd9cef38a"
+  integrity sha512-JQ1xvKAHh8rsnSVBjATLCjz/vQw1sWBGadxr2H69yFMwD7hShUGDwwEefdypaxroUJ/w6t1cSwilp/hRUxEW8w==
+  dependencies:
+    browser-request "~0.3.0"
+    debug "^3.0.0"
+    request "^2.83.0"
 
 cmd-shim@^4.1.0:
   version "4.1.0"
@@ -8534,7 +8556,7 @@ debug@4, debug@4.3.2, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, de
   dependencies:
     ms "2.1.2"
 
-debug@^3.0.1, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6, debug@^3.2.7:
+debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -8897,7 +8919,7 @@ detect-indent@^6.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
   integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
 
-detect-libc@^1.0.3:
+detect-libc@^1.0.2, detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -9493,6 +9515,11 @@ error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+errs@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/errs/-/errs-0.3.2.tgz#798099b2dbd37ca2bc749e538a7c1307d0b50499"
+  integrity sha1-eYCZstvTfKK8dJ5TinwTB9C1BJk=
 
 es-abstract@^1.18.5, es-abstract@^1.19.0, es-abstract@^1.19.1:
   version "1.19.1"
@@ -10566,6 +10593,18 @@ eyes@0.1.x:
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
   integrity sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=
 
+fabric-ca-client@1.4.18:
+  version "1.4.18"
+  resolved "https://registry.yarnpkg.com/fabric-ca-client/-/fabric-ca-client-1.4.18.tgz#ee9efe0fd4809c6052af19d3a834d6953dbab95a"
+  integrity sha512-OklEHXkY93Z4voT044ZY0le9iqPLHYMvU44oDd7bZxFkgAixEUPwWOGr9VjfDyeQdZlU9I3IMgtiK5V4SK7XeA==
+  dependencies:
+    grpc "1.24.3"
+    jsrsasign "^8.0.20"
+    lodash.clone "4.5.0"
+    url "^0.11.0"
+    util "^0.10.3"
+    winston "^2.4.0"
+
 fabric-ca-client@2.2.10:
   version "2.2.10"
   resolved "https://registry.yarnpkg.com/fabric-ca-client/-/fabric-ca-client-2.2.10.tgz#fa943b14b3d1d3a32bfb187647f005f48212cb56"
@@ -10585,6 +10624,37 @@ fabric-ca-client@2.3.0-snapshot.62:
     jsrsasign "^10.4.1"
     url "^0.11.0"
     winston "^2.4.5"
+
+fabric-client@^1.4.0:
+  version "1.4.18"
+  resolved "https://registry.yarnpkg.com/fabric-client/-/fabric-client-1.4.18.tgz#d124bd57be4763a93478bfdf9231169834cdaf61"
+  integrity sha512-gs3BkGbl+KAeu0H0s108eTXVcOiwJJaZpRcGqZt3DoiC5rwHipVERx/OH+bmZxoL7o8aaUEw8JkA+SmDqCh5BA==
+  dependencies:
+    "@types/bytebuffer" "^5.0.34"
+    bn.js "^4.11.3"
+    bytebuffer "^5.0.1"
+    callsite "^1.0.0"
+    elliptic "^6.5.4"
+    fabric-ca-client "1.4.18"
+    fs-extra "^8.1.0"
+    grpc "1.24.3"
+    ignore-walk "^3.0.0"
+    js-sha3 "^0.7.0"
+    js-yaml "^3.9.0"
+    jsrsasign "^8.0.20"
+    klaw "^2.0.0"
+    lodash.clone "4.5.0"
+    long "^4.0.0"
+    nano "^6.4.4"
+    nconf "^0.10.0"
+    promise-settle "^0.3.0"
+    protobufjs "5.0.3"
+    sjcl "1.0.7"
+    tar-stream "2.1.4"
+    url "^0.11.0"
+    winston "^2.4.0"
+  optionalDependencies:
+    pkcs11js "^1.0.6"
 
 fabric-common@2.2.10:
   version "2.2.10"
@@ -11791,6 +11861,18 @@ grpc@1.24.11:
     nan "^2.13.2"
     protobufjs "^5.0.3"
 
+grpc@1.24.3:
+  version "1.24.3"
+  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.24.3.tgz#92efe28dfc1250dca179b8133e40b4f2341473d9"
+  integrity sha512-EDemzuZTfhM0hgrXqC4PtR76O3t+hTIYJYR5vgiW0yt2WJqo4mhxUqZUirzUQz34Psz7dbLp38C6Cl7Ij2vXRQ==
+  dependencies:
+    "@types/bytebuffer" "^5.0.40"
+    lodash.camelcase "^4.3.0"
+    lodash.clone "^4.5.0"
+    nan "^2.13.2"
+    node-pre-gyp "^0.15.0"
+    protobufjs "^5.0.3"
+
 grpc_tools_node_protoc_ts@5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/grpc_tools_node_protoc_ts/-/grpc_tools_node_protoc_ts-5.3.1.tgz#6f81ab7c8289c801cba3373aa334c13ca8f29618"
@@ -12350,7 +12432,7 @@ ignore-by-default@^1.0.1:
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
   integrity sha1-SMptcvbGo68Aqa1K5odr44ieKwk=
 
-ignore-walk@3.0.4, ignore-walk@^3.0.3:
+ignore-walk@3.0.4, ignore-walk@^3.0.0, ignore-walk@^3.0.1, ignore-walk@^3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.4.tgz#c9a09f69b7c7b479a5d74ac1a3c0d4236d2a6335"
   integrity sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==
@@ -12489,7 +12571,7 @@ ini@2.0.0, ini@^2.0.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
   integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
 
-ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
+ini@^1.3.0, ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
@@ -14206,6 +14288,11 @@ js-sha3@^0.5.7:
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
   integrity sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=
 
+js-sha3@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.7.0.tgz#0a5c57b36f79882573b2d84051f8bb85dd1bd63a"
+  integrity sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA==
+
 js-string-escape@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
@@ -14224,7 +14311,7 @@ js-yaml@3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@3.14.1, js-yaml@^3.13.1:
+js-yaml@3.14.1, js-yaml@^3.13.1, js-yaml@^3.9.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -14471,6 +14558,11 @@ jsrsasign@^10.4.1:
   version "10.5.0"
   resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-10.5.0.tgz#28acf0dbe7565633d306190fd9400c38dd862cb0"
   integrity sha512-AC1kfL1LJASKBLGv4bLLl+auFlsBajOxEcggL7fn8cp7nMRPhyln3LK/Q9lEDCrxYFU35NGUeFtUBCbasoF2Uw==
+
+jsrsasign@^8.0.20:
+  version "8.0.24"
+  resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-8.0.24.tgz#fc26bac45494caac3dd8f69c1f95847c4bda6c83"
+  integrity sha512-u45jAyusqUpyGbFc2IbHoeE4rSkoBWQgLe/w99temHenX+GyCz4nflU5sjK7ajU1ffZTezl6le7u43Yjr/lkQg==
 
 jszip@^3.1.3:
   version "3.7.1"
@@ -14727,6 +14819,13 @@ klaw@^1.0.0:
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
   integrity sha1-QIhDO0azsbolnXh4XY6W9zugJDk=
   optionalDependencies:
+    graceful-fs "^4.1.9"
+
+klaw@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-2.1.1.tgz#42b76894701169cc910fd0d19ce677b5fb378af1"
+  integrity sha1-QrdolHARacyRD9DRnOZ3tfs3ivE=
+  dependencies:
     graceful-fs "^4.1.9"
 
 kleur@^3.0.3:
@@ -15110,7 +15209,7 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
-lodash.clone@^4.5.0:
+lodash.clone@4.5.0, lodash.clone@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
   integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
@@ -15149,6 +15248,11 @@ lodash.isboolean@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
   integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
+lodash.isempty@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
+  integrity sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=
 
 lodash.isequal@^4.5.0:
   version "4.5.0"
@@ -16209,6 +16313,17 @@ nano-json-stream-parser@^0.1.2:
   resolved "https://registry.yarnpkg.com/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz#0cc8f6d0e2b622b479c40d499c46d64b755c6f5f"
   integrity sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=
 
+nano@^6.4.4:
+  version "6.4.4"
+  resolved "https://registry.yarnpkg.com/nano/-/nano-6.4.4.tgz#4902a095e5186cfb23612c78826ea755b76fadf0"
+  integrity sha512-7sldMrZI1ZH8QE29PnzohxLfR67WNVzMKLa7EMl3x9Hr+0G+YpOUCq50qZ9G66APrjcb0Of2BTOZLNBCutZGag==
+  dependencies:
+    cloudant-follow "~0.17.0"
+    debug "^2.2.0"
+    errs "^0.3.2"
+    lodash.isempty "^4.4.0"
+    request "^2.85.0"
+
 nano@^9.0.3:
   version "9.0.5"
   resolved "https://registry.yarnpkg.com/nano/-/nano-9.0.5.tgz#2b767819f612907a3ac09b21f2929d4097407262"
@@ -16277,6 +16392,16 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+nconf@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/nconf/-/nconf-0.10.0.tgz#da1285ee95d0a922ca6cee75adcf861f48205ad2"
+  integrity sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==
+  dependencies:
+    async "^1.4.0"
+    ini "^1.3.0"
+    secure-keys "^1.0.0"
+    yargs "^3.19.0"
+
 nconf@^0.11.2:
   version "0.11.3"
   resolved "https://registry.yarnpkg.com/nconf/-/nconf-0.11.3.tgz#4ee545019c53f1037ca57d696836feede3c49163"
@@ -16287,7 +16412,7 @@ nconf@^0.11.2:
     secure-keys "^1.0.0"
     yargs "^16.1.1"
 
-needle@^2.5.2:
+needle@^2.5.0, needle@^2.5.2:
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.9.1.tgz#22d1dffbe3490c2b83e301f7709b6736cd8f2684"
   integrity sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==
@@ -16463,6 +16588,22 @@ node-polyfill-webpack-plugin@1.1.4:
     util "^0.12.4"
     vm-browserify "^1.1.2"
 
+node-pre-gyp@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz#c2fc383276b74c7ffa842925241553e8b40f1087"
+  integrity sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.3"
+    needle "^2.5.0"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4.4.2"
+
 node-preload@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/node-preload/-/node-preload-0.2.1.tgz#c03043bb327f417a18fee7ab7ee57b408a144301"
@@ -16588,7 +16729,7 @@ normalize-url@^6.0.1, normalize-url@^6.1.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
 
-npm-bundled@^1.1.1:
+npm-bundled@^1.0.1, npm-bundled@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.2.tgz#944c78789bd739035b70baa2ca5cc32b8d860bc1"
   integrity sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==
@@ -16637,6 +16778,15 @@ npm-package-arg@8.1.5, npm-package-arg@^8.0.0, npm-package-arg@^8.0.1, npm-packa
     hosted-git-info "^4.0.1"
     semver "^7.3.4"
     validate-npm-package-name "^3.0.0"
+
+npm-packlist@^1.1.6:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
+  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
+  dependencies:
+    ignore-walk "^3.0.1"
+    npm-bundled "^1.0.1"
+    npm-normalize-package-bin "^1.0.1"
 
 npm-packlist@^2.1.4:
   version "2.2.2"
@@ -16721,7 +16871,7 @@ npm-watch@0.11.0:
     nodemon "^2.0.7"
     through2 "^4.0.2"
 
-npmlog@^4.0.1, npmlog@^4.1.2:
+npmlog@^4.0.1, npmlog@^4.0.2, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -18492,6 +18642,16 @@ proto3-json-serializer@^0.1.1:
   resolved "https://registry.yarnpkg.com/proto3-json-serializer/-/proto3-json-serializer-0.1.5.tgz#c619769a59dc7fd8adf4e6c5060b9bf3039c8304"
   integrity sha512-G395jcZkgNXNeS+6FGqd09TsXeoCs9wmBWByDiwFy7Yd7HD8pyfyvf6q+rGh7PhT4AshRpG4NowzoKYUtkNjKg==
 
+protobufjs@5.0.3, protobufjs@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-5.0.3.tgz#e4dfe9fb67c90b2630d15868249bcc4961467a17"
+  integrity sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==
+  dependencies:
+    ascli "~1"
+    bytebuffer "~5"
+    glob "^7.0.5"
+    yargs "^3.10.0"
+
 protobufjs@6.11.2, protobufjs@^6.10.0, protobufjs@^6.10.2, protobufjs@^6.11.2:
   version "6.11.2"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.2.tgz#de39fabd4ed32beaa08e9bb1e30d08544c1edf8b"
@@ -18510,16 +18670,6 @@ protobufjs@6.11.2, protobufjs@^6.10.0, protobufjs@^6.10.2, protobufjs@^6.11.2:
     "@types/long" "^4.0.1"
     "@types/node" ">=13.7.0"
     long "^4.0.0"
-
-protobufjs@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-5.0.3.tgz#e4dfe9fb67c90b2630d15868249bcc4961467a17"
-  integrity sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==
-  dependencies:
-    ascli "~1"
-    bytebuffer "~5"
-    glob "^7.0.5"
-    yargs "^3.10.0"
 
 protoc-gen-ts@0.6.0:
   version "0.6.0"
@@ -19243,7 +19393,7 @@ request@2.88.0:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
-request@^2.79.0, request@^2.87.0, request@^2.88.0, request@^2.88.2:
+request@^2.79.0, request@^2.83.0, request@^2.85.0, request@^2.87.0, request@^2.88.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -19449,7 +19599,7 @@ rfdc@^1.1.2, rfdc@^1.1.4:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
-rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.3:
+rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -20090,6 +20240,11 @@ sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
+sjcl@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/sjcl/-/sjcl-1.0.7.tgz#32b365a50dc9bba26b88ba3c9df8ea34217d9f45"
+  integrity sha1-MrNlpQ3Ju6JriLo8nfjqNCF9n0U=
 
 sjcl@^1.0.8:
   version "1.0.8"
@@ -21256,6 +21411,17 @@ tar-fs@~2.0.1:
     pump "^3.0.0"
     tar-stream "^2.0.0"
 
+tar-stream@2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.4.tgz#c4fb1a11eb0da29b893a5b25476397ba2d053bfa"
+  integrity sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
 tar-stream@2.2.0, tar-stream@^2.0.0, tar-stream@^2.1.4:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
@@ -21280,7 +21446,7 @@ tar-stream@^1.5.2:
     to-buffer "^1.1.1"
     xtend "^4.0.0"
 
-tar@^4.0.2, tar@^4.4.12:
+tar@^4.0.2, tar@^4.4.12, tar@^4.4.2:
   version "4.4.19"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.19.tgz#2e4d7263df26f2b914dee10c825ab132123742f3"
   integrity sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==
@@ -22352,6 +22518,13 @@ util.promisify@^1.0.1:
     for-each "^0.3.3"
     has-symbols "^1.0.1"
     object.getownpropertydescriptors "^2.1.1"
+
+util@^0.10.3:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
+  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
+  dependencies:
+    inherits "2.0.3"
 
 util@^0.12.0, util@^0.12.4:
   version "0.12.4"
@@ -23630,7 +23803,7 @@ winston-transport@^4.4.0:
     readable-stream "^2.3.7"
     triple-beam "^1.2.0"
 
-winston@^2.4.5:
+winston@^2.4.0, winston@^2.4.5:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/winston/-/winston-2.4.5.tgz#f2e431d56154c4ea765545fc1003bd340c95b59a"
   integrity sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==
@@ -24058,7 +24231,7 @@ yargs@^17.0.0, yargs@^17.1.1:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^3.10.0:
+yargs@^3.10.0, yargs@^3.19.0:
   version "3.32.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.32.0.tgz#03088e9ebf9e756b69751611d2a5ef591482c995"
   integrity sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=


### PR DESCRIPTION
This is kinda a weird PR and I haven't altered _all_ the `try-catch` blocks within this package because some of them didn't show errors with the upgraded TS version. The ones that didn't show errors, I left alone. 


Depends on #1707 
Fixes #1749