### PR TITLE
build(examples): bump log4js from 3.0.6 to 6.4.0

### DIFF
--- a/contribs/Fujitsu-ConnectionChain/connection-chain/environment/base/cc_env/servers/cooperation/coreSide/ec1_adapter/package.json
+++ b/contribs/Fujitsu-ConnectionChain/connection-chain/environment/base/cc_env/servers/cooperation/coreSide/ec1_adapter/package.json
@@ -12,7 +12,7 @@
     "debug": "~4.1.1",
     "express": "~4.15.2",
     "https-proxy-agent": "^2.2.1",
-    "log4js": "^3.0.6",
+    "log4js": "6.4.0",
     "morgan": "~1.9.1",
     "request": "^2.81.0",
     "serve-favicon": "~2.4.2",

--- a/contribs/Fujitsu-ConnectionChain/connection-chain/environment/base/cc_env/servers/cooperation/coreSide/ec2_adapter/package.json
+++ b/contribs/Fujitsu-ConnectionChain/connection-chain/environment/base/cc_env/servers/cooperation/coreSide/ec2_adapter/package.json
@@ -12,7 +12,7 @@
     "debug": "~4.1.1",
     "express": "~4.15.2",
     "https-proxy-agent": "^2.2.1",
-    "log4js": "^3.0.6",
+    "log4js": "6.4.0",
     "morgan": "~1.9.1",
     "request": "^2.81.0",
     "serve-favicon": "~2.4.2",

--- a/contribs/Fujitsu-ConnectionChain/connection-chain/environment/base/cc_env/servers/cooperation/ecSide/ec1_connector/package.json
+++ b/contribs/Fujitsu-ConnectionChain/connection-chain/environment/base/cc_env/servers/cooperation/ecSide/ec1_connector/package.json
@@ -11,7 +11,7 @@
     "cookie-parser": "~1.4.3",
     "debug": "~4.1.1",
     "express": "~4.15.2",
-    "log4js": "^3.0.6",
+    "log4js": "6.4.0",
     "morgan": "~1.9.1",
     "serve-favicon": "~2.4.2",
     "socket.io": "^2.0.4"

--- a/contribs/Fujitsu-ConnectionChain/connection-chain/environment/base/cc_env/servers/cooperation/ecSide/ec2_connector/package.json
+++ b/contribs/Fujitsu-ConnectionChain/connection-chain/environment/base/cc_env/servers/cooperation/ecSide/ec2_connector/package.json
@@ -11,7 +11,7 @@
     "cookie-parser": "~1.4.3",
     "debug": "~4.1.1",
     "express": "~4.15.2",
-    "log4js": "^3.0.6",
+    "log4js": "6.4.0",
     "morgan": "~1.9.1",
     "serve-favicon": "~2.4.2",
     "socket.io": "^2.0.4"

--- a/contribs/Fujitsu-ConnectionChain/connection-chain/environment/base/cc_env/servers/restserver/coreapi/package.json
+++ b/contribs/Fujitsu-ConnectionChain/connection-chain/environment/base/cc_env/servers/restserver/coreapi/package.json
@@ -12,7 +12,7 @@
     "debug": "~4.1.1",
     "express": "~4.15.2",
     "https-proxy-agent": "^2.2.1",
-    "log4js": "^3.0.6",
+    "log4js": "6.4.0",
     "morgan": "~1.9.1",
     "request": "^2.81.0",
     "serve-favicon": "~2.4.2"

--- a/examples/cartrade/package.json
+++ b/examples/cartrade/package.json
@@ -24,7 +24,7 @@
     "fabric-network": "~1.4.0",
     "http-errors": "~1.6.3",
     "jsonwebtoken": "^8.5.1",
-    "log4js": "^3.0.6",
+    "log4js": "6.4.0",
     "morgan": "~1.9.1",
     "shelljs": "^0.8.4",
     "socket.io": "4.1.3",

--- a/examples/cartrade/validatorDriver/package.json
+++ b/examples/cartrade/validatorDriver/package.json
@@ -16,7 +16,7 @@
     "cookie-parser": "~1.4.3",
     "debug": "~4.1.1",
     "express": "~4.15.2",
-    "log4js": "^3.0.6",
+    "log4js": "6.4.0",
     "morgan": "~1.8.1",
     "serve-favicon": "~2.4.2",
     "socket.io": "4.1.3",

--- a/examples/discounted-cartrade/package.json
+++ b/examples/discounted-cartrade/package.json
@@ -26,7 +26,7 @@
     "http-errors": "~1.6.3",
     "indy-sdk": "^1.16.0-dev-1636",
     "jsonwebtoken": "^8.5.1",
-    "log4js": "^3.0.6",
+    "log4js": "6.4.0",
     "morgan": "~1.9.1",
     "shelljs": "^0.8.4",
     "socket.io": "4.1.3",

--- a/examples/discounted-cartrade/validatorDriver/package.json
+++ b/examples/discounted-cartrade/validatorDriver/package.json
@@ -16,7 +16,7 @@
     "cookie-parser": "~1.4.3",
     "debug": "~4.1.1",
     "express": "~4.15.2",
-    "log4js": "^3.0.6",
+    "log4js": "6.4.0",
     "morgan": "~1.8.1",
     "serve-favicon": "~2.4.2",
     "socket.io": "4.1.3",

--- a/examples/electricity-trade/package.json
+++ b/examples/electricity-trade/package.json
@@ -24,7 +24,7 @@
     "fabric-network": "2.2.10",
     "http-errors": "~1.6.3",
     "jsonwebtoken": "^8.5.1",
-    "log4js": "^3.0.6",
+    "log4js": "6.4.0",
     "morgan": "~1.9.1",
     "shelljs": "^0.8.4",
     "socket.io": "4.1.3",

--- a/examples/test-run-transaction/package.json
+++ b/examples/test-run-transaction/package.json
@@ -24,7 +24,7 @@
     "fabric-network": "2.2.10",
     "http-errors": "~1.6.3",
     "jsonwebtoken": "^8.5.1",
-    "log4js": "^3.0.6",
+    "log4js": "6.4.0",
     "morgan": "~1.9.1",
     "shelljs": "^0.8.4",
     "socket.io": "4.1.3",


### PR DESCRIPTION
Update log4js in packages not handled by dependabot

Closes: #1825
Signed-off-by: Michal Bajer <michal.bajer@fujitsu.com>