### PR TITLE
test(api-client): fix flaky verifier-integration-with-openapi-connectors

### DIFF
--- a/packages/cactus-api-client/src/test/typescript/unit/verifier.test.ts
+++ b/packages/cactus-api-client/src/test/typescript/unit/verifier.test.ts
@@ -3,6 +3,8 @@
 
 const testLogLevel: LogLevelDesc = "info";
 const sutLogLevel: LogLevelDesc = "info";
+const testTimeout = 1000 * 5; // 5 second timeout per test
+const setupTimeout = 1000 * 60; // 1 minute timeout for setup
 
 import "jest-extended";
 import { Observable } from "rxjs";
@@ -27,7 +29,7 @@ import {
 // Test Timeout
 //////////////////////////////////
 
-jest.setTimeout(3000);
+jest.setTimeout(testTimeout);
 
 //////////////////////////////////
 // Mocks
@@ -66,7 +68,7 @@ describe("Monitoring Tests", () => {
     );
     sut = new Verifier(apiClientMock, sutLogLevel);
     eventListenerMock = new MockEventListener();
-  });
+  }, setupTimeout);
 
   test("Entry is added to runningMonitors for new monitoring requests", () => {
     const monitorOptions = { test: true };

--- a/packages/cactus-test-api-client/src/test/typescript/integration/verifier-integration-with-openapi-connectors.test.ts
+++ b/packages/cactus-test-api-client/src/test/typescript/integration/verifier-integration-with-openapi-connectors.test.ts
@@ -52,12 +52,6 @@ const log: Logger = LoggerProvider.getOrCreate({
 });
 log.info("Test started");
 
-//////////////////////////////////
-// Test Timeout (default)
-//////////////////////////////////
-
-jest.setTimeout(15 * 1000); // 10 seconds (per test)
-
 describe("Verifier integration with openapi connectors tests", () => {
   let besuTestLedger: BesuTestLedger;
   let server: http.Server;
@@ -146,17 +140,19 @@ describe("Verifier integration with openapi connectors tests", () => {
       basePath: apiHost,
     });
     apiClient = new BesuApiClient(besuApiClientOptions);
-  }, 60 * 1000); // 60s timeout
+  });
 
   afterAll(async () => {
     log.info("Shutdown the server...");
-    await Servers.shutdown(server);
+    if (server) {
+      await Servers.shutdown(server);
+    }
     log.info("Stop and destroy the test ledger...");
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
     log.info("Prune docker...");
     await pruneDockerAllIfGithubAction({ logLevel: testLogLevel });
-  }, 60 * 1000); // 60s timeout
+  });
 
   //////////////////////////////////
   // Functional Tests


### PR DESCRIPTION
Use global jest timeout for verifier-integration-with-openapi-connectors
functional test. It's 60 minutes at the moment, should be enough for
docker based test. Increase timeout in verifier unit test to handle
possible failures.

Closes: #1827
Signed-off-by: Michal Bajer <michal.bajer@fujitsu.com>