### PR TITLE
refactor(cartrade): upgrade cartrade samples to fabric 2.2 

### DIFF
--- a/examples/cartrade/README.md
+++ b/examples/cartrade/README.md
@@ -39,7 +39,7 @@ Cactus **car-trade** is a sample application where users can exchange car owners
     - (NOTICE: Before executing the above, your account needs to be added to the docker group (`usermod -a -G docker YourAccount` from root user))
     - On success, this should start two containers:
         - `geth1`
-        - `cartrade_faio14x_testnet`
+        - `cartrade_faio2x_testnet`
 
 1. Build cartrade:
     ```
@@ -149,5 +149,5 @@ Cactus **car-trade** is a sample application where users can exchange car owners
     sudo rm -r ./etc/cactus/
     ```
 1. Stop the docker containers of Ethereum and Fabric
-    - `docker stop geth1 cartrade_faio14x_testnet`
-    - `docker rm geth1 cartrade_faio14x_testnet`
+    - `docker stop geth1 cartrade_faio2x_testnet`
+    - `docker rm geth1 cartrade_faio2x_testnet`

--- a/examples/cartrade/config/default.yaml
+++ b/examples/cartrade/config/default.yaml
@@ -3,7 +3,7 @@ cartradeInfo:
     validatorID: r9IS4dDf
     mspID: Org1MSP
     keystore: "/etc/cactus/fabric/wallet"
-    connUserName: user1
+    connUserName: appUser
     contractName: fabcar
     peers:
       -

--- a/examples/cartrade/docker-compose.yml
+++ b/examples/cartrade/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - ./etc/cactus:/etc/cactus
     networks:
-      - fabric-all-in-one_testnet-14
+      - fabric-all-in-one_testnet-2x
       - cartrade-net
   ethereum-validator:
     container_name: cartrade-ethereum-validator
@@ -54,7 +54,7 @@ services:
           target: /etc/cactus
 
 networks:
-  fabric-all-in-one_testnet-14:
+  fabric-all-in-one_testnet-2x:
     external: true
   geth1net:
     external: true

--- a/examples/cartrade/script-get-app.sh
+++ b/examples/cartrade/script-get-app.sh
@@ -2,6 +2,8 @@
 # Copyright 2020-2021 Hyperledger Cactus Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+export CACTUS_FABRIC_ALL_IN_ONE_CONTAINER_NAME="cartrade_faio2x_testnet"
+
 ## Execute a getting app
 echo "[process] Execute an app for getting Balance on Ethereum"
 pushd ../../tools/docker/geth-testnet/get-eth-balance

--- a/examples/cartrade/script-start-ledgers.sh
+++ b/examples/cartrade/script-start-ledgers.sh
@@ -9,16 +9,18 @@ WAIT_TIME=30 # How often to check container status
 CONFIG_VOLUME_PATH="./etc/cactus" # Docker volume with shared configuration
 
 # Fabric Env Variables
-export CACTUS_FABRIC_ALL_IN_ONE_CONTAINER_NAME="cartrade_faio14x_testnet"
-export CACTUS_FABRIC_TEST_LOOSE_MEMBERSHIP=1 # Loose membership check required for cartrade
+export CACTUS_FABRIC_ALL_IN_ONE_CONTAINER_NAME="cartrade_faio2x_testnet"
+export CACTUS_FABRIC_ALL_IN_ONE_VERSION="2.2.0"
+export CACTUS_FABRIC_ALL_IN_ONE_CHAINCODE="fabcar"
+export CACTUS_FABRIC_TEST_LOOSE_MEMBERSHIP=1
 
 function start_fabric_testnet() {
     echo ">> start_fabric_testnet()"
     pushd "${ROOT_DIR}/tools/docker/fabric-all-in-one"
 
-    echo ">> Start Fabric 1.4 FabCar..."
-    docker-compose -f ./docker-compose-v1.4.yml build
-    docker-compose -f ./docker-compose-v1.4.yml up -d
+    echo ">> Start Fabric ${CACTUS_FABRIC_ALL_IN_ONE_VERSION} FabCar..."
+    docker-compose -f ./docker-compose-v2.x.yml build
+    docker-compose -f ./docker-compose-v2.x.yml up -d
     sleep 1
 
     # Wait for fabric cotnainer to become healthy
@@ -29,9 +31,9 @@ function start_fabric_testnet() {
         sleep $WAIT_TIME
         health_status="$(docker inspect -f '{{.State.Health.Status}}' ${CACTUS_FABRIC_ALL_IN_ONE_CONTAINER_NAME})"
     done
-    echo ">> Fabric 1.4 FabCar started."
+    echo ">> Fabric ${CACTUS_FABRIC_ALL_IN_ONE_VERSION} FabCar started."
 
-    echo ">> Register admin and user1..."
+    echo ">> Register admin and appUser..."
     pushd fabcar-cli-1.4
     ./setup.sh
     popd
@@ -44,7 +46,7 @@ function start_fabric_testnet() {
 function copy_fabric_tlsca() {
     echo ">> copy_fabric_tlsca()"
     mkdir -p "${CONFIG_VOLUME_PATH}/fabric"
-    docker cp "${CACTUS_FABRIC_ALL_IN_ONE_CONTAINER_NAME}:/fabric-samples/first-network/crypto-config/" "${CONFIG_VOLUME_PATH}/fabric/"
+    docker cp "${CACTUS_FABRIC_ALL_IN_ONE_CONTAINER_NAME}:/fabric-samples/test-network/organizations/" "${CONFIG_VOLUME_PATH}/fabric/crypto-config/"
     echo ">> copy_fabric_tlsca() done."
 }
 
@@ -62,8 +64,8 @@ function start_ethereum_testnet() {
 
 function start_ledgers() {
     # Clear ./etc/cactus
-    mkdir -p "${CONFIG_VOLUME_PATH}/"
-    rm -fr "${CONFIG_VOLUME_PATH}/*"
+    mkdir -p ${CONFIG_VOLUME_PATH}/
+    rm -fr ${CONFIG_VOLUME_PATH}/*
 
     # Copy cmd-socketio-config
     cp -f ./config/*.yaml "${CONFIG_VOLUME_PATH}/"

--- a/examples/discounted-cartrade/README.md
+++ b/examples/discounted-cartrade/README.md
@@ -84,9 +84,9 @@ Alice will use credentials and other Indy formats such as schema and definition 
     ```
     - This script will start all ledger docker containers, networks, and will setup configuration needed to operate the sample app.
     - (NOTICE: Before executing the above, your account needs to be added to the docker group (`usermod -a -G docker YourAccount` from root user))
-    - On success, this should start two containers:
+    - On success, this should start three containers:
         - `geth1`
-        - `discounted_cartrade_faio14x_testnet`
+        - `discounted_cartrade_faio2x_testnet`
         - `indy-testnet-pool`
 
 1. Build cartrade:
@@ -200,8 +200,8 @@ Alice will use credentials and other Indy formats such as schema and definition 
     sudo rm -r ./etc/cactus/
     ```
 1. Stop the docker containers of Ethereum and Fabric
-    - `docker stop geth1 cartrade_faio14x_testnet`
-    - `docker rm geth1 cartrade_faio14x_testnet`
+    - `docker stop geth1 cartrade_faio2x_testnet`
+    - `docker rm geth1 cartrade_faio2x_testnet`
     - `docker rm geth1 indy-testnet-pool`
 
 1. Clear indy testnet sandbox

--- a/examples/discounted-cartrade/config/default.yaml
+++ b/examples/discounted-cartrade/config/default.yaml
@@ -3,7 +3,7 @@ cartradeInfo:
     validatorID: r9IS4dDf
     mspID: Org1MSP
     keystore: "/etc/cactus/fabric/wallet"
-    connUserName: user1
+    connUserName: appUser
     contractName: fabcar
     peers:
       -

--- a/examples/discounted-cartrade/docker-compose.yml
+++ b/examples/discounted-cartrade/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - ./etc/cactus:/etc/cactus
     networks:
-      - fabric-all-in-one_testnet-14
+      - fabric-all-in-one_testnet-2x
       - discounted-cartrade-net
 
   ethereum-validator:
@@ -113,7 +113,7 @@ services:
     command: [ "--proof_only" ]
 
 networks:
-  fabric-all-in-one_testnet-14:
+  fabric-all-in-one_testnet-2x:
     external: true
   geth1net:
     external: true

--- a/packages/cactus-plugin-ledger-connector-fabric-socketio/src/main/typescript/connector/PluginConfig.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric-socketio/src/main/typescript/connector/PluginConfig.ts
@@ -15,25 +15,25 @@ export const SplugConfig = {
   fabric: {
     mspid: "Org1MSP",
     keystore: "/etc/cactus/fabric/wallet",
-    connUserName: "user1",
+    connUserName: "appUser",
     contractName: "fabcar",
     peers: [
       {
         name: "peer0.org1.example.com",
-        requests: "grpcs://cartrade_faio14x_testnet:7051",
+        requests: "grpcs://cartrade_faio2x_testnet:7051",
         tlsca:
           "/etc/cactus/fabric/crypto-config/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem",
       },
     ],
     orderer: {
       name: "orderer.example.com",
-      url: "grpcs://cartrade_faio14x_testnet:7050",
+      url: "grpcs://cartrade_faio2x_testnet:7050",
       tlsca:
-        "/etc/cactus/fabric/crypto-config/ordererOrganizations/example.com/tlsca/tlsca.example.com-cert.pem",
+        "/etc/cactus/fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem",
     },
     ca: {
       name: "ca-org1",
-      url: "https://cartrade_faio14x_testnet:7054",
+      url: "https://cartrade_faio2x_testnet:7054",
     },
     submitter: {
       name: "admin",

--- a/tools/docker/fabric-all-in-one/docker-compose-v2.x.yml
+++ b/tools/docker/fabric-all-in-one/docker-compose-v2.x.yml
@@ -1,0 +1,26 @@
+version: "3"
+
+services:
+  fabric-all-in-one-testnet-2x:
+    container_name: ${CACTUS_FABRIC_ALL_IN_ONE_CONTAINER_NAME:-fabric_all_in_one_testnet_2x}
+    image: ${CACTUS_FABRIC_ALL_IN_ONE_IMAGE_NAME:-faio2x}
+    privileged: true
+    build:
+      context: ./
+      dockerfile: Dockerfile_v2.x
+    ports:
+        - "4022:22"   # SSH
+        - "7051:7051" # peer0.org1.example.com
+        - "8051:8051" # peer1.org1.example.com
+        - "7054:7054" # ca.org1.example.com
+        - "7050:7050" # orderer.example.com
+    environment:
+      - FABRIC_VERSION=${CACTUS_FABRIC_ALL_IN_ONE_VERSION:-2.2.0}
+      - FABRIC_CHAINCODE=${CACTUS_FABRIC_ALL_IN_ONE_CHAINCODE:-fabcar}
+      - CACTUS_FABRIC_TEST_LOOSE_MEMBERSHIP=1
+    networks:
+       - testnet-2x
+
+networks:
+  testnet-2x:
+    driver: bridge

--- a/tools/docker/fabric-all-in-one/fabcar-cli-1.4/README.md
+++ b/tools/docker/fabric-all-in-one/fabcar-cli-1.4/README.md
@@ -8,9 +8,9 @@ Sources come from official fabric-samples 1.4.8 - https://github.com/hyperledger
 ### Setup
  - Run `npm install`
  - Run `./setup.sh` before using any other script from this directory.
- - Setup will copy `connection-org1.json` to `./connection.json`, and will deploy `admin` and `user1`. Wallet can later be used by other applications (sample apps, for instance)
+ - Setup will copy `connection-org1.json` to `./connection.json`, and will deploy `admin` and `appUser`. Wallet can later be used by other applications (sample apps, for instance)
 
 ### Scripts
  - `enrollAdmin.js` - Will enrol `admin` and store it in the wallet.
- - `registerUser.js` - Will register `user1` and store it in the wallet.
+ - `registerUser.js` - Will register `appUser` and store it in the wallet.
  - `query.js` - Will run `queryAllCars` on the fabric, all cars will be printed in verbose (formatted) way.

--- a/tools/docker/fabric-all-in-one/fabcar-cli-1.4/query.js
+++ b/tools/docker/fabric-all-in-one/fabcar-cli-1.4/query.js
@@ -19,10 +19,10 @@ async function main() {
     console.log(`Wallet path: ${walletPath}`);
 
     // Check to see if we've already enrolled the user.
-    const userExists = await wallet.exists("user1");
+    const userExists = await wallet.exists("appUser");
     if (!userExists) {
       console.log(
-        'An identity for the user "user1" does not exist in the wallet',
+        'An identity for the user "appUser" does not exist in the wallet',
       );
       console.log("Run the registerUser.js application before retrying");
       // EDIT - Return error code when identity is missing
@@ -33,7 +33,7 @@ async function main() {
     const gateway = new Gateway();
     await gateway.connect(ccpPath, {
       wallet,
-      identity: "user1",
+      identity: "appUser",
       discovery: { enabled: true, asLocalhost: true },
     });
 

--- a/tools/docker/fabric-all-in-one/fabcar-cli-1.4/registerUser.js
+++ b/tools/docker/fabric-all-in-one/fabcar-cli-1.4/registerUser.js
@@ -23,10 +23,10 @@ async function main() {
     console.log(`Wallet path: ${walletPath}`);
 
     // Check to see if we've already enrolled the user.
-    const userExists = await wallet.exists("user1");
+    const userExists = await wallet.exists("appUser");
     if (userExists) {
       console.log(
-        'An identity for the user "user1" already exists in the wallet',
+        'An identity for the user "appUser" already exists in the wallet',
       );
       return;
     }
@@ -57,13 +57,13 @@ async function main() {
     const secret = await ca.register(
       {
         affiliation: "org1.department1",
-        enrollmentID: "user1",
+        enrollmentID: "appUser",
         role: "client",
       },
       adminIdentity,
     );
     const enrollment = await ca.enroll({
-      enrollmentID: "user1",
+      enrollmentID: "appUser",
       enrollmentSecret: secret,
     });
     const userIdentity = X509WalletMixin.createIdentity(
@@ -71,12 +71,12 @@ async function main() {
       enrollment.certificate,
       enrollment.key.toBytes(),
     );
-    await wallet.import("user1", userIdentity);
+    await wallet.import("appUser", userIdentity);
     console.log(
-      'Successfully registered and enrolled admin user "user1" and imported it into the wallet',
+      'Successfully registered and enrolled admin user "appUser" and imported it into the wallet',
     );
   } catch (error) {
-    console.error(`Failed to register user "user1": ${error}`);
+    console.error(`Failed to register user "appUser": ${error}`);
     process.exit(1);
   }
 }

--- a/tools/docker/fabric-all-in-one/fabcar-cli-1.4/setup.sh
+++ b/tools/docker/fabric-all-in-one/fabcar-cli-1.4/setup.sh
@@ -5,7 +5,7 @@
 # Exit on error
 set -e
 
-FABRIC_CONTAINER_NAME=${CACTUS_FABRIC_ALL_IN_ONE_CONTAINER_NAME:-cartrade_faio14x_testnet}
+FABRIC_CONTAINER_NAME=${CACTUS_FABRIC_ALL_IN_ONE_CONTAINER_NAME:-cartrade_faio2x_testnet}
 
 if ! [ "$(docker inspect -f '{{.State.Running}}' ${FABRIC_CONTAINER_NAME})" == "true" ]
 then
@@ -16,7 +16,7 @@ fi
 echo "Copy FabCar connection info from container to local storage"
 echo "*********************************"
 rm -fr ./connection.json
-docker cp ${FABRIC_CONTAINER_NAME}:/fabric-samples/first-network/connection-org1.json ./connection.json
+docker cp ${FABRIC_CONTAINER_NAME}:/fabric-samples/test-network/organizations/peerOrganizations/org1.example.com/connection-org1.json ./connection.json
 echo "Done!"
 
 if node ./query.js &> /dev/null
@@ -28,7 +28,7 @@ fi
 echo "Could not query the ledger with current wallet - clear it"
 rm -rf ./wallet/*
 
-echo -e "\nEnroll admin and user1"
+echo -e "\nEnroll admin and appUser"
 echo "*********************************"
 node ./enrollAdmin.js
 node ./registerUser.js

--- a/tools/docker/fabric-all-in-one/healthcheck.sh
+++ b/tools/docker/fabric-all-in-one/healthcheck.sh
@@ -17,7 +17,13 @@ function main()
   if [ "$MAJOR" -gt 1 ]; then
     # Major version is 2 or newer (we'll deal with 3.x when it is released)
     cd /fabric-samples/test-network/
-    peer chaincode invoke -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile "${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem" -C mychannel -n basic --peerAddresses localhost:7051 --tlsRootCertFiles "${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt" --peerAddresses localhost:9051 --tlsRootCertFiles "${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt" -c '{"function":"InitLedger","Args":[]}'
+
+    if [ "${FABRIC_CHAINCODE}" == "fabcar" ]; then
+      peer chaincode query -C mychannel -n fabcar -c '{"Args": [], "Function": "queryAllCars"}'
+    else
+      # default: asset-transfer-basic
+      peer chaincode invoke -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile "${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem" -C mychannel -n basic --peerAddresses localhost:7051 --tlsRootCertFiles "${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt" --peerAddresses localhost:9051 --tlsRootCertFiles "${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt" -c '{"function":"InitLedger","Args":[]}'
+    fi
   else
     # Major version is 1.x or earlier (assumption is 1.4.x only)
     docker exec cli peer chaincode query --channelID mychannel --name fabcar --ctor '{"Args": [], "Function": "queryAllCars"}'

--- a/tools/docker/fabric-all-in-one/run-fabric-network.sh
+++ b/tools/docker/fabric-all-in-one/run-fabric-network.sh
@@ -36,13 +36,30 @@ function main()
 
     /bootstrap.sh ${FABRIC_VERSION} ${CA_VERSION} -b -s
 
-    cd /fabric-samples/test-network/
-    echo "[FabricAIO] >>> pulling up test network..."
-    ./network.sh up -ca
-    echo "[FabricAIO] >>> test network pulled up OK."
-    ./network.sh createChannel -c mychannel
-    echo "[FabricAIO] >>> channel created OK."
-    ./network.sh deployCC -ccn basic -ccp ../asset-transfer-basic/chaincode-go -ccl go
+    # Deploy chaincode
+    if [ "${FABRIC_CHAINCODE}" == "fabcar" ]; then
+      echo "[FabricAIO] >>> Deploy fabcar..."
+      cd /fabric-samples/fabcar/
+
+      if [ -n "$CACTUS_FABRIC_TEST_LOOSE_MEMBERSHIP" ]; then
+        # This will change endorsment policy on fabcar chaincode.
+        # cartrade sample supports only single peer endorsment at the moment.
+        echo "[FabricAIO] >>> PATCH - Changing to loose endorsment policy."
+        sed -i "s/deployCC/deployCC -ccep \"OR('Org1MSP.member','Org2MSP.member')\"/g" ./startFabric.sh
+      fi
+
+      ./startFabric.sh
+    else
+      echo "[FabricAIO] >>> Deploy asset-transfer-basic..."
+      cd /fabric-samples/test-network/
+      echo "[FabricAIO] >>> pulling up test network..."
+      ./network.sh up -ca
+      echo "[FabricAIO] >>> test network pulled up OK."
+      ./network.sh createChannel -c mychannel
+      echo "[FabricAIO] >>> channel created OK."
+      ./network.sh deployCC -ccn basic -ccp ../asset-transfer-basic/chaincode-go -ccl go
+    fi
+
     echo "[FabricAIO] >>> contract deployed OK."
     echo "[FabricAIO] >>> container healthcheck should begin passing in about 5-15 seconds..."
   else


### PR DESCRIPTION
Add fabcar setup to fabric 2.x all-in-one startup script and adjust
healthcheck accordingly. Use fabric 2.x in cartrade and discounted
cartrade sample apps. No packages updated, fabric sdk 1.4.19 seems to
work fine with fabric 2.2 for now. Both samples has been tested and work
OK.

Closes: https://github.com/hyperledger/cactus/issues/1842
Signed-off-by: Michal Bajer <michal.bajer@fujitsu.com>

### Note: 
- Next step is to use basic asset transfer instead of depracated fabcar, so fabcar-cli-1.4 will be removed in the future (most probably).
- Upgrade of SDK seems to be complex task for now (since packages were re-organized), I think it'd be better to just focus on migration to common fabric connector.

Depends on #1824