### PR TITLE
chore: fix licenses

### DIFF
--- a/examples/test-run-transaction/supply-chain-app-stub/package.json
+++ b/examples/test-run-transaction/supply-chain-app-stub/package.json
@@ -24,5 +24,5 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
These files are auto-generated with ISC as
the default licese. Switched to Apache 2

Signed-off-by: Ry Jones <ry@linux.com>