### PR TITLE
refactor: migrate to jest and fix neg test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1051,7 +1051,7 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
-      TAPE_TEST_PATTERN: '--files={./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-single-status-endpoint.test.ts,./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/openapi/openapi-validation.test.ts,./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/withdraw-endpoint-invalid.test.ts}'
+      TAPE_TEST_PATTERN: '--files={./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-single-status-endpoint.test.ts,./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/openapi/openapi-validation.test.ts}'
       TAPE_TEST_RUNNER_DISABLED: false
     needs: build-dev
     runs-on: ubuntu-20.04

--- a/.taprc
+++ b/.taprc
@@ -113,7 +113,6 @@ files:
   - ./packages/cactus-test-tooling/src/test/typescript/integration/common/containers.test.ts
   - ./packages/cactus-test-tooling/src/test/typescript/integration/besu/besu-test-ledger/constructor-validates-options.test.ts
   - ./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-single-status-endpoint.test.ts
-  - ./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/withdraw-endpoint-invalid.test.ts
   - ./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/openapi/openapi-validation.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/benchmark/artillery-api-benchmark.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-socketio-endpoint-authorization.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -119,7 +119,6 @@ module.exports = {
     `./packages/cactus-test-tooling/src/test/typescript/integration/besu/besu-test-ledger/constructor-validates-options.test.ts`,
     `./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-single-status-endpoint.test.ts`,
     `./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get--status-endpoint-invalid.test.ts`,
-    `./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/withdraw-endpoint-invalid.test.ts`,
     `./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/openapi/openapi-validation.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/benchmark/artillery-api-benchmark.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-socketio-endpoint-authorization.test.ts`,

--- a/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/withdraw-endpoint-invalid.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/withdraw-endpoint-invalid.test.ts
@@ -1,6 +1,6 @@
 import http from "http";
 import type { AddressInfo } from "net";
-import test, { Test } from "tape-promise/tape";
+import "jest-extended";
 import { v4 as uuidv4 } from "uuid";
 import express from "express";
 import bodyParser from "body-parser";
@@ -41,78 +41,8 @@ const logLevel: LogLevelDesc = "INFO";
 
 const testCase = "Test invalid withdraw";
 
-test("BEFORE " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
-  t.end();
-});
-
-test(testCase, async (t: Test) => {
-  t.comment("Starting Besu Test Ledger");
+describe(testCase, () => {
   const besuTestLedger = new BesuTestLedger({ logLevel });
-
-  test.onFinish(async () => {
-    await besuTestLedger.stop();
-    await besuTestLedger.destroy();
-    await pruneDockerAllIfGithubAction({ logLevel });
-  });
-
-  await besuTestLedger.start();
-
-  const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
-  const rpcApiWsHost = await besuTestLedger.getRpcApiWsHost();
-  const firstHighNetWorthAccount = besuTestLedger.getGenesisAccountPubKey();
-  const privateKey = besuTestLedger.getGenesisAccountPrivKey();
-  const web3SigningCredential: Web3SigningCredential = {
-    ethAccount: firstHighNetWorthAccount,
-    secret: privateKey,
-    type: Web3SigningCredentialType.PrivateKeyHex,
-  } as Web3SigningCredential;
-
-  const keychainId = uuidv4();
-  const keychainPlugin = new PluginKeychainMemory({
-    instanceId: uuidv4(),
-    keychainId,
-    // pre-provision keychain with mock backend holding the private key of the
-    // test account that we'll reference while sending requests with the
-    // signing credential pointing to this keychain entry.
-    backend: new Map([
-      [DemoHelperJSON.contractName, JSON.stringify(DemoHelperJSON)],
-    ]),
-    logLevel,
-  });
-  keychainPlugin.set(
-    HashTimeLockJSON.contractName,
-    JSON.stringify(HashTimeLockJSON),
-  );
-
-  const factory = new PluginFactoryLedgerConnector({
-    pluginImportType: PluginImportType.Local,
-  });
-
-  const pluginRegistry = new PluginRegistry({});
-  const connector: PluginLedgerConnectorBesu = await factory.create({
-    rpcApiHttpHost,
-    rpcApiWsHost,
-    logLevel,
-    instanceId: connectorId,
-    pluginRegistry: new PluginRegistry({ plugins: [keychainPlugin] }),
-  });
-
-  pluginRegistry.add(connector);
-  const pluginOptions: IPluginHtlcEthBesuOptions = {
-    logLevel,
-    instanceId: uuidv4(),
-    pluginRegistry,
-  };
-
-  const factoryHTLC = new PluginFactoryHtlcEthBesu({
-    pluginImportType: PluginImportType.Local,
-  });
-
-  const pluginHtlc = await factoryHTLC.create(pluginOptions);
-  pluginRegistry.add(pluginHtlc);
-
   const expressApp = express();
   expressApp.use(bodyParser.json({ limit: "250mb" }));
   const server = http.createServer(expressApp);
@@ -121,94 +51,148 @@ test(testCase, async (t: Test) => {
     port: 0,
     server,
   };
-  const addressInfo = (await Servers.listen(listenOptions)) as AddressInfo;
-  test.onFinish(async () => await Servers.shutdown(server));
-  const { address, port } = addressInfo;
-  const apiHost = `http://${address}:${port}`;
-
-  const configuration = new Configuration({ basePath: apiHost });
-  const api = new BesuApi(configuration);
-
-  await pluginHtlc.getOrCreateWebServices();
-  await pluginHtlc.registerWebServices(expressApp);
-
-  t.comment("Deploys HashTimeLock via .json file on initialize function");
-  const initRequest: InitializeRequest = {
-    connectorId,
-    keychainId,
-    constructorArgs: [],
-    web3SigningCredential,
-    gas: DataTest.estimated_gas,
-  };
-  const deployOut = await pluginHtlc.initialize(initRequest);
-  t.ok(
-    deployOut.transactionReceipt,
-    "pluginHtlc.initialize() output.transactionReceipt is truthy OK",
-  );
-  t.ok(
-    deployOut.transactionReceipt.contractAddress,
-    "pluginHtlc.initialize() output.transactionReceipt.contractAddress is truthy OK",
-  );
-  const hashTimeLockAddress = deployOut.transactionReceipt
-    .contractAddress as string;
-
-  //Deploy DemoHelpers
-  t.comment("Deploys DemoHelpers via .json file on deployContract function");
-  const deployOutDemo = await connector.deployContract({
-    contractName: DemoHelperJSON.contractName,
-    contractAbi: DemoHelperJSON.abi,
-    bytecode: DemoHelperJSON.bytecode,
-    web3SigningCredential,
-    keychainId,
-    constructorArgs: [],
-    gas: DataTest.estimated_gas,
-  });
-  t.ok(deployOutDemo, "deployContract() output is truthy OK");
-  t.ok(
-    deployOutDemo.transactionReceipt,
-    "deployContract() output.transactionReceipt is truthy OK",
-  );
-  t.ok(
-    deployOutDemo.transactionReceipt.contractAddress,
-    "deployContract() output.transactionReceipt.contractAddress is truthy OK",
-  );
-
-  t.comment("Create new contract for HTLC");
-  const bodyObj: NewContractObj = {
-    contractAddress: hashTimeLockAddress,
-    inputAmount: 10,
-    outputAmount: 0x04,
-    expiration: DataTest.expiration,
-    hashLock: DataTest.hashLock,
-    receiver: DataTest.receiver,
-    outputNetwork: "BTC",
-    outputAddress: "1AcVYm7M3kkJQH28FXAvyBFQzFRL6xPKu8",
-    connectorId: connectorId,
-    web3SigningCredential,
-    keychainId,
-    gas: DataTest.estimated_gas,
-  };
-  const resp = await api.newContractV1(bodyObj);
-  t.ok(resp, "response newContract is OK");
-  t.equal(resp.status, 200, "response status newContract is OK");
-
-  const { callOutput } = await connector.invokeContract({
-    contractName: DemoHelperJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "getTxId",
-    params: [
-      firstHighNetWorthAccount,
-      DataTest.receiver,
-      10,
-      DataTest.hashLock,
-      DataTest.expiration,
-    ],
+  beforeAll(async () => {
+    const pruning = pruneDockerAllIfGithubAction({ logLevel });
+    await expect(pruning).resolves.toBeTruthy();
   });
 
-  t.comment("Withdraw");
-  try {
+  afterAll(async () => {
+    await besuTestLedger.stop();
+    await besuTestLedger.destroy();
+    await pruneDockerAllIfGithubAction({ logLevel });
+  });
+
+  beforeAll(async () => {
+    await besuTestLedger.start();
+  });
+
+  afterAll(async () => await Servers.shutdown(server));
+
+  test(testCase, async () => {
+    const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
+    const rpcApiWsHost = await besuTestLedger.getRpcApiWsHost();
+    const firstHighNetWorthAccount = besuTestLedger.getGenesisAccountPubKey();
+    const privateKey = besuTestLedger.getGenesisAccountPrivKey();
+    const web3SigningCredential: Web3SigningCredential = {
+      ethAccount: firstHighNetWorthAccount,
+      secret: privateKey,
+      type: Web3SigningCredentialType.PrivateKeyHex,
+    } as Web3SigningCredential;
+
+    const keychainId = uuidv4();
+    const keychainPlugin = new PluginKeychainMemory({
+      instanceId: uuidv4(),
+      keychainId,
+      // pre-provision keychain with mock backend holding the private key of the
+      // test account that we'll reference while sending requests with the
+      // signing credential pointing to this keychain entry.
+      backend: new Map([
+        [DemoHelperJSON.contractName, JSON.stringify(DemoHelperJSON)],
+      ]),
+      logLevel,
+    });
+    keychainPlugin.set(
+      HashTimeLockJSON.contractName,
+      JSON.stringify(HashTimeLockJSON),
+    );
+
+    const factory = new PluginFactoryLedgerConnector({
+      pluginImportType: PluginImportType.Local,
+    });
+
+    const pluginRegistry = new PluginRegistry({});
+    const connector: PluginLedgerConnectorBesu = await factory.create({
+      rpcApiHttpHost,
+      rpcApiWsHost,
+      logLevel,
+      instanceId: connectorId,
+      pluginRegistry: new PluginRegistry({ plugins: [keychainPlugin] }),
+    });
+
+    pluginRegistry.add(connector);
+    const pluginOptions: IPluginHtlcEthBesuOptions = {
+      logLevel,
+      instanceId: uuidv4(),
+      pluginRegistry,
+    };
+
+    const factoryHTLC = new PluginFactoryHtlcEthBesu({
+      pluginImportType: PluginImportType.Local,
+    });
+
+    const pluginHtlc = await factoryHTLC.create(pluginOptions);
+    pluginRegistry.add(pluginHtlc);
+
+    const addressInfo = (await Servers.listen(listenOptions)) as AddressInfo;
+    const { address, port } = addressInfo;
+    const apiHost = `http://${address}:${port}`;
+
+    const configuration = new Configuration({ basePath: apiHost });
+    const api = new BesuApi(configuration);
+
+    await pluginHtlc.getOrCreateWebServices();
+    await pluginHtlc.registerWebServices(expressApp);
+
+    const initRequest: InitializeRequest = {
+      connectorId,
+      keychainId,
+      constructorArgs: [],
+      web3SigningCredential,
+      gas: DataTest.estimated_gas,
+    };
+    const deployOut = await pluginHtlc.initialize(initRequest);
+    expect(deployOut.transactionReceipt).toBeTruthy();
+    expect(deployOut.transactionReceipt.contractAddress).toBeTruthy();
+    const hashTimeLockAddress = deployOut.transactionReceipt
+      .contractAddress as string;
+
+    //Deploy DemoHelpers
+    const deployOutDemo = await connector.deployContract({
+      contractName: DemoHelperJSON.contractName,
+      contractAbi: DemoHelperJSON.abi,
+      bytecode: DemoHelperJSON.bytecode,
+      web3SigningCredential,
+      keychainId,
+      constructorArgs: [],
+      gas: DataTest.estimated_gas,
+    });
+    expect(deployOutDemo).toBeTruthy();
+    expect(deployOutDemo.transactionReceipt).toBeTruthy();
+    expect(deployOutDemo.transactionReceipt.contractAddress).toBeTruthy();
+
+    const bodyObj: NewContractObj = {
+      contractAddress: hashTimeLockAddress,
+      inputAmount: 10,
+      outputAmount: 0x04,
+      expiration: DataTest.expiration,
+      hashLock: DataTest.hashLock,
+      receiver: DataTest.receiver,
+      outputNetwork: "BTC",
+      outputAddress: "1AcVYm7M3kkJQH28FXAvyBFQzFRL6xPKu8",
+      connectorId: connectorId,
+      web3SigningCredential,
+      keychainId,
+      gas: DataTest.estimated_gas,
+    };
+    const resp = await api.newContractV1(bodyObj);
+    expect(resp).toBeTruthy();
+    expect(resp.status).toEqual(200);
+
+    const { callOutput } = await connector.invokeContract({
+      contractName: DemoHelperJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "getTxId",
+      params: [
+        firstHighNetWorthAccount,
+        DataTest.receiver,
+        10,
+        DataTest.hashLock,
+        DataTest.expiration,
+      ],
+    });
+
     const bodyWithdraw: WithdrawReq = {
       id: callOutput,
       secret:
@@ -217,11 +201,7 @@ test(testCase, async (t: Test) => {
       connectorId,
       keychainId: "",
     };
-    const res = await api.withdrawV1(bodyWithdraw);
-
-    t.equal(res.status, 200, "response status is 200 OK");
-  } catch (error) {
-    t.equal(error.response.status, 500, "response status is 500");
-  }
-  t.end();
+    const apiCall = api.withdrawV1(bodyWithdraw);
+    await expect(apiCall).rejects.toHaveProperty(["response", "status"], 500);
+  });
 });


### PR DESCRIPTION
Original issue was to  __test(plugin-htlc-eth-besu): fix assertion withdraw-endpoint-invalid #1871__  However, this test case hadn't been jestified (slipped through the cracks according to @awadhana) so I went ahead and jestified the file along with fixing the negative test case. Commit message for jestification and the original issue. 

_______________________________
Migrated test from Tap to Jest

File Path: packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/withdraw-endpoint-invalid.test.ts
This is a PARTIAL resolution to issue https://github.com/hyperledger/cactus/issues/238
_______________________________

Fixes #1871 