### PR TITLE
test(cmd-api-server): fix flaky runtime-plugin-imports-test

### DIFF
--- a/packages/cactus-test-cmd-api-server/src/test/typescript/integration/runtime-plugin-imports.test.ts
+++ b/packages/cactus-test-cmd-api-server/src/test/typescript/integration/runtime-plugin-imports.test.ts
@@ -16,6 +16,11 @@ const logLevel: LogLevelDesc = "TRACE";
 const testCase = "can import plugins at runtime (CLI)";
 describe(testCase, () => {
   let apiServer: ApiServer;
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   test(testCase, async () => {
     const pluginsPath = path.join(
       __dirname, // start at the current file's path
@@ -67,5 +72,7 @@ describe(testCase, () => {
     ];
     await expect(apiServer.start()).not.toReject();
   });
-  afterAll(async () => await apiServer.shutdown());
+  afterAll(async () => {
+    await apiServer.shutdown();
+  });
 });


### PR DESCRIPTION
This is a flaky test case that can't be reliably reproduce. I've ran the test individually 40 times and all 40 times it has passed successfully. 

This error, however, seems to pop up only when the `yarn jest` command is run (when I ran the test individually). 

Based on the linked ["hint"](https://stackoverflow.com/questions/50793885/referenceerror-you-are-trying-to-import-a-file-after-the-jest-environment-has/50793993#50793993) from the issue, it seems like using `jest.useFakeTimers()` a good solution. However, using the `jest.useFakeTimers()` with`async/await` was not recommended.

However, I found a [different source](https://gist.github.com/apieceofbart/e6dea8d884d29cf88cdb54ef14ddbcc4#file-test-js-L58) that showed examples of how to use the `jest.useFakeTimers()`. Our original problem, however, is probably because the after the test environment is torn down, the second test file is trying to import files from the first environment, triggering the error ([explained here](https://github.com/facebook/jest/issues/11438#issuecomment-916711164)). So I've come to the solution of installing another node package: [node-cleanup](https://www.npmjs.com/package/node-cleanup) and running that within the afterAll at the very end of the test. 

My laptop can't take running the `yarn jest` script too much so I haven't seen it reproduce the error yet. (WOT ruhrow) 

_______________________edit below _________________________

So it turns out that this flaky test due to libraries trying to third libraries trying to run after the test runs is a simple fix that was documented [here](https://testing-library.com/docs/using-fake-timers/) where we just add the `useRealTimer` in the `afterEach`. Lol so sorry!! 

Fixes #1667 
 