### PR TITLE
fix(cmd-api-server): add express static rate limiting

### DIFF
--- a/packages/cactus-cmd-api-server/package.json
+++ b/packages/cactus-cmd-api-server/package.json
@@ -74,6 +74,7 @@
     "express-http-proxy": "1.6.2",
     "express-jwt": "6.0.0",
     "express-openapi-validator": "4.12.12",
+    "express-rate-limit": "6.3.0",
     "fs-extra": "10.0.0",
     "google-protobuf": "3.18.0-rc.2",
     "jose": "4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10488,6 +10488,11 @@ express-openapi-validator@4.12.12:
     ono "^7.1.3"
     path-to-regexp "^6.2.0"
 
+express-rate-limit@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-6.3.0.tgz#253387ce4d36c9c2cc77c7c676068deb36cc0821"
+  integrity sha512-932Io1VGKjM3ppi7xW9sb1J5nVkEJSUiOtHw2oE+JyHks1e+AXuOBSXbJKM0mcXwEnW1TibJibQ455Ow1YFjfg==
+
 express-unless@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/express-unless/-/express-unless-0.3.1.tgz#2557c146e75beb903e2d247f9b5ba01452696e20"


### PR DESCRIPTION
fix(cmd-api-server): add express static rate limiting

Introduces rate limiting to the static file serving express
middleware that returns the index.html of the single
page web applications that the API server can host.

The lack of rate limiting was highlighted as a problem by
CodeQL

Fixes #1840

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>