### PR TITLE
fix(security): address CVE-2021-23358 - TEMPORARY fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,5 +141,8 @@
     "webpack": "5.50.0",
     "webpack-bundle-analyzer": "4.4.2",
     "webpack-cli": "4.7.2"
+  },
+  "resolutions": {
+    "underscore": "1.13.2"
   }
 }


### PR DESCRIPTION
This is just a temporary fix for the short term where we
simply force all underscore versions to be the latest availabe
at the time of this writing.
This is necessary because the vulnerabilities would be
much more complicated to be fixed on the top level
where we have to execute a costly migration from web3-eea to
web3js-quorum.

Temporarily addresses #1775
TODO: We still need to fix this in the correct way on the longer term.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>