### PR TITLE
fix(cmd-api-server): upgrade socket.io - CVE-2022-21676

### DIFF
--- a/examples/cactus-check-connection-ethereum-validator/package.json
+++ b/examples/cactus-check-connection-ethereum-validator/package.json
@@ -15,6 +15,6 @@
   },
   "dependencies": {
     "@types/node": "15.14.7",
-    "socket.io": "4.1.3"
+    "socket.io": "4.4.1"
   }
 }

--- a/examples/discounted-cartrade/package.json
+++ b/examples/discounted-cartrade/package.json
@@ -27,7 +27,7 @@
     "log4js": "6.4.0",
     "morgan": "1.9.1",
     "shelljs": "0.8.5",
-    "socket.io": "4.1.3",
+    "socket.io": "4.4.1",
     "ts-node": "8.9.1",
     "web3": "1.7.0",
     "xmlhttprequest": "1.8.0"

--- a/examples/electricity-trade/package.json
+++ b/examples/electricity-trade/package.json
@@ -23,7 +23,7 @@
     "log4js": "6.4.0",
     "morgan": "1.9.1",
     "shelljs": "0.8.5",
-    "socket.io": "4.1.3",
+    "socket.io": "4.4.1",
     "ts-node": "8.9.1",
     "web3": "1.7.0",
     "xmlhttprequest": "1.8.0"

--- a/examples/electricity-trade/tools/transferNumericAsset/package.json
+++ b/examples/electricity-trade/tools/transferNumericAsset/package.json
@@ -15,7 +15,7 @@
     "ethereumjs-tx": "2.1.2",
     "ts-node": "9.1.1",
     "web3": "1.7.0",
-    "socket.io": "4.1.3"
+    "socket.io": "4.4.1"
   },
   "devDependencies": {
     "typescript": "3.9.10"

--- a/examples/test-run-transaction/package.json
+++ b/examples/test-run-transaction/package.json
@@ -27,7 +27,7 @@
     "log4js": "6.4.0",
     "morgan": "1.9.1",
     "shelljs": "0.8.5",
-    "socket.io": "4.1.3",
+    "socket.io": "4.4.1",
     "ts-node": "8.9.1",
     "web3": "1.7.0",
     "xmlhttprequest": "1.8.0"

--- a/extensions/cactus-plugin-htlc-coordinator-besu/package.json
+++ b/extensions/cactus-plugin-htlc-coordinator-besu/package.json
@@ -75,7 +75,7 @@
     "@hyperledger/cactus-plugin-keychain-memory": "1.0.0-rc.3",
     "@hyperledger/cactus-test-tooling": "1.0.0-rc.3",
     "@types/express": "4.17.8",
-    "socket.io": "4.1.3"
+    "socket.io": "4.4.1"
   },
   "engines": {
     "node": ">=10",

--- a/packages/cactus-cmd-api-server/package.json
+++ b/packages/cactus-cmd-api-server/package.json
@@ -84,8 +84,8 @@
     "run-time-error": "1.4.0",
     "rxjs": "7.3.0",
     "semver": "7.3.5",
-    "socket.io": "4.1.3",
-    "socket.io-client": "4.1.3",
+    "socket.io": "4.4.1",
+    "socket.io-client": "4.4.1",
     "typescript-optional": "2.0.1",
     "uuid": "8.3.2"
   },

--- a/packages/cactus-cmd-api-server/src/main/typescript/api-client/api-server-api-client.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/api-client/api-server-api-client.ts
@@ -100,6 +100,11 @@ export class ApiServerApiClient extends DefaultApi {
         socket.auth = { token };
         this.options.baseOptions = { headers: { Authorization: token } };
         log.debug("Received fresh token from token provider OK");
+
+        // After upgrading to SocketIO 4.4.1 the automatic reconnection became
+        // flaky in this test so we are giving it a nudge in here manually to
+        // do the right thing and reconnect after the token has been updated.
+        socket.connect();
       } else {
         socket.disconnect();
         subject.error(err);

--- a/packages/cactus-cmd-socketio-server/package.json
+++ b/packages/cactus-cmd-socketio-server/package.json
@@ -29,7 +29,7 @@
     "jsrsasign": "10.5.0",
     "log4js": "6.4.1",
     "shelljs": "0.8.5",
-    "socket.io": "4.1.3",
+    "socket.io": "4.4.1",
     "socket.io-client": "4.1.3",
     "web3": "1.6.0",
     "xmlhttprequest": "1.8.0"

--- a/packages/cactus-core-api/package.json
+++ b/packages/cactus-core-api/package.json
@@ -106,7 +106,7 @@
     "@types/express": "4.17.13",
     "make-dir-cli": "3.0.0",
     "rxjs": "7.3.0",
-    "socket.io": "4.1.3",
+    "socket.io": "4.4.1",
     "typescript-optional": "2.0.1"
   },
   "engines": {

--- a/packages/cactus-plugin-ledger-connector-besu/package.json
+++ b/packages/cactus-plugin-ledger-connector-besu/package.json
@@ -75,7 +75,7 @@
     "@hyperledger/cactus-plugin-keychain-memory": "1.0.0-rc.3",
     "@hyperledger/cactus-test-tooling": "1.0.0-rc.3",
     "@types/express": "4.17.13",
-    "socket.io": "4.1.3",
+    "socket.io": "4.4.1",
     "web3-core": "1.5.2",
     "web3-eth": "1.5.2"
   },

--- a/packages/cactus-plugin-ledger-connector-fabric-socketio/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric-socketio/package.json
@@ -27,7 +27,7 @@
     "log4js": "6.4.1",
     "serve-favicon": "2.4.5",
     "shelljs": "0.8.5",
-    "socket.io": "4.1.3"
+    "socket.io": "4.4.1"
   },
   "devDependencies": {
     "@types/config": "0.0.41",

--- a/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/package.json
+++ b/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/package.json
@@ -24,7 +24,7 @@
     "log4js": "6.4.1",
     "serve-favicon": "2.4.5",
     "shelljs": "0.8.5",
-    "socket.io": "4.1.3",
+    "socket.io": "4.4.1",
     "web3": "0.20.7"
   },
   "devDependencies": {

--- a/packages/cactus-plugin-ledger-connector-sawtooth-socketio/package.json
+++ b/packages/cactus-plugin-ledger-connector-sawtooth-socketio/package.json
@@ -24,7 +24,7 @@
     "log4js": "6.4.1",
     "serve-favicon": "2.4.5",
     "shelljs": "0.8.5",
-    "socket.io": "4.1.3",
+    "socket.io": "4.4.1",
     "xmlhttprequest": "1.8.0"
   },
   "devDependencies": {

--- a/packages/cactus-plugin-odap-hermes/package.json
+++ b/packages/cactus-plugin-odap-hermes/package.json
@@ -42,7 +42,7 @@
     "axios": "0.21.4",
     "crypto-js": "4.0.0",
     "secp256k1": "4.0.2",
-    "socket.io": "4.1.3",
+    "socket.io": "4.4.1",
     "typescript-optional": "2.0.1",
     "web3": "1.5.2",
     "web3-utils": "1.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3935,6 +3935,11 @@
   resolved "https://registry.yarnpkg.com/@socket.io/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#568d9beae00b0d835f4f8c53fd55714986492e61"
   integrity sha512-dOlCBKnDw4iShaIsH/bxujKTM18+2TOAsYz+KSc11Am38H4q5Xw8Bbz97ZYdrVNM+um3p7w86Bvvmcn9q+5+eQ==
 
+"@socket.io/component-emitter@~3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz#8863915676f837d9dad7b76f50cb500c1e9422e9"
+  integrity sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==
+
 "@solidity-parser/parser@^0.11.0":
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.11.1.tgz#fa840af64840c930f24a9c82c08d4a092a068add"
@@ -4130,7 +4135,7 @@
   dependencies:
     "@types/express" "*"
 
-"@types/cookie@^0.4.0", "@types/cookie@^0.4.1":
+"@types/cookie@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
   integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
@@ -4140,7 +4145,7 @@
   resolved "https://registry.yarnpkg.com/@types/cordova/-/cordova-0.0.34.tgz#ea7addf74ecec3d7629827a0c39e2c9addc73d04"
   integrity sha1-6nrd907Ow9dimCegw54smt3HPQQ=
 
-"@types/cors@2.8.12", "@types/cors@^2.8.10", "@types/cors@^2.8.12":
+"@types/cors@2.8.12", "@types/cors@^2.8.12":
   version "2.8.12"
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
   integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
@@ -9482,6 +9487,21 @@ engine.io-client@~5.1.2:
     ws "~7.4.2"
     yeast "0.1.2"
 
+engine.io-client@~6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-6.1.1.tgz#800d4b9db5487d169686729e5bd887afa78d36b0"
+  integrity sha512-V05mmDo4gjimYW+FGujoGmmmxRaDsrVr7AXA3ZIfa04MWM1jOfZfUwou0oNqhNwy/votUDvGDt4JA4QF4e0b4g==
+  dependencies:
+    "@socket.io/component-emitter" "~3.0.0"
+    debug "~4.3.1"
+    engine.io-parser "~5.0.0"
+    has-cors "1.1.0"
+    parseqs "0.0.6"
+    parseuri "0.0.6"
+    ws "~8.2.3"
+    xmlhttprequest-ssl "~2.0.0"
+    yeast "0.1.2"
+
 engine.io-parser@~2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-2.2.1.tgz#57ce5611d9370ee94f99641b589f94c97e4f5da7"
@@ -9493,32 +9513,19 @@ engine.io-parser@~2.2.0:
     blob "0.0.5"
     has-binary2 "~1.0.2"
 
-engine.io-parser@~4.0.0, engine.io-parser@~4.0.1:
+engine.io-parser@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-4.0.3.tgz#83d3a17acfd4226f19e721bb22a1ee8f7662d2f6"
   integrity sha512-xEAAY0msNnESNPc00e19y5heTPX4y/TJ36gr8t1voOaNmTojP9b3oK3BbJLFufW2XFPQaaijpFewm2g2Um3uqA==
   dependencies:
     base64-arraybuffer "0.1.4"
 
-engine.io-parser@~5.0.3:
+engine.io-parser@~5.0.0, engine.io-parser@~5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.0.3.tgz#ca1f0d7b11e290b4bfda251803baea765ed89c09"
   integrity sha512-BtQxwF27XUNnSafQLvDi0dQ8s3i6VgzSoQMJacpIcGNrlUdfHSKbgm3jmjCVvQluGzqwujQMPAoMai3oYSTurg==
   dependencies:
     "@socket.io/base64-arraybuffer" "~1.0.2"
-
-engine.io@~5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-5.1.1.tgz#a1f97e51ddf10cbd4db8b5ff4b165aad3760cdd3"
-  integrity sha512-aMWot7H5aC8L4/T8qMYbLdvKlZOdJTH54FxfdFunTGvhMx1BHkJOntWArsVfgAZVwAO9LC2sryPWRcEeUzCe5w==
-  dependencies:
-    accepts "~1.3.4"
-    base64id "2.0.0"
-    cookie "~0.4.1"
-    cors "~2.8.5"
-    debug "~4.3.1"
-    engine.io-parser "~4.0.0"
-    ws "~7.4.2"
 
 engine.io@~6.1.0:
   version "6.1.3"
@@ -20554,7 +20561,7 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-socket.io-adapter@~2.3.1, socket.io-adapter@~2.3.3:
+socket.io-adapter@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz#4d6111e4d42e9f7646e365b4f578269821f13486"
   integrity sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==
@@ -20571,6 +20578,18 @@ socket.io-client@4.1.3:
     engine.io-client "~5.1.2"
     parseuri "0.0.6"
     socket.io-parser "~4.0.4"
+
+socket.io-client@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.4.1.tgz#b6aa9448149d09b8d0b2bbf3d2fac310631fdec9"
+  integrity sha512-N5C/L5fLNha5Ojd7Yeb/puKcPWWcoB/A09fEjjNsg91EDVr5twk/OEyO6VT9dlLSUNY85NpW6KBhVMvaLKQ3vQ==
+  dependencies:
+    "@socket.io/component-emitter" "~3.0.0"
+    backo2 "~1.0.2"
+    debug "~4.3.2"
+    engine.io-client "~6.1.1"
+    parseuri "0.0.6"
+    socket.io-parser "~4.1.1"
 
 socket.io-client@^2.1.0:
   version "2.4.0"
@@ -20607,22 +20626,15 @@ socket.io-parser@~4.0.4:
     component-emitter "~1.3.0"
     debug "~4.3.1"
 
-socket.io@4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.1.3.tgz#d114328ef27ab31b889611792959c3fa6d502500"
-  integrity sha512-tLkaY13RcO4nIRh1K2hT5iuotfTaIQw7cVIe0FUykN3SuQi0cm7ALxuyT5/CtDswOMWUzMGTibxYNx/gU7In+Q==
+socket.io-parser@~4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.1.2.tgz#0a97d4fb8e67022158a568450a6e41887e42035e"
+  integrity sha512-j3kk71QLJuyQ/hh5F/L2t1goqzdTL0gvDzuhTuNSwihfuFUrcSji0qFZmJJPtG6Rmug153eOPsUizeirf1IIog==
   dependencies:
-    "@types/cookie" "^0.4.0"
-    "@types/cors" "^2.8.10"
-    "@types/node" ">=10.0.0"
-    accepts "~1.3.4"
-    base64id "~2.0.0"
+    "@socket.io/component-emitter" "~3.0.0"
     debug "~4.3.1"
-    engine.io "~5.1.1"
-    socket.io-adapter "~2.3.1"
-    socket.io-parser "~4.0.4"
 
-socket.io@^4.2.0:
+socket.io@4.4.1, socket.io@^4.2.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.4.1.tgz#cd6de29e277a161d176832bb24f64ee045c56ab8"
   integrity sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==
@@ -24320,6 +24332,11 @@ xmlhttprequest-ssl@~1.6.2:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz#03b713873b01659dfa2c1c5d056065b27ddc2de6"
   integrity sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==
+
+xmlhttprequest-ssl@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz#91360c86b914e67f44dce769180027c0da618c67"
+  integrity sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==
 
 xmlhttprequest@*, xmlhttprequest@1.8.0:
   version "1.8.0"


### PR DESCRIPTION
Upgrade the version of socket.io to 4.4.1 which contains the
patches for the CVE mentioned in the title.

Fixes #1914

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>