### PR TITLE
fix(api-server): allow no authorization on socketio endpoints

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
@@ -732,14 +732,15 @@ export class ApiServer {
 
     this.wsApi.attach(this.httpServerApi, wsOptions);
 
-    const socketIoAuthorizer = authorizeSocket({
-      ...authzConf.socketIoJwtOptions,
-      onAuthentication: (decodedToken) => {
-        this.log.debug("Socket authorized OK: %o", decodedToken);
-      },
-    });
-
-    this.wsApi.use(socketIoAuthorizer as never);
+    if (authorizerO.isPresent()) {
+      const socketIoAuthorizer = authorizeSocket({
+        ...authzConf.socketIoJwtOptions,
+        onAuthentication: (decodedToken) => {
+          this.log.debug("Socket authorized OK: %o", decodedToken);
+        },
+      });
+      this.wsApi.use(socketIoAuthorizer as never);
+    }
 
     return addressInfo;
   }


### PR DESCRIPTION
authorizeSocket middleware will be installed only if AuthorizationProtocol different than NONE was provided.

Closes:  #1925
Signed-off-by: Michal Bajer <michal.bajer@fujitsu.com>

Note
- This change work on my other local branch (not PR ready yet).
- This can be refactored, so that all authorization middleware creation would be handled by `AuthorizerFactory.createMiddleware`, but I didn't want to touch it without test coverage. I will probably introduce some tests with of socketio authorization as part of other PR, we can think about improvements then.