### PR TITLE
refactor(quorum-multi-party-all-in-one): enhance quorum-mp image

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -131,7 +131,8 @@
         "uuidv",
         "vscc",
         "wasm",
-        "Xdai"
+        "Xdai",
+        "goquorum"
     ],
     "dictionaries": [
         "typescript,node,npm,go,rust"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,12 @@ jobs:
     - name: Print Disk Usage Reports
       run: df ; echo "" ; docker system df
 
+    - name: ghcr.io/hyperledger/cactus-quorum-multi-party-all-in-one
+      run: DOCKER_BUILDKIT=1 docker build ./tools/docker/quorum-multi-party-all-in-one/ -f ./tools/docker/quorum-multi-party-all-in-one/Dockerfile
+
+    - name: Print Disk Usage Reports
+      run: df ; echo "" ; docker system df
+
     - name: ghcr.io/hyperledger/cactus-rust-compiler
       run: DOCKER_BUILDKIT=1 docker build ./tools/docker/rust-compiler/ -f ./tools/docker/rust-compiler/Dockerfile
 

--- a/.github/workflows/quorum-multi-party-all-in-one-publish.yaml
+++ b/.github/workflows/quorum-multi-party-all-in-one-publish.yaml
@@ -1,0 +1,56 @@
+name: quorum-multi-party-all-in-one-publish
+
+on:
+  push:
+    # Publish `main` as Docker `latest` image.
+    branches:
+      - main
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+env:
+  IMAGE_NAME: cactus-quorum-multi-party-all-in-one
+
+jobs:
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  build-tag-push-container:
+    runs-on: ubuntu-20.04
+    env:
+      DOCKER_BUILDKIT: 1
+      DOCKERFILE_PATH: ./tools/docker/quorum-multi-party-all-in-one/Dockerfile
+      DOCKER_BUILD_DIR: ./tools/docker/quorum-multi-party-all-in-one/
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2.4.0
+
+      - name: Build image
+        run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+
+      - name: Log in to registry
+        # This is where you will update the PAT to GITHUB_TOKEN
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          SHORTHASH=$(git rev-parse --short "$GITHUB_SHA")
+          TODAYS_DATE="$(date +%F)"
+          DOCKER_TAG="$TODAYS_DATE-$SHORTHASH"
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Do not use the `latest` tag at all, tag with date + git short hash if there is no git tag
+          [ "$VERSION" == "main" ] && VERSION=$DOCKER_TAG
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
@@ -486,18 +486,27 @@ export class Containers {
     });
   }
 
+  public static async getByPredicate(
+    pred: (ci: ContainerInfo) => boolean,
+  ): Promise<ContainerInfo> {
+    const docker = new Dockerode();
+    const containerList = await docker.listContainers();
+    const containerInfo = containerList.find(pred);
+
+    if (!containerInfo) {
+      throw new Error(`No container that matches given predicate!`);
+    }
+
+    return containerInfo;
+  }
+
   public static async getById(containerId: string): Promise<ContainerInfo> {
     const fnTag = `Containers#getById()`;
-
     Checks.nonBlankString(containerId, `${fnTag}:containerId`);
 
-    const docker = new Dockerode();
-    const containerInfos = await docker.listContainers({});
-    const aContainerInfo = containerInfos.find((ci) => ci.Id === containerId);
-
-    if (aContainerInfo) {
-      return aContainerInfo;
-    } else {
+    try {
+      return this.getByPredicate((ci) => ci.Id === containerId);
+    } catch {
       throw new Error(`${fnTag} no container by ID"${containerId}"`);
     }
   }

--- a/packages/cactus-test-tooling/src/main/typescript/public-api.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/public-api.ts
@@ -21,6 +21,11 @@ export {
 } from "./quorum/quorum-test-ledger";
 
 export {
+  QuorumMultiPartyTestLedger,
+  IQuorumMultiPartyTestLedgerOptions,
+} from "./quorum/quorum-mp-test-ledger";
+
+export {
   CordaTestLedger,
   ICordaTestLedgerConstructorOptions,
   CORDA_TEST_LEDGER_DEFAULT_OPTIONS,

--- a/packages/cactus-test-tooling/src/main/typescript/quorum/quorum-mp-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/quorum/quorum-mp-test-ledger.ts
@@ -1,0 +1,255 @@
+import { EventEmitter } from "events";
+import Docker, { Container, ContainerCreateOptions } from "dockerode";
+import {
+  Bools,
+  Logger,
+  LoggerProvider,
+  LogLevelDesc,
+} from "@hyperledger/cactus-common";
+import { ITestLedger } from "../i-test-ledger";
+import { Containers } from "../common/containers";
+
+export interface IQuorumMultiPartyTestLedgerOptions {
+  readonly containerImageName?: string;
+  readonly containerImageVersion?: string;
+  readonly logLevel?: LogLevelDesc;
+  readonly emitContainerLogs?: boolean;
+  readonly envVars?: string[];
+  // For test development, attach to ledger that is already running, don't spin up new one
+  readonly useRunningLedger?: boolean;
+}
+
+export class QuorumMultiPartyTestLedger implements ITestLedger {
+  public readonly containerImageName: string;
+  public readonly containerImageVersion: string;
+  private readonly logLevel: LogLevelDesc;
+  private readonly emitContainerLogs: boolean;
+  private readonly useRunningLedger: boolean;
+  private readonly envVars: string[];
+
+  private readonly log: Logger;
+  public container: Container | undefined;
+  public containerId: string | undefined;
+
+  constructor(public readonly options: IQuorumMultiPartyTestLedgerOptions) {
+    // @todo Replace with hyperledger ghcr link when available
+    this.containerImageName =
+      options?.containerImageName ||
+      "ghcr.io/hyperledger/cactus-quorum-multi-party-all-in-one";
+
+    this.containerImageVersion =
+      options?.containerImageVersion || "2022-03-30--1928";
+
+    this.logLevel = options?.logLevel || "info";
+
+    this.emitContainerLogs = Bools.isBooleanStrict(options.emitContainerLogs)
+      ? (options.emitContainerLogs as boolean)
+      : true;
+
+    this.useRunningLedger = Bools.isBooleanStrict(options.useRunningLedger)
+      ? (options.useRunningLedger as boolean)
+      : false;
+
+    this.envVars = options?.envVars || [];
+
+    this.log = LoggerProvider.getOrCreate({
+      level: this.logLevel,
+      label: "quorum-multi-party-test-ledger",
+    });
+  }
+
+  public get fullContainerImageName(): string {
+    return [this.containerImageName, this.containerImageVersion].join(":");
+  }
+
+  public async start(omitPull = false): Promise<Container> {
+    if (this.useRunningLedger) {
+      this.log.info(
+        "Search for already running Quorum Test Ledger because 'useRunningLedger' flag is enabled.",
+      );
+      this.log.info(
+        "Search criteria - image name: ",
+        this.fullContainerImageName,
+        ", state: running",
+      );
+      const containerInfo = await Containers.getByPredicate(
+        (ci) =>
+          ci.Image === this.fullContainerImageName && ci.State === "running",
+      );
+      const docker = new Docker();
+      this.containerId = containerInfo.Id;
+      this.container = docker.getContainer(this.containerId);
+      return this.container;
+    }
+
+    if (this.container) {
+      await this.container.stop();
+      await this.container.remove();
+      this.container = undefined;
+      this.containerId = undefined;
+    }
+
+    if (!omitPull) {
+      await Containers.pullImage(
+        this.fullContainerImageName,
+        {},
+        this.logLevel,
+      );
+    }
+
+    const createOptions: ContainerCreateOptions = {
+      ExposedPorts: {
+        "8545/tcp": {}, // HTTP RPC
+        "8546/tcp": {}, // WS RPC
+        "20000/tcp": {}, // Member1 HTTP RPC
+        "20001/tcp": {}, // Member1 WS RPC
+        "9081/tcp": {}, // Member1 Tessera
+        "20002/tcp": {}, // Member2 HTTP RPC
+        "20003/tcp": {}, // Member2 WS RPC
+        "9082/tcp": {}, // Member2 Tessera
+        "20004/tcp": {}, // Member3 HTTP RPC
+        "20005/tcp": {}, // Member3 WS RPC
+        "9083/tcp": {}, // Member3 Tessera
+      },
+
+      Env: this.envVars,
+
+      HostConfig: {
+        PublishAllPorts: true,
+        Privileged: true,
+      },
+    };
+
+    return new Promise<Container>((resolve, reject) => {
+      const docker = new Docker();
+      const eventEmitter: EventEmitter = docker.run(
+        this.fullContainerImageName,
+        [],
+        [],
+        createOptions,
+        {},
+        (err: any) => {
+          if (err) {
+            reject(err);
+          }
+        },
+      );
+
+      eventEmitter.once("start", async (container: Container) => {
+        this.container = container;
+        this.containerId = container.id;
+
+        if (this.emitContainerLogs) {
+          const fnTag = `[${this.fullContainerImageName}]`;
+          await Containers.streamLogs({
+            container: this.container,
+            tag: fnTag,
+            log: this.log,
+          });
+        }
+
+        try {
+          await Containers.waitForHealthCheck(this.containerId);
+          resolve(container);
+        } catch (ex) {
+          this.log.error(ex);
+          reject(ex);
+        }
+      });
+    });
+  }
+
+  public stop(): Promise<unknown> {
+    if (this.useRunningLedger) {
+      this.log.info("Ignore stop request because useRunningLedger is enabled.");
+      return Promise.resolve();
+    } else if (this.container) {
+      return Containers.stop(this.container);
+    } else {
+      return Promise.reject(
+        new Error(
+          `QuorumMultiPartyTestLedger#destroy() Container was never created, nothing to stop.`,
+        ),
+      );
+    }
+  }
+
+  public destroy(): Promise<unknown> {
+    if (this.useRunningLedger) {
+      this.log.info(
+        "Ignore destroy request because useRunningLedger is enabled.",
+      );
+      return Promise.resolve();
+    } else if (this.container) {
+      return this.container.remove();
+    } else {
+      return Promise.reject(
+        new Error(
+          `QuorumMultiPartyTestLedger#destroy() Container was never created, nothing to destroy.`,
+        ),
+      );
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  public async getKeys() {
+    if (!this.containerId) {
+      throw new Error("Missing container ID");
+    }
+
+    const container = await Containers.getById(this.containerId);
+
+    const member1HttpPort = await Containers.getPublicPort(20000, container);
+    const member1WsPort = await Containers.getPublicPort(20001, container);
+    const member1PrivPort = await Containers.getPublicPort(9081, container);
+
+    const member2HttpPort = await Containers.getPublicPort(20002, container);
+    const member2WsPort = await Containers.getPublicPort(20003, container);
+    const member2PrivPort = await Containers.getPublicPort(9082, container);
+
+    const member3HttpPort = await Containers.getPublicPort(20004, container);
+    const member3WsPort = await Containers.getPublicPort(20005, container);
+    const member3PrivPort = await Containers.getPublicPort(9083, container);
+
+    // This configuration comes from quorum-dev-quickstart@smart_contracts/scripts/keys.js
+    return {
+      tessera: {
+        member1: {
+          publicKey: "BULeR8JyUWhiuuCMU/HLA0Q5pzkYT+cHII3ZKBey3Bo=",
+        },
+        member2: {
+          publicKey: "QfeDAys9MPDs2XHExtc84jKGHxZg/aj52DTh0vtA3Xc=",
+        },
+        member3: {
+          publicKey: "1iTZde/ndBHvzhcl7V68x44Vx7pl8nwx9LqnM/AfJUg=",
+        },
+      },
+      quorum: {
+        member1: {
+          url: `http://127.0.0.1:${member1HttpPort}`,
+          wsUrl: `ws://127.0.0.1:${member1WsPort}`,
+          privateUrl: `http://127.0.0.1:${member1PrivPort}`,
+          privateKey:
+            "b9a4bd1539c15bcc83fa9078fe89200b6e9e802ae992f13cd83c853f16e8bed4",
+          accountAddress: "f0e2db6c8dc6c681bb5d6ad121a107f300e9b2b5",
+        },
+        member2: {
+          url: `http://127.0.0.1:${member2HttpPort}`,
+          wsUrl: `ws://127.0.0.1:${member2WsPort}`,
+          privateUrl: `http://127.0.0.1:${member2PrivPort}`,
+          privateKey:
+            "f18166704e19b895c1e2698ebc82b4e007e6d2933f4b31be23662dd0ec602570",
+          accountAddress: "ca843569e3427144cead5e4d5999a3d0ccf92b8e",
+        },
+        member3: {
+          url: `http://127.0.0.1:${member3HttpPort}`,
+          wsUrl: `ws://127.0.0.1:${member3WsPort}`,
+          privateUrl: `http://127.0.0.1:${member3PrivPort}`,
+          privateKey:
+            "4107f0b6bf67a3bc679a15fe36f640415cf4da6a4820affaac89c8b280dfd1b3",
+          accountAddress: "0fbdc686b912d7722dc86510934589e0aaf3b55a",
+        },
+      },
+    };
+  }
+}

--- a/tools/docker/quorum-multi-party-all-in-one/Dockerfile
+++ b/tools/docker/quorum-multi-party-all-in-one/Dockerfile
@@ -1,115 +1,53 @@
+################################
+# STAGE 1
+# Setup quorum-dev-quickstart
+################################
+
+FROM node:16 AS quorum-dev-quickstart-setup
+
+ENV QUORUM_QUICKSTART_VERSION=0.0.53
+ENV ROOT_DIR=/opt/quorum-dev-quickstart
+
+WORKDIR "${ROOT_DIR}"
+RUN npm install -g "quorum-dev-quickstart@${QUORUM_QUICKSTART_VERSION}"
+RUN quorum-dev-quickstart --clientType goquorum --outputPath ./ --monitoring default --privacy true --orchestrate false
+
+################################
+# STAGE 2
+# docker-compose base
+################################
+
 FROM docker:20.10.3-dind
 
-ARG BESU_VERSION=21.1.2
-ARG QUORUM_VERSION=21.4.1
-ARG QUORUM_TESSERA_VERSION=21.1.1
-ARG CA_VERSION=1.4.9
+ENV ROOT_DIR=/opt/quorum-dev-quickstart
 
-WORKDIR /
+# Install docker-compose and quorum-dev-quickstart setup dependencies
+RUN apk update \
+  && apk add --no-cache \
+    py-pip \
+    python3-dev \
+    libffi-dev \
+    openssl-dev \
+    gcc \
+    libc-dev \
+    rust \
+    cargo \
+    make \
+    bash \
+    ncurses \
+    supervisor \
+  && pip install docker-compose
 
-RUN apk update
-
-# Install dependencies of Docker Compose
-RUN apk add py-pip python3-dev libffi-dev openssl-dev gcc libc-dev make
-
-# Install python/pip - We need this because DinD 18.x has Python 2
-# And we cannot upgrade to DinD 19 because of
-# https://github.com/docker-library/docker/issues/170
-ENV PYTHONUNBUFFERED=1
-RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
-RUN python3 -m ensurepip
-RUN pip3 install --no-cache --upgrade "pip>=21" setuptools
-
-# Without this the docker-compose installation crashes, complaining about
-# a lack of rust compiler...
-# RUN pip install setuptools_rust
-ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
-
-# Install Docker Compose which is a dependency of Fabric Samples
-RUN pip install docker-compose
-
-# Need git to clone the sources of the Fabric Samples repository from GitHub
-RUN apk add --no-cache git
-
-# Fabric Samples needs bash, sh is not good enough here
-RUN apk add --no-cache bash
-
-# The file binary is used to inspect exectubles when debugging container image issues
-RUN apk add --no-cache file
-
-# Need NodeJS tooling for the Typescript contracts
-RUN apk add --no-cache npm nodejs
-
-# Needed because the Fabric binaries need the GNU libc dynamic linker to be executed
-# and alpine does not have that by default
-# @see https://askubuntu.com/a/1035037/1008695
-# @see https://github.com/gliderlabs/docker-alpine/issues/219#issuecomment-254741346
-RUN apk add --no-cache libc6-compat
-
-RUN apk add --no-cache --update chromium
-
-ENV CACTUS_CFG_PATH=/etc/hyperledger/cactus
-RUN mkdir -p $CACTUS_CFG_PATH
-# OpenSSH - need to have it so we can shell in and install/instantiate contracts
-RUN apk add --no-cache openssh augeas
-
-# Configure the OpenSSH server we just installed
-RUN augtool 'set /files/etc/ssh/sshd_config/AuthorizedKeysFile ".ssh/authorized_keys /etc/authorized_keys/%u"'
-RUN augtool 'set /files/etc/ssh/sshd_config/PermitRootLogin yes'
-RUN augtool 'set /files/etc/ssh/sshd_config/PasswordAuthentication no'
-RUN augtool 'set /files/etc/ssh/sshd_config/PermitEmptyPasswords no'
-RUN augtool 'set /files/etc/ssh/sshd_config/Port 22'
-RUN augtool 'set /files/etc/ssh/sshd_config/LogLevel DEBUG2'
-RUN augtool 'set /files/etc/ssh/sshd_config/LoginGraceTime 10'
-# Create the server's key - without this sshd will refuse to start
-RUN ssh-keygen -A
-
-# Generate an RSA keypair on the fly to avoid having to hardcode one in the image
-# which technically does not pose a security threat since this is only a development
-# image, but we do it like this anyway.
-RUN mkdir ~/.ssh
-RUN chmod 700 ~/.ssh/
-RUN touch ~/.ssh/authorized_keys
-RUN ["/bin/bash", "-c", "ssh-keygen -t rsa -N '' -f $CACTUS_CFG_PATH/quorum-aio-image <<< y"]
-RUN mv $CACTUS_CFG_PATH/quorum-aio-image $CACTUS_CFG_PATH/quorum-aio-image.key
-RUN cp $CACTUS_CFG_PATH/quorum-aio-image.pub ~/.ssh/authorized_keys
-
-RUN apk add --no-cache util-linux
-
-# FIXME - make it so that SSHd does not need this to work
-RUN echo "root:$(uuidgen)" | chpasswd
-
-RUN git clone https://github.com/travis-payne/quorum-dev-quickstart.git
-
-WORKDIR /quorum-dev-quickstart
-
-RUN git fetch
-
-RUN git checkout e029993
-
-RUN npm i
-
-RUN npm run build
-
-RUN npm run start -- --clientType goquorum --outputPath ./ --monitoring default --privacy true --orchestrate false
-
-RUN chmod -R a+rwx ../quorum-dev-quickstart/
-
-RUN apk add --no-cache supervisor
-RUN apk add --no-cache ncurses
+# Copy quorum-dev-quickstart from the base
+COPY --from=quorum-dev-quickstart-setup "${ROOT_DIR}" "${ROOT_DIR}"
+WORKDIR "${ROOT_DIR}"
 
 COPY healthcheck.sh /healthcheck.sh
-COPY supervisord.conf /etc/supervisord.conf
-
-# # Extend the parent image's entrypoint
-# # https://superuser.com/questions/1459466/can-i-add-an-additional-docker-entrypoint-script
-ENTRYPOINT ["/usr/bin/supervisord"]
-CMD ["--configuration", "/etc/supervisord.conf", "--nodaemon"]
-
 HEALTHCHECK --interval=10s --timeout=5s --start-period=60s --retries=500 CMD /healthcheck.sh
 
-# OpenSSH Server
-EXPOSE 22
+COPY supervisord.conf /etc/supervisord.conf
+ENTRYPOINT ["/usr/bin/supervisord"]
+CMD ["--configuration", "/etc/supervisord.conf", "--nodaemon"]
 
 # Grafana
 EXPOSE 3000
@@ -123,9 +61,6 @@ EXPOSE 9001
 # Prometheus
 EXPOSE 9090
 
-# ETH signer proxy
-EXPOSE 18545
-
 # Quorum member 1: HTTP; WebSocket Providers; Tessera
 EXPOSE 20000 20001 9081
 
@@ -137,3 +72,6 @@ EXPOSE 20004 20005 9083
 
 # Web block explorer
 EXPOSE 25000
+
+# Geth logs location
+VOLUME [ "/root/logs/quorum" ]

--- a/tools/docker/quorum-multi-party-all-in-one/README.md
+++ b/tools/docker/quorum-multi-party-all-in-one/README.md
@@ -4,15 +4,14 @@
 
 - [Summary](#summary)
 - [Usage via Public Container Registry](#usage-via-public-container-registry)
-- [List endpoints and services](#list-endpoints-and-services)
-- [2021-08-17 09:39:45,048 DEBG 'quorum-network' stdout output:](#2021-08-17-093945048-debg-quorum-network-stdout-output)
-- [List endpoints and services](#list-endpoints-and-services-1)
+- [Endpoints](#endpoints)
+- [Building the Image Locally](#building-the-image-locally)
 
 ## Summary
-
 A container image that hosts a Quorum network which is
-- Has multiple nodes and validators
-- Supports transaction privacy (`privateFrom` and `privateFor`)
+- Has multiple nodes and validators.
+- Supports transaction privacy (`privateFrom` and `privateFor`).
+- Based on official `quorum-dev-quickstart` setup.
 
 ## Usage via Public Container Registry
 
@@ -20,6 +19,7 @@ A container image that hosts a Quorum network which is
 docker run \
   --rm \
   --privileged \
+  --tty \
   --publish 2222:22 \
   --publish 3000:3000 \
   --publish 8545:8545 \
@@ -38,37 +38,18 @@ docker run \
   --publish 20005:20005 \
   --publish 25000:25000 \
   ghcr.io/hyperledger/cactus-quorum-multi-party-all-in-one:latest
-
 ```
 
-*************************************
-Quorum Dev Quickstart 
-*************************************
+### Note on --tty flag
+Underlying software used by the image requires pseudo-TTY to be allocated in a container. Without it, there'll be no log output from the Quorum Dev Quickstart application. The quorum services should work anyway, but use of `--tty` is convenient and recommended.
 
-----------------------------------
-List endpoints and services
-----------------------------------
+## Endpoints
+```sh
 JSON-RPC HTTP service endpoint                 : http://localhost:8545
-2021-08-17 09:39:45,048 DEBG 'quorum-network' stdout output:
-----------------------------------
-List endpoints and services
-----------------------------------
-JSON-RPC HTTP service endpoint                 : http://localhost:8545
-
 JSON-RPC WebSocket service endpoint            : ws://localhost:8546
 Web block explorer address                     : http://localhost:25000/
-2021-08-17 09:39:45,049 DEBG 'quorum-network' stdout output:
-JSON-RPC WebSocket service endpoint            : ws://localhost:8546
-Web block explorer address                     : http://localhost:25000/
-
-
-For more information on the endpoints and services, refer to README.md in the installation directory.
-****************************************************************
-2021-08-17 09:39:47,429 DEBG 'quorum-network' stdout output:
-
-For more information on the endpoints and services, refer to README.md in the installation directory.
-****************************************************************
-
+Prometheus address                             : http://localhost:9090/graph
+Grafana address                                : http://localhost:3000/d/a1lVy7ycin9Yv/goquorum-overview?orgId=1&refresh=10s&from=now-30m&to=now&var-system=All
 ```
 
 ## Building the Image Locally
@@ -78,13 +59,14 @@ DOCKER_BUILDKIT=1 docker build ./tools/docker/quorum-multi-party-all-in-one/ --p
 ```
 
 ```sh
-docker run --rm --privileged --publish-all cqmpaio
+docker run --rm --privileged --tty --publish-all cqmpaio
 ```
 
 ```sh
 docker run \
   --rm \
   --privileged \
+  --tty \
   --publish 2222:22 \
   --publish 3000:3000 \
   --publish 8545:8545 \

--- a/tools/docker/quorum-multi-party-all-in-one/healthcheck.sh
+++ b/tools/docker/quorum-multi-party-all-in-one/healthcheck.sh
@@ -6,8 +6,7 @@ set -e
 wget -O- --post-data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' --header 'Content-Type: application/json' http://localhost:20000
 
 # # Quorum Member 2
-wget -O- --post-data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' --header 'Content-Type: application/json' http://localhost:20000
+wget -O- --post-data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' --header 'Content-Type: application/json' http://localhost:20002
 
 # # Quorum Member 3
-wget -O- --post-data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' --header 'Content-Type: application/json' http://localhost:20000
-
+wget -O- --post-data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' --header 'Content-Type: application/json' http://localhost:20004

--- a/tools/docker/quorum-multi-party-all-in-one/supervisord.conf
+++ b/tools/docker/quorum-multi-party-all-in-one/supervisord.conf
@@ -4,15 +4,6 @@ logfile_maxbytes = 50MB
 logfile_backups=10
 loglevel = debug
 
-[program:sshd]
-command=/usr/sbin/sshd -D
-autostart=true
-autorestart=true
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-
 [program:dockerd]
 command=dockerd-entrypoint.sh
 autostart=true
@@ -23,7 +14,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:quorum-network]
-command=/quorum-dev-quickstart/run.sh
+command=%(ENV_ROOT_DIR)s/run.sh
 autostart=true
 autorestart=false
 stderr_logfile=/dev/stderr
@@ -33,4 +24,3 @@ stdout_logfile_maxbytes=0
 
 [inet_http_server]
 port = 0.0.0.0:9001
-


### PR DESCRIPTION
Current Quorum-MP WS endpoints are not available outside of docker, fix
it. Use upstream npm setup package instead of contributor branch. Test
all members in healthcheck. Update readme. Add test tooling to setup
multi party ledger in functional tests. Cleanup and simplify dockerfile.
Publish MP image to ghcr.

Closes: #1927
Signed-off-by: Michal Bajer <michal.bajer@fujitsu.com>

Notes
- I've added a new image publish in this PR, but there's ongoing issue with package publish - https://github.com/hyperledger/cactus/issues/1881
- Since I'm not sure when the image will be published, I've used my personal ghcr for now, since I'm already using it in some functional tests on another branch. I will change it to hyperledger ghcr when the publish completes correctly.