### PR TITLE
feat(quorum-connector): implement validator interface on go-quorum-connector

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -130,7 +130,9 @@
         "uuidv",
         "vscc",
         "wasm",
-        "Xdai"
+        "Xdai",
+        "goquorum",
+        "outsh"
     ],
     "dictionaries": [
         "typescript,node,npm,go,rust"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,12 @@ jobs:
     - name: Print Disk Usage Reports
       run: df ; echo "" ; docker system df
 
+    - name: ghcr.io/hyperledger/cactus-quorum-multi-party-all-in-one
+      run: DOCKER_BUILDKIT=1 docker build ./tools/docker/quorum-multi-party-all-in-one/ -f ./tools/docker/quorum-multi-party-all-in-one/Dockerfile
+
+    - name: Print Disk Usage Reports
+      run: df ; echo "" ; docker system df
+
     - name: ghcr.io/hyperledger/cactus-rust-compiler
       run: DOCKER_BUILDKIT=1 docker build ./tools/docker/rust-compiler/ -f ./tools/docker/rust-compiler/Dockerfile
 

--- a/.github/workflows/quorum-multi-party-all-in-one-publish.yaml
+++ b/.github/workflows/quorum-multi-party-all-in-one-publish.yaml
@@ -1,0 +1,56 @@
+name: quorum-multi-party-all-in-one-publish
+
+on:
+  push:
+    # Publish `main` as Docker `latest` image.
+    branches:
+      - main
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+env:
+  IMAGE_NAME: cactus-quorum-multi-party-all-in-one
+
+jobs:
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  build-tag-push-container:
+    runs-on: ubuntu-20.04
+    env:
+      DOCKER_BUILDKIT: 1
+      DOCKERFILE_PATH: ./tools/docker/quorum-multi-party-all-in-one/Dockerfile
+      DOCKER_BUILD_DIR: ./tools/docker/quorum-multi-party-all-in-one/
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2.4.0
+
+      - name: Build image
+        run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+
+      - name: Log in to registry
+        # This is where you will update the PAT to GITHUB_TOKEN
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          SHORTHASH=$(git rev-parse --short "$GITHUB_SHA")
+          TODAYS_DATE="$(date +%F)"
+          DOCKER_TAG="$TODAYS_DATE-$SHORTHASH"
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Do not use the `latest` tag at all, tag with date + git short hash if there is no git tag
+          [ "$VERSION" == "main" ] && VERSION=$DOCKER_TAG
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
@@ -58,7 +58,6 @@ import { WatchHealthcheckV1Endpoint } from "./web-services/watch-healthcheck-v1-
 import * as default_service from "./generated/proto/protoc-gen-ts/services/default_service";
 import { GrpcServerApiServer } from "./web-services/grpc/grpc-server-api-server";
 import { determineAddressFamily } from "./common/determine-address-family";
-import { AuthorizationProtocol } from "./public-api";
 
 export interface IApiServerConstructorOptions {
   readonly pluginManagerOptions?: { pluginsPath: string };
@@ -733,7 +732,7 @@ export class ApiServer {
 
     this.wsApi.attach(this.httpServerApi, wsOptions);
 
-    if (authzProtocol != AuthorizationProtocol.NONE) {
+    if (authorizerO.isPresent()) {
       const socketIoAuthorizer = authorizeSocket({
         ...authzConf.socketIoJwtOptions,
         onAuthentication: (decodedToken) => {

--- a/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
@@ -58,6 +58,7 @@ import { WatchHealthcheckV1Endpoint } from "./web-services/watch-healthcheck-v1-
 import * as default_service from "./generated/proto/protoc-gen-ts/services/default_service";
 import { GrpcServerApiServer } from "./web-services/grpc/grpc-server-api-server";
 import { determineAddressFamily } from "./common/determine-address-family";
+import { AuthorizationProtocol } from "./public-api";
 
 export interface IApiServerConstructorOptions {
   readonly pluginManagerOptions?: { pluginsPath: string };
@@ -732,14 +733,15 @@ export class ApiServer {
 
     this.wsApi.attach(this.httpServerApi, wsOptions);
 
-    const socketIoAuthorizer = authorizeSocket({
-      ...authzConf.socketIoJwtOptions,
-      onAuthentication: (decodedToken) => {
-        this.log.debug("Socket authorized OK: %o", decodedToken);
-      },
-    });
-
-    this.wsApi.use(socketIoAuthorizer as never);
+    if (authzProtocol != AuthorizationProtocol.NONE) {
+      const socketIoAuthorizer = authorizeSocket({
+        ...authzConf.socketIoJwtOptions,
+        onAuthentication: (decodedToken) => {
+          this.log.debug("Socket authorized OK: %o", decodedToken);
+        },
+      });
+      this.wsApi.use(socketIoAuthorizer as never);
+    }
 
     return addressInfo;
   }

--- a/packages/cactus-plugin-ledger-connector-quorum/package.json
+++ b/packages/cactus-plugin-ledger-connector-quorum/package.json
@@ -59,6 +59,8 @@
     "axios": "0.21.4",
     "express": "4.17.1",
     "prom-client": "13.2.0",
+    "rxjs": "7.3.0",
+    "sanitize-html": "2.7.0",
     "typescript-optional": "2.0.1",
     "web3": "1.5.2",
     "web3-eth-contract": "1.5.2"
@@ -67,6 +69,7 @@
     "@hyperledger/cactus-plugin-keychain-memory": "1.0.0",
     "@hyperledger/cactus-test-tooling": "1.0.0",
     "@types/express": "4.17.13",
+    "@types/sanitize-html": "2.6.2",
     "web3-eth": "1.5.2"
   },
   "engines": {

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/json/openapi.json
@@ -147,8 +147,10 @@
             "EthContractInvocationType": {
                 "type": "string",
                 "enum": [
-                    "SEND",
-                    "CALL"
+                    "send",
+                    "call",
+                    "encodeABI",
+                    "estimateGas"
                 ]
             },
             "SolidityContractJsonArtifact": {
@@ -507,7 +509,7 @@
                     }
                 }
             },
-            "DeployContractSolidityBytecodeJsonObjectV1Request": { 
+            "DeployContractSolidityBytecodeJsonObjectV1Request": {
                 "type": "object",
                 "required": [
                     "web3SigningCredential",
@@ -534,7 +536,7 @@
                         "default": 60000,
                         "nullable": false
                     },
-                    "contractJSON": { 
+                    "contractJSON": {
                         "$ref": "#/components/schemas/ContractJSON",
                         "description": "For use when not using keychain, pass the contract in as this variable",
                         "nullable": false
@@ -713,7 +715,7 @@
                         "default": 60000,
                         "nullable": false
                     },
-                    "contractJSON": { 
+                    "contractJSON": {
                         "$ref": "#/components/schemas/ContractJSON",
                         "description": "For use when not using keychain, pass the contract in as this variable",
                         "nullable": false
@@ -736,9 +738,385 @@
                     }
                 }
             },
+            "InvokeRawWeb3EthMethodV1Request": {
+                "type": "object",
+                "required": ["methodName"],
+                "additionalProperties": false,
+                "properties": {
+                    "methodName": {
+                        "description": "The name of the web3.eth method to invoke",
+                        "type": "string",
+                        "nullable": false,
+                        "minLength": 1,
+                        "maxLength": 2048
+                    },
+                    "params": {
+                        "description": "The list of arguments to pass to web3.eth method specified in methodName",
+                        "type": "array",
+                        "default": [],
+                        "items": {}
+                    }
+                }
+            },
+            "InvokeRawWeb3EthMethodV1Response": {
+                "type": "object",
+                "required": [
+                    "status"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "status": {
+                        "type": "number",
+                        "nullable": false,
+                        "description": "Status code of the operation"
+                    },
+                    "data": {
+                        "description": "Output of requested web3.eth method"
+                    },
+                    "errorDetail": {
+                        "type": "string",
+                        "nullable": false,
+                        "description": "Error details"
+                    }
+                }
+            },
+            "InvokeRawWeb3EthContractV1Request": {
+                "type": "object",
+                "required": [
+                    "abi",
+                    "address",
+                    "invocationType",
+                    "contractMethod"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "abi": {
+                        "description": "The application binary interface of the solidity contract",
+                        "type": "array",
+                        "items": {}
+                    },
+                    "address": {
+                        "description": "Deployed solidity contract address",
+                        "type": "string"
+                    },
+                    "invocationType": {
+                        "description": "Contract invocation method to be performed (send, call, etc...)",
+                        "$ref": "#/components/schemas/EthContractInvocationType"
+                    },
+                    "invocationParams": {
+                        "description": "The list of arguments for contract invocation method (send, call, etc...)",
+                        "type": "object",
+                        "default": {}
+                    },
+                    "contractMethod": {
+                        "description": "Method of deployed solidity contract to execute",
+                        "type": "string"
+                    },
+                    "contractMethodArgs": {
+                        "description": "The list of arguments for deployed solidity contract method",
+                        "type": "array",
+                        "default": [],
+                        "items": {}
+                    }
+                }
+            },
+            "InvokeRawWeb3EthContractV1Response": {
+                "type": "object",
+                "required": [
+                    "status"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "status": {
+                        "description": "Status code of the operation",
+                        "type": "number"
+                    },
+                    "data": {
+                        "description": "Output of contract invocation method"
+                    },
+                    "errorDetail": {
+                        "description": "Error details",
+                        "type": "string"
+                    }
+                }
+            },
             "PrometheusExporterMetricsResponse": {
                 "type": "string",
                 "nullable": false
+            },
+            "WatchBlocksV1": {
+                "type": "string",
+                "enum": [
+                    "org.hyperledger.cactus.api.async.quorum.WatchBlocksV1.Subscribe",
+                    "org.hyperledger.cactus.api.async.quorum.WatchBlocksV1.Next",
+                    "org.hyperledger.cactus.api.async.quorum.WatchBlocksV1.Unsubscribe",
+                    "org.hyperledger.cactus.api.async.quorum.WatchBlocksV1.Error",
+                    "org.hyperledger.cactus.api.async.quorum.WatchBlocksV1.Complete"
+                ],
+                "x-enum-varnames": [
+                    "Subscribe",
+                    "Next",
+                    "Unsubscribe",
+                    "Error",
+                    "Complete"
+                ]
+            },
+            "WatchBlocksV1Options": {
+                "type": "object",
+                "properties": {
+                    "getBlockData": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "Web3BlockHeader": {
+                "type": "object",
+                "required": [
+                    "number",
+                    "hash",
+                    "parentHash",
+                    "nonce",
+                    "sha3Uncles",
+                    "logsBloom",
+                    "transactionRoot",
+                    "stateRoot",
+                    "receiptRoot",
+                    "miner",
+                    "extraData",
+                    "gasLimit",
+                    "gasUsed",
+                    "timestamp"
+                ],
+                "properties": {
+                    "number": {
+                        "type": "number"
+                    },
+                    "hash": {
+                        "type": "string"
+                    },
+                    "parentHash": {
+                        "type": "string"
+                    },
+                    "nonce": {
+                        "type": "string"
+                    },
+                    "sha3Uncles": {
+                        "type": "string"
+                    },
+                    "logsBloom": {
+                        "type": "string"
+                    },
+                    "transactionsRoot": {
+                        "type": "string"
+                    },
+                    "stateRoot": {
+                        "type": "string"
+                    },
+                    "receiptsRoot": {
+                        "type": "string"
+                    },
+                    "difficulty": {
+                        "type": "string"
+                    },
+                    "mixHash": {
+                        "type": "string"
+                    },
+                    "miner": {
+                        "type": "string"
+                    },
+                    "extraData": {
+                        "type": "string"
+                    },
+                    "gasLimit": {
+                        "type": "integer"
+                    },
+                    "gasUsed": {
+                        "type": "integer"
+                    },
+                    "timestamp": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ]
+                    }
+                }
+            },
+            "Web3Transaction": {
+                "type": "object",
+                "required": [
+                    "hash",
+                    "nonce",
+                    "blockHash",
+                    "blockNumber",
+                    "transactionIndex",
+                    "from",
+                    "to",
+                    "value",
+                    "gasPrice",
+                    "gas",
+                    "input"
+                ],
+                "properties": {
+                    "hash": {
+                        "type": "string"
+                    },
+                    "nonce": {
+                        "type": "number"
+                    },
+                    "blockHash": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "blockNumber": {
+                        "type": "number",
+                        "nullable": true
+                    },
+                    "transactionIndex": {
+                        "type": "number",
+                        "nullable": true
+                    },
+                    "from": {
+                        "type": "string"
+                    },
+                    "to": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "value": {
+                        "type": "string"
+                    },
+                    "gasPrice": {
+                        "type": "string"
+                    },
+                    "gas": {
+                        "type": "number"
+                    },
+                    "input": {
+                        "type": "string"
+                    },
+                    "v": {
+                        "type": "string"
+                    },
+                    "r": {
+                        "type": "string"
+                    },
+                    "s": {
+                        "type": "string"
+                    }
+                }
+            },
+            "WatchBlocksV1BlockData": {
+                "type": "object",
+                "required": [
+                    "number",
+                    "hash",
+                    "parentHash",
+                    "nonce",
+                    "sha3Uncles",
+                    "logsBloom",
+                    "transactionRoot",
+                    "stateRoot",
+                    "receiptRoot",
+                    "miner",
+                    "extraData",
+                    "gasLimit",
+                    "gasUsed",
+                    "timestamp",
+                    "size",
+                    "totalDifficulty",
+                    "uncles",
+                    "transactions"
+                ],
+                "properties": {
+                    "number": {
+                        "type": "number"
+                    },
+                    "hash": {
+                        "type": "string"
+                    },
+                    "parentHash": {
+                        "type": "string"
+                    },
+                    "nonce": {
+                        "type": "string"
+                    },
+                    "sha3Uncles": {
+                        "type": "string"
+                    },
+                    "logsBloom": {
+                        "type": "string"
+                    },
+                    "transactionsRoot": {
+                        "type": "string"
+                    },
+                    "stateRoot": {
+                        "type": "string"
+                    },
+                    "receiptsRoot": {
+                        "type": "string"
+                    },
+                    "difficulty": {
+                        "type": "string"
+                    },
+                    "mixHash": {
+                        "type": "string"
+                    },
+                    "miner": {
+                        "type": "string"
+                    },
+                    "extraData": {
+                        "type": "string"
+                    },
+                    "gasLimit": {
+                        "type": "integer"
+                    },
+                    "gasUsed": {
+                        "type": "integer"
+                    },
+                    "timestamp": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ]
+                    },
+                    "size": {
+                        "type": "number"
+                    },
+                    "totalDifficulty": {
+                        "type": "string"
+                    },
+                    "uncles": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "transactions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Web3Transaction"
+                        }
+                    }
+                }
+            },
+            "WatchBlocksV1Progress": {
+                "type": "object",
+                "properties": {
+                    "blockHeader": {
+                        "$ref": "#/components/schemas/Web3BlockHeader"
+                    },
+                    "blockData": {
+                        "$ref": "#/components/schemas/WatchBlocksV1BlockData"
+                    }
+                }
             }
         }
     },
@@ -931,6 +1309,74 @@
                             "text/plain": {
                                 "schema": {
                                     "$ref": "#/components/schemas/PrometheusExporterMetricsResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/invoke-raw-web3eth-method": {
+            "post": {
+                "x-hyperledger-cactus": {
+                    "http": {
+                        "verbLowerCase": "post",
+                        "path": "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/invoke-raw-web3eth-method"
+                    }
+                },
+                "operationId": "invokeWeb3EthMethodV1",
+                "summary": "Invoke any method from web3.eth (low-level)",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/InvokeRawWeb3EthMethodV1Request"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InvokeRawWeb3EthMethodV1Response"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/invoke-raw-web3eth-contract": {
+            "post": {
+                "x-hyperledger-cactus": {
+                    "http": {
+                        "verbLowerCase": "post",
+                        "path": "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/invoke-raw-web3eth-contract"
+                    }
+                },
+                "operationId": "InvokeRawWeb3EthContractV1",
+                "summary": "Low-level endpoint to invoke a method on deployed contract.",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/InvokeRawWeb3EthContractV1Request"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InvokeRawWeb3EthContractV1Response"
                                 }
                             }
                         }

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/api-client/quorum-api-client.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/api-client/quorum-api-client.ts
@@ -1,0 +1,253 @@
+import { Observable, ReplaySubject } from "rxjs";
+import { finalize } from "rxjs/operators";
+import { io } from "socket.io-client";
+import { Logger, Checks } from "@hyperledger/cactus-common";
+import { LogLevelDesc, LoggerProvider } from "@hyperledger/cactus-common";
+import { Constants, ISocketApiClient } from "@hyperledger/cactus-core-api";
+import {
+  DefaultApi,
+  EthContractInvocationType,
+  InvokeRawWeb3EthContractV1Request,
+  WatchBlocksV1,
+  WatchBlocksV1Options,
+  WatchBlocksV1Progress,
+} from "../generated/openapi/typescript-axios";
+import { Configuration } from "../generated/openapi/typescript-axios/configuration";
+import { AbiItem } from "web3-utils";
+
+export class QuorumApiClientOptions extends Configuration {
+  readonly logLevel?: LogLevelDesc;
+  readonly wsApiHost?: string;
+  readonly wsApiPath?: string;
+}
+
+// Command 'web3Eth' input method type
+export type QuorumRequestInputWeb3EthMethod = {
+  type: "web3Eth";
+  command: string;
+};
+
+// Command 'web3EthContract' input method type
+export type QuorumRequestInputWeb3EthContractMethod = {
+  type: "web3EthContract";
+  command: EthContractInvocationType;
+  function: string;
+  params?: any[];
+};
+
+// Common input types for sending requests
+export type QuorumRequestInputContract = {
+  abi?: AbiItem[];
+  address?: string;
+};
+export type QuorumRequestInputMethod =
+  | QuorumRequestInputWeb3EthMethod
+  | QuorumRequestInputWeb3EthContractMethod;
+export type QuorumRequestInputArgs = {
+  args?: any[] | Record<string, unknown>;
+};
+
+export class QuorumApiClient
+  extends DefaultApi
+  implements ISocketApiClient<WatchBlocksV1Progress> {
+  public static readonly CLASS_NAME = "QuorumApiClient";
+
+  private readonly log: Logger;
+  private readonly wsApiHost: string;
+  private readonly wsApiPath: string;
+
+  public get className(): string {
+    return QuorumApiClient.CLASS_NAME;
+  }
+
+  constructor(public readonly options: QuorumApiClientOptions) {
+    super(options);
+    const fnTag = `${this.className}#constructor()`;
+    Checks.truthy(options, `${fnTag} arg options`);
+
+    const level = this.options.logLevel || "INFO";
+    const label = this.className;
+    this.log = LoggerProvider.getOrCreate({ level, label });
+
+    this.wsApiHost = options.wsApiHost || options.basePath || location.host;
+    this.wsApiPath = options.wsApiPath || Constants.SocketIoConnectionPathV1;
+    this.log.debug(`Created ${this.className} OK.`);
+    this.log.debug(`wsApiHost=${this.wsApiHost}`);
+    this.log.debug(`wsApiPath=${this.wsApiPath}`);
+    this.log.debug(`basePath=${this.options.basePath}`);
+  }
+
+  public watchBlocksV1(
+    options?: WatchBlocksV1Options,
+  ): Observable<WatchBlocksV1Progress> {
+    const socket = io(this.wsApiHost, { path: this.wsApiPath });
+    const subject = new ReplaySubject<WatchBlocksV1Progress>(0);
+
+    socket.on(WatchBlocksV1.Next, (data: WatchBlocksV1Progress) => {
+      this.log.debug("Received WatchBlocksV1.Next");
+      subject.next(data);
+    });
+
+    socket.on(WatchBlocksV1.Error, (ex: string) => {
+      this.log.warn("Received WatchBlocksV1.Error:", ex);
+      subject.error(ex);
+    });
+
+    socket.on(WatchBlocksV1.Complete, () => {
+      this.log.debug("Received WatchBlocksV1.Complete");
+      subject.complete();
+    });
+
+    socket.on("connect", () => {
+      this.log.info("Connected OK, sending WatchBlocksV1.Subscribe request...");
+      socket.emit(WatchBlocksV1.Subscribe, options);
+    });
+
+    socket.connect();
+
+    return subject.pipe(
+      finalize(() => {
+        this.log.info("FINALIZE - unsubscribing from the stream...");
+        socket.emit(WatchBlocksV1.Unsubscribe);
+        socket.disconnect();
+      }),
+    );
+  }
+
+  /**
+   * Immediately sends request to the validator, doesn't report any error or responses.
+   * @param contract - contract to execute on the ledger.
+   * @param method - function / method to be executed by validator.
+   * @param args - arguments.
+   * @note Internally, it's just a wrapper around sendSyncRequest, but handles the promise resolution seamlessly.
+   * @deprecated Use QuorumApiClient REST calls directly.
+   */
+  public sendAsyncRequest(
+    contract: QuorumRequestInputContract,
+    method: QuorumRequestInputMethod,
+    args: QuorumRequestInputArgs,
+  ): void {
+    const callName = `${method.type} - ${method.command}`;
+    this.log.debug("sendAsyncRequest()", callName);
+
+    this.sendSyncRequest(contract, method, args)
+      .then((value) => {
+        this.log.info(`sendAsyncRequest call resolved (${callName})`);
+        this.log.debug("sendAsyncRequest results:", JSON.stringify(value));
+      })
+      .catch((err) => {
+        this.log.warn(`sendAsyncRequest failed (${callName}). Error:`, err);
+      });
+  }
+
+  private sendWeb3EthRequest(
+    method: QuorumRequestInputWeb3EthMethod,
+    args?: any[],
+  ): Promise<any> {
+    return new Promise((resolve, reject) => {
+      // Check parameters
+      Checks.nonBlankString(method.command, "Method command must not be empty");
+      if (args && !Array.isArray(args)) {
+        throw new Error("web3Eth arguments (args) must be an array");
+      }
+
+      // Prepare input
+      const invokeArgs = {
+        methodName: method.command,
+        params: args,
+      };
+
+      // Call the endpoint
+      this.invokeWeb3EthMethodV1(invokeArgs)
+        .then((value) => {
+          this.log.debug("sendWeb3EthRequest() OK");
+          resolve(value.data);
+        })
+        .catch((err) => {
+          this.log.debug("sendWeb3EthRequest() Error:", err);
+          reject(err);
+        });
+    });
+  }
+
+  private sendWeb3EthContractRequest(
+    contract: QuorumRequestInputContract,
+    method: QuorumRequestInputWeb3EthContractMethod,
+    args?: Record<string, unknown>,
+  ): Promise<any> {
+    return new Promise((resolve, reject) => {
+      // Check parameters
+      Checks.truthy(contract.abi, "Contract ABI must be defined");
+      Checks.truthy(contract.address, "Contract address must be set");
+      if (!Object.values(EthContractInvocationType).includes(method.command)) {
+        throw new Error(
+          `Unknown invocationType (${method.command}), must be specified in EthContractInvocationType`,
+        );
+      }
+      Checks.nonBlankString(
+        method.function,
+        "contractMethod (method.function) must not be empty",
+      );
+      if (method.params && !Array.isArray(method.params)) {
+        throw new Error(
+          "Contract method arguments (method.params) must be an array",
+        );
+      }
+
+      // Prepare input
+      const invokeArgs: InvokeRawWeb3EthContractV1Request = {
+        abi: contract.abi as AbiItem[],
+        address: contract.address as string,
+        invocationType: method.command,
+        invocationParams: args,
+        contractMethod: method.function,
+        contractMethodArgs: method.params,
+      };
+
+      // Call the endpoint
+      this.invokeRawWeb3EthContractV1(invokeArgs)
+        .then((value) => {
+          resolve(value.data);
+        })
+        .catch((err) => {
+          reject(err);
+        });
+    });
+  }
+
+  /**
+   * Sends request to be executed on the ledger, watches and reports any error and the response from a ledger.
+   * @param contract - contract to execute on the ledger.
+   * @param method - function / method specification to be executed by validator.
+   * @param args - arguments.
+   * @returns Promise that will resolve with response from the ledger, or reject when error occurred.
+   * @deprecated Use QuorumApiClient REST calls directly.
+   */
+  public sendSyncRequest(
+    contract: QuorumRequestInputContract,
+    method: QuorumRequestInputMethod,
+    args: QuorumRequestInputArgs,
+  ): Promise<any> {
+    this.log.debug("sendSyncRequest()");
+
+    switch (method.type) {
+      case "web3Eth": {
+        this.log.info("Send 'web3Eth' request command");
+        return this.sendWeb3EthRequest(method, args.args as any);
+      }
+      case "web3EthContract": {
+        this.log.info("Send 'web3EthContract' request command");
+        return this.sendWeb3EthContractRequest(
+          contract,
+          method,
+          args.args as any,
+        );
+      }
+      default:
+        const value: never = method;
+        return Promise.reject(
+          `Not support request method on Quorum: ${JSON.stringify(value)}`,
+        );
+    }
+  }
+}

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -226,8 +226,10 @@ export interface DeployContractSolidityBytecodeV1Response {
  */
 
 export enum EthContractInvocationType {
-    Send = 'SEND',
-    Call = 'CALL'
+    Send = 'send',
+    Call = 'call',
+    EncodeAbi = 'encodeABI',
+    EstimateGas = 'estimateGas'
 }
 
 /**
@@ -404,6 +406,118 @@ export interface InvokeContractV1Response {
 /**
  * 
  * @export
+ * @interface InvokeRawWeb3EthContractV1Request
+ */
+export interface InvokeRawWeb3EthContractV1Request {
+    /**
+     * The application binary interface of the solidity contract
+     * @type {Array<any>}
+     * @memberof InvokeRawWeb3EthContractV1Request
+     */
+    abi: Array<any>;
+    /**
+     * Deployed solidity contract address
+     * @type {string}
+     * @memberof InvokeRawWeb3EthContractV1Request
+     */
+    address: string;
+    /**
+     * 
+     * @type {EthContractInvocationType}
+     * @memberof InvokeRawWeb3EthContractV1Request
+     */
+    invocationType: EthContractInvocationType;
+    /**
+     * The list of arguments for contract invocation method (send, call, etc...)
+     * @type {object}
+     * @memberof InvokeRawWeb3EthContractV1Request
+     */
+    invocationParams?: object;
+    /**
+     * Method of deployed solidity contract to execute
+     * @type {string}
+     * @memberof InvokeRawWeb3EthContractV1Request
+     */
+    contractMethod: string;
+    /**
+     * The list of arguments for deployed solidity contract method
+     * @type {Array<any>}
+     * @memberof InvokeRawWeb3EthContractV1Request
+     */
+    contractMethodArgs?: Array<any>;
+}
+/**
+ * 
+ * @export
+ * @interface InvokeRawWeb3EthContractV1Response
+ */
+export interface InvokeRawWeb3EthContractV1Response {
+    /**
+     * Status code of the operation
+     * @type {number}
+     * @memberof InvokeRawWeb3EthContractV1Response
+     */
+    status: number;
+    /**
+     * Output of contract invocation method
+     * @type {any}
+     * @memberof InvokeRawWeb3EthContractV1Response
+     */
+    data?: any | null;
+    /**
+     * Error details
+     * @type {string}
+     * @memberof InvokeRawWeb3EthContractV1Response
+     */
+    errorDetail?: string;
+}
+/**
+ * 
+ * @export
+ * @interface InvokeRawWeb3EthMethodV1Request
+ */
+export interface InvokeRawWeb3EthMethodV1Request {
+    /**
+     * The name of the web3.eth method to invoke
+     * @type {string}
+     * @memberof InvokeRawWeb3EthMethodV1Request
+     */
+    methodName: string;
+    /**
+     * The list of arguments to pass to web3.eth method specified in methodName
+     * @type {Array<any>}
+     * @memberof InvokeRawWeb3EthMethodV1Request
+     */
+    params?: Array<any>;
+}
+/**
+ * 
+ * @export
+ * @interface InvokeRawWeb3EthMethodV1Response
+ */
+export interface InvokeRawWeb3EthMethodV1Response {
+    /**
+     * Status code of the operation
+     * @type {number}
+     * @memberof InvokeRawWeb3EthMethodV1Response
+     */
+    status: number;
+    /**
+     * Output of requested web3.eth method
+     * @type {any}
+     * @memberof InvokeRawWeb3EthMethodV1Response
+     */
+    data?: any | null;
+    /**
+     * Error details
+     * @type {string}
+     * @memberof InvokeRawWeb3EthMethodV1Response
+     */
+    errorDetail?: string;
+}
+/**
+ * 
+ * @export
  * @interface QuorumTransactionConfig
  */
 export interface QuorumTransactionConfig {
@@ -564,6 +678,282 @@ export interface SolidityContractJsonArtifact {
     gasEstimates?: object;
 }
 /**
+ * 
+ * @export
+ * @enum {string}
+ */
+
+export enum WatchBlocksV1 {
+    Subscribe = 'org.hyperledger.cactus.api.async.quorum.WatchBlocksV1.Subscribe',
+    Next = 'org.hyperledger.cactus.api.async.quorum.WatchBlocksV1.Next',
+    Unsubscribe = 'org.hyperledger.cactus.api.async.quorum.WatchBlocksV1.Unsubscribe',
+    Error = 'org.hyperledger.cactus.api.async.quorum.WatchBlocksV1.Error',
+    Complete = 'org.hyperledger.cactus.api.async.quorum.WatchBlocksV1.Complete'
+}
+
+/**
+ * 
+ * @export
+ * @interface WatchBlocksV1BlockData
+ */
+export interface WatchBlocksV1BlockData {
+    /**
+     * 
+     * @type {number}
+     * @memberof WatchBlocksV1BlockData
+     */
+    number: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof WatchBlocksV1BlockData
+     */
+    hash: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof WatchBlocksV1BlockData
+     */
+    parentHash: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof WatchBlocksV1BlockData
+     */
+    nonce: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof WatchBlocksV1BlockData
+     */
+    sha3Uncles: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof WatchBlocksV1BlockData
+     */
+    logsBloom: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof WatchBlocksV1BlockData
+     */
+    transactionsRoot?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof WatchBlocksV1BlockData
+     */
+    stateRoot: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof WatchBlocksV1BlockData
+     */
+    receiptsRoot?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof WatchBlocksV1BlockData
+     */
+    difficulty?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof WatchBlocksV1BlockData
+     */
+    mixHash?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof WatchBlocksV1BlockData
+     */
+    miner: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof WatchBlocksV1BlockData
+     */
+    extraData: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof WatchBlocksV1BlockData
+     */
+    gasLimit: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof WatchBlocksV1BlockData
+     */
+    gasUsed: number;
+    /**
+     * 
+     * @type {string | number}
+     * @memberof WatchBlocksV1BlockData
+     */
+    timestamp: string | number;
+    /**
+     * 
+     * @type {number}
+     * @memberof WatchBlocksV1BlockData
+     */
+    size: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof WatchBlocksV1BlockData
+     */
+    totalDifficulty: string;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof WatchBlocksV1BlockData
+     */
+    uncles: Array<string>;
+    /**
+     * 
+     * @type {Array<Web3Transaction>}
+     * @memberof WatchBlocksV1BlockData
+     */
+    transactions: Array<Web3Transaction>;
+}
+/**
+ * 
+ * @export
+ * @interface WatchBlocksV1Options
+ */
+export interface WatchBlocksV1Options {
+    /**
+     * 
+     * @type {boolean}
+     * @memberof WatchBlocksV1Options
+     */
+    getBlockData?: boolean;
+}
+/**
+ * 
+ * @export
+ * @interface WatchBlocksV1Progress
+ */
+export interface WatchBlocksV1Progress {
+    /**
+     * 
+     * @type {Web3BlockHeader}
+     * @memberof WatchBlocksV1Progress
+     */
+    blockHeader?: Web3BlockHeader;
+    /**
+     * 
+     * @type {WatchBlocksV1BlockData}
+     * @memberof WatchBlocksV1Progress
+     */
+    blockData?: WatchBlocksV1BlockData;
+}
+/**
+ * 
+ * @export
+ * @interface Web3BlockHeader
+ */
+export interface Web3BlockHeader {
+    /**
+     * 
+     * @type {number}
+     * @memberof Web3BlockHeader
+     */
+    number: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3BlockHeader
+     */
+    hash: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3BlockHeader
+     */
+    parentHash: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3BlockHeader
+     */
+    nonce: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3BlockHeader
+     */
+    sha3Uncles: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3BlockHeader
+     */
+    logsBloom: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3BlockHeader
+     */
+    transactionsRoot?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3BlockHeader
+     */
+    stateRoot: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3BlockHeader
+     */
+    receiptsRoot?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3BlockHeader
+     */
+    difficulty?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3BlockHeader
+     */
+    mixHash?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3BlockHeader
+     */
+    miner: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3BlockHeader
+     */
+    extraData: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof Web3BlockHeader
+     */
+    gasLimit: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof Web3BlockHeader
+     */
+    gasUsed: number;
+    /**
+     * 
+     * @type {string | number}
+     * @memberof Web3BlockHeader
+     */
+    timestamp: string | number;
+}
+/**
  * @type Web3SigningCredential
  * @export
  */
@@ -676,6 +1066,97 @@ export enum Web3SigningCredentialType {
     None = 'NONE'
 }
 
+/**
+ * 
+ * @export
+ * @interface Web3Transaction
+ */
+export interface Web3Transaction {
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3Transaction
+     */
+    hash: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof Web3Transaction
+     */
+    nonce: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3Transaction
+     */
+    blockHash: string | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof Web3Transaction
+     */
+    blockNumber: number | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof Web3Transaction
+     */
+    transactionIndex: number | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3Transaction
+     */
+    from: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3Transaction
+     */
+    to: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3Transaction
+     */
+    value: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3Transaction
+     */
+    gasPrice: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof Web3Transaction
+     */
+    gas: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3Transaction
+     */
+    input: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3Transaction
+     */
+    v?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3Transaction
+     */
+    r?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Web3Transaction
+     */
+    s?: string;
+}
 /**
  * 
  * @export
@@ -914,6 +1395,74 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
+         * @summary Low-level endpoint to invoke a method on deployed contract.
+         * @param {InvokeRawWeb3EthContractV1Request} [invokeRawWeb3EthContractV1Request] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        invokeRawWeb3EthContractV1: async (invokeRawWeb3EthContractV1Request?: InvokeRawWeb3EthContractV1Request, options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/invoke-raw-web3eth-contract`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(invokeRawWeb3EthContractV1Request, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Invoke any method from web3.eth (low-level)
+         * @param {InvokeRawWeb3EthMethodV1Request} [invokeRawWeb3EthMethodV1Request] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        invokeWeb3EthMethodV1: async (invokeRawWeb3EthMethodV1Request?: InvokeRawWeb3EthMethodV1Request, options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/invoke-raw-web3eth-method`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(invokeRawWeb3EthMethodV1Request, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary Executes a transaction on a quorum ledger
          * @param {RunTransactionRequest} [runTransactionRequest] 
          * @param {*} [options] Override http request option.
@@ -1012,6 +1561,28 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @summary Low-level endpoint to invoke a method on deployed contract.
+         * @param {InvokeRawWeb3EthContractV1Request} [invokeRawWeb3EthContractV1Request] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async invokeRawWeb3EthContractV1(invokeRawWeb3EthContractV1Request?: InvokeRawWeb3EthContractV1Request, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<InvokeRawWeb3EthContractV1Response>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.invokeRawWeb3EthContractV1(invokeRawWeb3EthContractV1Request, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
+         * @summary Invoke any method from web3.eth (low-level)
+         * @param {InvokeRawWeb3EthMethodV1Request} [invokeRawWeb3EthMethodV1Request] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async invokeWeb3EthMethodV1(invokeRawWeb3EthMethodV1Request?: InvokeRawWeb3EthMethodV1Request, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<InvokeRawWeb3EthMethodV1Response>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.invokeWeb3EthMethodV1(invokeRawWeb3EthMethodV1Request, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
          * @summary Executes a transaction on a quorum ledger
          * @param {RunTransactionRequest} [runTransactionRequest] 
          * @param {*} [options] Override http request option.
@@ -1079,6 +1650,26 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          */
         invokeContractV1NoKeychain(invokeContractJsonObjectV1Request?: InvokeContractJsonObjectV1Request, options?: any): AxiosPromise<InvokeContractV1Response> {
             return localVarFp.invokeContractV1NoKeychain(invokeContractJsonObjectV1Request, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Low-level endpoint to invoke a method on deployed contract.
+         * @param {InvokeRawWeb3EthContractV1Request} [invokeRawWeb3EthContractV1Request] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        invokeRawWeb3EthContractV1(invokeRawWeb3EthContractV1Request?: InvokeRawWeb3EthContractV1Request, options?: any): AxiosPromise<InvokeRawWeb3EthContractV1Response> {
+            return localVarFp.invokeRawWeb3EthContractV1(invokeRawWeb3EthContractV1Request, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Invoke any method from web3.eth (low-level)
+         * @param {InvokeRawWeb3EthMethodV1Request} [invokeRawWeb3EthMethodV1Request] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        invokeWeb3EthMethodV1(invokeRawWeb3EthMethodV1Request?: InvokeRawWeb3EthMethodV1Request, options?: any): AxiosPromise<InvokeRawWeb3EthMethodV1Response> {
+            return localVarFp.invokeWeb3EthMethodV1(invokeRawWeb3EthMethodV1Request, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -1157,6 +1748,30 @@ export class DefaultApi extends BaseAPI {
      */
     public invokeContractV1NoKeychain(invokeContractJsonObjectV1Request?: InvokeContractJsonObjectV1Request, options?: any) {
         return DefaultApiFp(this.configuration).invokeContractV1NoKeychain(invokeContractJsonObjectV1Request, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Low-level endpoint to invoke a method on deployed contract.
+     * @param {InvokeRawWeb3EthContractV1Request} [invokeRawWeb3EthContractV1Request] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public invokeRawWeb3EthContractV1(invokeRawWeb3EthContractV1Request?: InvokeRawWeb3EthContractV1Request, options?: any) {
+        return DefaultApiFp(this.configuration).invokeRawWeb3EthContractV1(invokeRawWeb3EthContractV1Request, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Invoke any method from web3.eth (low-level)
+     * @param {InvokeRawWeb3EthMethodV1Request} [invokeRawWeb3EthMethodV1Request] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public invokeWeb3EthMethodV1(invokeRawWeb3EthMethodV1Request?: InvokeRawWeb3EthMethodV1Request, options?: any) {
+        return DefaultApiFp(this.configuration).invokeWeb3EthMethodV1(invokeRawWeb3EthMethodV1Request, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/plugin-ledger-connector-quorum.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/plugin-ledger-connector-quorum.ts
@@ -1,12 +1,14 @@
 import { Server } from "http";
 import { Server as SecureServer } from "https";
+import type {
+  Server as SocketIoServer,
+  Socket as SocketIoSocket,
+} from "socket.io";
 
 import { Express } from "express";
 import Web3 from "web3";
-// The strange way of obtaining the contract class here is like this because
-// web3-eth internally sub-classes the Contract class at runtime
-// @see https://stackoverflow.com/a/63639280/698470
-const Contract = new Web3().eth.Contract;
+import { AbiItem } from "web3-utils";
+import { Contract } from "web3-eth-contract";
 import { ContractSendMethod } from "web3-eth-contract";
 import { TransactionReceipt } from "web3-eth";
 
@@ -50,23 +52,28 @@ import {
   Web3SigningCredentialCactusKeychainRef,
   Web3SigningCredentialPrivateKeyHex,
   Web3SigningCredentialType,
+  WatchBlocksV1,
+  WatchBlocksV1Options,
+  InvokeRawWeb3EthMethodV1Request,
+  InvokeRawWeb3EthContractV1Request,
 } from "./generated/openapi/typescript-axios/";
 
 import { RunTransactionEndpoint } from "./web-services/run-transaction-endpoint";
 import { InvokeContractEndpoint } from "./web-services/invoke-contract-endpoint";
 import { InvokeContractJsonObjectEndpoint } from "./web-services/invoke-contract-endpoint-json-object";
-import { isWeb3SigningCredentialNone } from "./model-type-guards";
+import { WatchBlocksV1Endpoint } from "./web-services/watch-blocks-v1-endpoint";
+import { GetPrometheusExporterMetricsEndpointV1 } from "./web-services/get-prometheus-exporter-metrics-endpoint-v1";
+import { InvokeRawWeb3EthMethodEndpoint } from "./web-services/invoke-raw-web3eth-method-v1-endpoint";
+import { InvokeRawWeb3EthContractEndpoint } from "./web-services/invoke-raw-web3eth-contract-v1-endpoint";
 
+import { isWeb3SigningCredentialNone } from "./model-type-guards";
 import { PrometheusExporter } from "./prometheus-exporter/prometheus-exporter";
-import {
-  GetPrometheusExporterMetricsEndpointV1,
-  IGetPrometheusExporterMetricsEndpointV1Options,
-} from "./web-services/get-prometheus-exporter-metrics-endpoint-v1";
 import { RuntimeError } from "run-time-error";
 
 export interface IPluginLedgerConnectorQuorumOptions
   extends ICactusPluginOptions {
   rpcApiHttpHost: string;
+  rpcApiWsHost?: string;
   logLevel?: LogLevelDesc;
   prometheusExporter?: PrometheusExporter;
   pluginRegistry: PluginRegistry;
@@ -96,6 +103,14 @@ export class PluginLedgerConnectorQuorum
     return PluginLedgerConnectorQuorum.CLASS_NAME;
   }
 
+  private getWeb3Provider() {
+    if (!this.options.rpcApiWsHost) {
+      return new Web3.providers.HttpProvider(this.options.rpcApiHttpHost);
+    }
+
+    return new Web3.providers.WebsocketProvider(this.options.rpcApiWsHost);
+  }
+
   constructor(public readonly options: IPluginLedgerConnectorQuorumOptions) {
     const fnTag = `${this.className}#constructor()`;
     Checks.truthy(options, `${fnTag} arg options`);
@@ -107,10 +122,7 @@ export class PluginLedgerConnectorQuorum
     const label = this.className;
     this.log = LoggerProvider.getOrCreate({ level, label });
 
-    const web3Provider = new Web3.providers.HttpProvider(
-      this.options.rpcApiHttpHost,
-    );
-    this.web3 = new Web3(web3Provider);
+    this.web3 = new Web3(this.getWeb3Provider());
     this.instanceId = options.instanceId;
     this.pluginRegistry = options.pluginRegistry as PluginRegistry;
     this.prometheusExporter =
@@ -144,18 +156,42 @@ export class PluginLedgerConnectorQuorum
 
   public async shutdown(): Promise<void> {
     this.log.info(`Shutting down ${this.className}...`);
+    const provider = this.web3.currentProvider;
+    if (provider && typeof provider == "object") {
+      if ("disconnect" in provider) {
+        provider.disconnect(1000, "shutdown");
+      }
+    }
   }
 
   public async onPluginInit(): Promise<unknown> {
     return;
   }
 
-  async registerWebServices(app: Express): Promise<IWebServiceEndpoint[]> {
+  async registerWebServices(
+    app: Express,
+    wsApi: SocketIoServer,
+  ): Promise<IWebServiceEndpoint[]> {
+    const { web3 } = this;
+    const { logLevel } = this.options;
     const webServices = await this.getOrCreateWebServices();
     await Promise.all(webServices.map((ws) => ws.registerExpress(app)));
+
+    wsApi.on("connection", (socket: SocketIoSocket) => {
+      this.log.debug(`New Socket connected. ID=${socket.id}`);
+
+      socket.on(WatchBlocksV1.Subscribe, (options?: WatchBlocksV1Options) => {
+        new WatchBlocksV1Endpoint({
+          web3,
+          socket,
+          logLevel,
+          options,
+        }).subscribe();
+      });
+    });
+
     return webServices;
   }
-
   public async getOrCreateWebServices(): Promise<IWebServiceEndpoint[]> {
     if (Array.isArray(this.endpoints)) {
       return this.endpoints;
@@ -197,11 +233,24 @@ export class PluginLedgerConnectorQuorum
       endpoints.push(endpoint);
     }
     {
-      const opts: IGetPrometheusExporterMetricsEndpointV1Options = {
+      const endpoint = new GetPrometheusExporterMetricsEndpointV1({
         connector: this,
         logLevel: this.options.logLevel,
-      };
-      const endpoint = new GetPrometheusExporterMetricsEndpointV1(opts);
+      });
+      endpoints.push(endpoint);
+    }
+    {
+      const endpoint = new InvokeRawWeb3EthMethodEndpoint({
+        connector: this,
+        logLevel: this.options.logLevel,
+      });
+      endpoints.push(endpoint);
+    }
+    {
+      const endpoint = new InvokeRawWeb3EthContractEndpoint({
+        connector: this,
+        logLevel: this.options.logLevel,
+      });
       endpoints.push(endpoint);
     }
     this.endpoints = endpoints;
@@ -252,12 +301,15 @@ export class PluginLedgerConnectorQuorum
 
     const { methods } = contract;
 
-    return Object.prototype.hasOwnProperty.call(methods, name);
+    return (
+      Object.prototype.hasOwnProperty.call(methods, name) &&
+      typeof methods[name] === "function"
+    );
   }
 
   public async getContractInfoKeychain(
     req: InvokeContractV1Request,
-  ): Promise<any> {
+  ): Promise<InvokeContractV1Response> {
     const fnTag = `${this.className}#invokeContract()`;
 
     const { contractName, keychainId } = req;
@@ -277,7 +329,6 @@ export class PluginLedgerConnectorQuorum
     }
     const contractStr = await keychainPlugin.get(contractName);
     const contractJSON = JSON.parse(contractStr);
-    (req as any).contractJSON = contractJSON;
 
     // if not exists a contract deployed, we deploy it
     const networkId = await this.web3.eth.net.getId();
@@ -299,14 +350,17 @@ export class PluginLedgerConnectorQuorum
       contractJSON.networks = network;
       keychainPlugin.set(req.contractName, JSON.stringify(contractJSON));
     }
-    (req as any).contractAddress = contractJSON.networks[networkId].address;
 
-    return this.invokeContract(req);
+    return this.invokeContract({
+      ...req,
+      contractAddress: contractJSON.networks[networkId].address,
+      contractJSON: contractJSON,
+    });
   }
 
   public async getContractInfo(
     req: InvokeContractJsonObjectV1Request,
-  ): Promise<any> {
+  ): Promise<InvokeContractV1Response> {
     const fnTag = `${this.className}#invokeContractNoKeychain()`;
     const { contractJSON, contractAddress } = req;
     if (!contractJSON) {
@@ -318,7 +372,9 @@ export class PluginLedgerConnectorQuorum
     return this.invokeContract(req);
   }
 
-  public async invokeContract(req: any): Promise<InvokeContractV1Response> {
+  public async invokeContract(
+    req: InvokeContractJsonObjectV1Request,
+  ): Promise<InvokeContractV1Response> {
     const fnTag = `${this.className}#invokeContract()`;
 
     const { contractAddress, contractJSON } = req;
@@ -653,5 +709,81 @@ export class PluginLedgerConnectorQuorum
       );
     }
     return this.runDeploy(req);
+  }
+
+  // Low level function to call any method from web3.eth
+  // Should be used only if given functionality is not already covered by another endpoint.
+  public async invokeRawWeb3EthMethod(
+    args: InvokeRawWeb3EthMethodV1Request,
+  ): Promise<any> {
+    return new Promise((resolve, rejects) => {
+      this.log.debug("invokeRawWeb3EthMethod input:", JSON.stringify(args));
+
+      Checks.nonBlankString(
+        args.methodName,
+        "web3.eth method string must not be empty",
+      );
+
+      const looseWeb3Eth = this.web3.eth as any;
+      if (
+        Object.prototype.hasOwnProperty.call(looseWeb3Eth, args.methodName) &&
+        typeof looseWeb3Eth[args.methodName] === "function"
+      ) {
+        const web3Method = looseWeb3Eth[args.methodName];
+
+        const web3Response: Promise<unknown> = args.params
+          ? web3Method(...args.params)
+          : web3Method();
+
+        web3Response
+          .then((result: any) => {
+            this.log.debug("invokeRawWeb3EthMethod response (OK):", result);
+            return resolve(result);
+          })
+          .catch((err) => {
+            this.log.warn("invokeRawWeb3EthMethod response (ERROR):", err);
+            rejects(err);
+          });
+      } else {
+        rejects(new Error(`No method "${args.methodName}" in web3.eth`));
+      }
+    });
+  }
+
+  // Low level function to invoke contract
+  // Should be used only if given functionality is not already covered by another endpoint.
+  public async invokeRawWeb3EthContract(
+    args: InvokeRawWeb3EthContractV1Request,
+  ): Promise<any> {
+    this.log.debug("invokeRawWeb3EthContract input:", JSON.stringify(args));
+
+    const contractMethodArgs = args.contractMethodArgs || [];
+
+    if (
+      !Object.values(EthContractInvocationType).includes(args.invocationType)
+    ) {
+      throw new Error(
+        `Unknown invocationType (${args.invocationType}), must be specified in EthContractInvocationType`,
+      );
+    }
+
+    const contract = new this.web3.eth.Contract(
+      args.abi as AbiItem[],
+      args.address,
+    );
+
+    const isSafeToCall = await this.isSafeToCallContractMethod(
+      contract,
+      args.contractMethod,
+    );
+    if (!isSafeToCall) {
+      throw new RuntimeError(
+        `Invalid method name provided in request. ${args.contractMethod} does not exist on the Web3 contract object's "methods" property.`,
+      );
+    }
+
+    return contract.methods[args.contractMethod](...contractMethodArgs)[
+      args.invocationType
+    ](args.invocationParams);
   }
 }

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/public-api.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/public-api.ts
@@ -12,6 +12,18 @@ export { PluginFactoryLedgerConnector } from "./plugin-factory-ledger-connector"
 import { IPluginFactoryOptions } from "@hyperledger/cactus-core-api";
 import { PluginFactoryLedgerConnector } from "./plugin-factory-ledger-connector";
 
+export {
+  QuorumApiClient,
+  QuorumApiClientOptions,
+  QuorumRequestInputWeb3EthMethod,
+  QuorumRequestInputWeb3EthContractMethod,
+  QuorumRequestInputContract,
+  QuorumRequestInputMethod,
+  QuorumRequestInputArgs,
+} from "./api-client/quorum-api-client";
+
+export * from "./generated/openapi/typescript-axios/api";
+
 export async function createPluginFactory(
   pluginFactoryOptions: IPluginFactoryOptions,
 ): Promise<PluginFactoryLedgerConnector> {

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/invoke-raw-web3eth-contract-v1-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/invoke-raw-web3eth-contract-v1-endpoint.ts
@@ -1,0 +1,109 @@
+import { Express, Request, Response } from "express";
+import {
+  Logger,
+  Checks,
+  LogLevelDesc,
+  LoggerProvider,
+  IAsyncProvider,
+} from "@hyperledger/cactus-common";
+import {
+  IEndpointAuthzOptions,
+  IExpressRequestHandler,
+  IWebServiceEndpoint,
+} from "@hyperledger/cactus-core-api";
+import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";
+import { PluginLedgerConnectorQuorum } from "../plugin-ledger-connector-quorum";
+import OAS from "../../json/openapi.json";
+import sanitizeHtml from "sanitize-html";
+import { InvokeRawWeb3EthContractV1Response } from "../generated/openapi/typescript-axios";
+
+export interface IInvokeRawWeb3EthContractEndpointOptions {
+  logLevel?: LogLevelDesc;
+  connector: PluginLedgerConnectorQuorum;
+}
+
+export class InvokeRawWeb3EthContractEndpoint implements IWebServiceEndpoint {
+  public static readonly CLASS_NAME = "InvokeRawWeb3EthContractEndpoint";
+
+  private readonly log: Logger;
+
+  public get className(): string {
+    return InvokeRawWeb3EthContractEndpoint.CLASS_NAME;
+  }
+
+  constructor(
+    public readonly options: IInvokeRawWeb3EthContractEndpointOptions,
+  ) {
+    const fnTag = `${this.className}#constructor()`;
+    Checks.truthy(options, `${fnTag} arg options`);
+    Checks.truthy(options.connector, `${fnTag} arg options.connector`);
+
+    const level = this.options.logLevel || "INFO";
+    const label = this.className;
+    this.log = LoggerProvider.getOrCreate({ level, label });
+  }
+
+  public get oasPath(): typeof OAS.paths["/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/invoke-raw-web3eth-contract"] {
+    return OAS.paths[
+      "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/invoke-raw-web3eth-contract"
+    ];
+  }
+
+  public getPath(): string {
+    return this.oasPath.post["x-hyperledger-cactus"].http.path;
+  }
+
+  public getVerbLowerCase(): string {
+    return this.oasPath.post["x-hyperledger-cactus"].http.verbLowerCase;
+  }
+
+  public getOperationId(): string {
+    return this.oasPath.post.operationId;
+  }
+
+  getAuthorizationOptionsProvider(): IAsyncProvider<IEndpointAuthzOptions> {
+    // TODO: make this an injectable dependency in the constructor
+    return {
+      get: async () => ({
+        isProtected: true,
+        requiredRoles: [],
+      }),
+    };
+  }
+
+  public async registerExpress(
+    expressApp: Express,
+  ): Promise<IWebServiceEndpoint> {
+    await registerWebServiceEndpoint(expressApp, this);
+    return this;
+  }
+
+  public getExpressRequestHandler(): IExpressRequestHandler {
+    return this.handleRequest.bind(this);
+  }
+
+  public async handleRequest(req: Request, res: Response): Promise<void> {
+    const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
+    this.log.debug(reqTag);
+
+    try {
+      const methodResponse = await this.options.connector.invokeRawWeb3EthContract(
+        req.body,
+      );
+      const response: InvokeRawWeb3EthContractV1Response = {
+        status: 200,
+        data: methodResponse,
+      };
+      res.json(response);
+    } catch (ex: any) {
+      this.log.warn(`Error while serving ${reqTag}`, ex);
+      res.json({
+        status: 504,
+        errorDetail: sanitizeHtml(ex, {
+          allowedTags: [],
+          allowedAttributes: {},
+        }),
+      });
+    }
+  }
+}

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/invoke-raw-web3eth-method-v1-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/invoke-raw-web3eth-method-v1-endpoint.ts
@@ -1,0 +1,107 @@
+import { Express, Request, Response } from "express";
+import {
+  Logger,
+  Checks,
+  LogLevelDesc,
+  LoggerProvider,
+  IAsyncProvider,
+} from "@hyperledger/cactus-common";
+import {
+  IEndpointAuthzOptions,
+  IExpressRequestHandler,
+  IWebServiceEndpoint,
+} from "@hyperledger/cactus-core-api";
+import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";
+import { PluginLedgerConnectorQuorum } from "../plugin-ledger-connector-quorum";
+import OAS from "../../json/openapi.json";
+import sanitizeHtml from "sanitize-html";
+import { InvokeRawWeb3EthMethodV1Response } from "../public-api";
+
+export interface IInvokeRawWeb3EthMethodEndpointOptions {
+  logLevel?: LogLevelDesc;
+  connector: PluginLedgerConnectorQuorum;
+}
+
+export class InvokeRawWeb3EthMethodEndpoint implements IWebServiceEndpoint {
+  public static readonly CLASS_NAME = "InvokeRawWeb3EthMethodEndpoint";
+
+  private readonly log: Logger;
+
+  public get className(): string {
+    return InvokeRawWeb3EthMethodEndpoint.CLASS_NAME;
+  }
+
+  constructor(public readonly options: IInvokeRawWeb3EthMethodEndpointOptions) {
+    const fnTag = `${this.className}#constructor()`;
+    Checks.truthy(options, `${fnTag} arg options`);
+    Checks.truthy(options.connector, `${fnTag} arg options.connector`);
+
+    const level = this.options.logLevel || "INFO";
+    const label = this.className;
+    this.log = LoggerProvider.getOrCreate({ level, label });
+  }
+
+  public get oasPath(): typeof OAS.paths["/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/invoke-raw-web3eth-method"] {
+    return OAS.paths[
+      "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/invoke-raw-web3eth-method"
+    ];
+  }
+
+  public getPath(): string {
+    return this.oasPath.post["x-hyperledger-cactus"].http.path;
+  }
+
+  public getVerbLowerCase(): string {
+    return this.oasPath.post["x-hyperledger-cactus"].http.verbLowerCase;
+  }
+
+  public getOperationId(): string {
+    return this.oasPath.post.operationId;
+  }
+
+  getAuthorizationOptionsProvider(): IAsyncProvider<IEndpointAuthzOptions> {
+    // TODO: make this an injectable dependency in the constructor
+    return {
+      get: async () => ({
+        isProtected: true,
+        requiredRoles: [],
+      }),
+    };
+  }
+
+  public async registerExpress(
+    expressApp: Express,
+  ): Promise<IWebServiceEndpoint> {
+    await registerWebServiceEndpoint(expressApp, this);
+    return this;
+  }
+
+  public getExpressRequestHandler(): IExpressRequestHandler {
+    return this.handleRequest.bind(this);
+  }
+
+  public async handleRequest(req: Request, res: Response): Promise<void> {
+    const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
+    this.log.debug(reqTag);
+
+    try {
+      const methodResponse = await this.options.connector.invokeRawWeb3EthMethod(
+        req.body,
+      );
+      const response: InvokeRawWeb3EthMethodV1Response = {
+        status: 200,
+        data: methodResponse,
+      };
+      res.json(response);
+    } catch (ex: any) {
+      this.log.warn(`Error while serving ${reqTag}`, ex);
+      res.json({
+        status: 504,
+        errorDetail: sanitizeHtml(ex, {
+          allowedTags: [],
+          allowedAttributes: {},
+        }),
+      });
+    }
+  }
+}

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/watch-blocks-v1-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/watch-blocks-v1-endpoint.ts
@@ -1,0 +1,103 @@
+import {
+  Logger,
+  LogLevelDesc,
+  LoggerProvider,
+  Checks,
+} from "@hyperledger/cactus-common";
+import {
+  WatchBlocksV1Options,
+  WatchBlocksV1Progress,
+  WatchBlocksV1,
+  WatchBlocksV1BlockData,
+} from "../generated/openapi/typescript-axios";
+import { Socket as SocketIoSocket } from "socket.io";
+import Web3 from "web3";
+
+export interface IWatchBlocksV1EndpointConfiguration {
+  logLevel?: LogLevelDesc;
+  socket: SocketIoSocket;
+  web3: Web3;
+  options?: WatchBlocksV1Options;
+}
+
+export class WatchBlocksV1Endpoint {
+  public static readonly CLASS_NAME = "WatchBlocksV1Endpoint";
+
+  private readonly log: Logger;
+  private readonly socket: SocketIoSocket<
+    Record<WatchBlocksV1, (next: string) => void>,
+    Record<WatchBlocksV1, (next: WatchBlocksV1Progress | string) => void>
+  >;
+  private readonly web3: Web3;
+  private readonly isGetBlockData: boolean;
+
+  public get className(): string {
+    return WatchBlocksV1Endpoint.CLASS_NAME;
+  }
+
+  constructor(public readonly config: IWatchBlocksV1EndpointConfiguration) {
+    const fnTag = `${this.className}#constructor()`;
+    Checks.truthy(config, `${fnTag} arg options`);
+    Checks.truthy(config.web3, `${fnTag} arg options.web3`);
+    Checks.truthy(config.socket, `${fnTag} arg options.socket`);
+
+    this.web3 = config.web3;
+    this.socket = config.socket;
+    this.isGetBlockData = config.options?.getBlockData == true;
+
+    const level = this.config.logLevel || "INFO";
+    const label = this.className;
+    this.log = LoggerProvider.getOrCreate({ level, label });
+  }
+
+  public async subscribe(): Promise<void> {
+    const { socket, log, web3, isGetBlockData } = this;
+    log.debug(`${WatchBlocksV1.Subscribe} => ${socket.id}`);
+
+    const sub = web3.eth.subscribe(
+      "newBlockHeaders",
+      async (ex, blockHeader) => {
+        log.debug("newBlockHeaders: Error=%o BlockHeader=%o", ex, blockHeader);
+
+        if (ex) {
+          socket.emit(WatchBlocksV1.Error, ex.message);
+          sub.unsubscribe();
+        } else if (blockHeader) {
+          let next: WatchBlocksV1Progress;
+
+          if (isGetBlockData) {
+            const web3BlockData = await web3.eth.getBlock(
+              blockHeader.hash,
+              true,
+            );
+
+            next = {
+              // difficulty and totalDifficulty returned from the ledger are string, forcing typecast
+              blockData: (web3BlockData as unknown) as WatchBlocksV1BlockData,
+            };
+          } else {
+            next = { blockHeader };
+          }
+
+          socket.emit(WatchBlocksV1.Next, next);
+        }
+      },
+    );
+
+    log.debug("Subscribing to Web3 new block headers event...");
+
+    socket.on("disconnect", async (reason: string) => {
+      log.debug("WebSocket:disconnect reason=%o", reason);
+      sub.unsubscribe((ex: Error, success: boolean) => {
+        log.debug("Web3 unsubscribe success=%o, ex=%", success, ex);
+      });
+    });
+
+    socket.on(WatchBlocksV1.Unsubscribe, () => {
+      log.debug(`${WatchBlocksV1.Unsubscribe}: unsubscribing Web3...`);
+      sub.unsubscribe((ex: Error, success: boolean) => {
+        log.debug("Web3 unsubscribe error=%o, success=%", ex, success);
+      });
+    });
+  }
+}

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/openapi/openapi-validation-no-keychain.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/openapi/openapi-validation-no-keychain.test.ts
@@ -30,8 +30,9 @@ import express from "express";
 import bodyParser from "body-parser";
 import http from "http";
 import { AddressInfo } from "net";
-import { Configuration } from "@hyperledger/cactus-core-api";
+import { Configuration, Constants } from "@hyperledger/cactus-core-api";
 import { PluginRegistry } from "@hyperledger/cactus-core";
+import { Server as SocketIoServer } from "socket.io";
 
 import { installOpenapiValidationMiddleware } from "@hyperledger/cactus-core";
 import OAS from "../../../../../../main/json/openapi.json";
@@ -97,6 +98,10 @@ test(testCase, async (t: Test) => {
   const apiConfig = new Configuration({ basePath: apiHost });
   const apiClient = new QuorumApi(apiConfig);
 
+  const wsApi = new SocketIoServer(server, {
+    path: Constants.SocketIoConnectionPathV1,
+  });
+
   await installOpenapiValidationMiddleware({
     logLevel,
     app: expressApp,
@@ -104,7 +109,7 @@ test(testCase, async (t: Test) => {
   });
 
   await connector.getOrCreateWebServices();
-  await connector.registerWebServices(expressApp);
+  await connector.registerWebServices(expressApp, wsApi);
 
   const fDeploy = "deployContractSolBytecodeJsonObjectV1";
   const fInvoke = "invokeContractV1NoKeychain";

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/openapi/openapi-validation.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/openapi/openapi-validation.test.ts
@@ -27,7 +27,8 @@ import { AddressInfo } from "net";
 import express from "express";
 import bodyParser from "body-parser";
 import http from "http";
-import { Configuration } from "@hyperledger/cactus-core-api";
+import { Configuration, Constants } from "@hyperledger/cactus-core-api";
+import { Server as SocketIoServer } from "socket.io";
 
 import { installOpenapiValidationMiddleware } from "@hyperledger/cactus-core";
 import OAS from "../../../../../../main/json/openapi.json";
@@ -116,6 +117,10 @@ test(testCase, async (t: Test) => {
   const apiConfig = new Configuration({ basePath: apiHost });
   const apiClient = new QuorumApi(apiConfig);
 
+  const wsApi = new SocketIoServer(server, {
+    path: Constants.SocketIoConnectionPathV1,
+  });
+
   await installOpenapiValidationMiddleware({
     logLevel,
     app: expressApp,
@@ -123,7 +128,7 @@ test(testCase, async (t: Test) => {
   });
 
   await connector.getOrCreateWebServices();
-  await connector.registerWebServices(expressApp);
+  await connector.registerWebServices(expressApp, wsApi);
 
   const fDeploy = "apiV1QuorumDeployContractSolidityBytecode";
   const fInvoke = "apiV1QuorumInvokeContract";

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-deploy-contract-from-json-json-object-endpoints.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-deploy-contract-from-json-json-object-endpoints.test.ts
@@ -32,7 +32,8 @@ import express from "express";
 import bodyParser from "body-parser";
 import http from "http";
 import { AddressInfo } from "net";
-import { Configuration } from "@hyperledger/cactus-core-api";
+import { Configuration, Constants } from "@hyperledger/cactus-core-api";
+import { Server as SocketIoServer } from "socket.io";
 
 const logLevel: LogLevelDesc = "INFO";
 
@@ -101,8 +102,12 @@ test(testCase, async (t: Test) => {
   const apiConfig = new Configuration({ basePath: apiHost });
   const apiClient = new QuorumApi(apiConfig);
 
+  const wsApi = new SocketIoServer(server, {
+    path: Constants.SocketIoConnectionPathV1,
+  });
+
   await connector.getOrCreateWebServices();
-  await connector.registerWebServices(expressApp);
+  await connector.registerWebServices(expressApp, wsApi);
 
   await connector.transact({
     web3SigningCredential: {

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-deploy-contract-from-json-json-object.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-deploy-contract-from-json-json-object.test.ts
@@ -32,7 +32,8 @@ import express from "express";
 import bodyParser from "body-parser";
 import http from "http";
 import { AddressInfo } from "net";
-import { Configuration } from "@hyperledger/cactus-core-api";
+import { Configuration, Constants } from "@hyperledger/cactus-core-api";
+import { Server as SocketIoServer } from "socket.io";
 
 const logLevel: LogLevelDesc = "INFO";
 
@@ -101,8 +102,12 @@ test(testCase, async (t: Test) => {
   const apiConfig = new Configuration({ basePath: apiHost });
   const apiClient = new QuorumApi(apiConfig);
 
+  const wsApi = new SocketIoServer(server, {
+    path: Constants.SocketIoConnectionPathV1,
+  });
+
   await connector.getOrCreateWebServices();
-  await connector.registerWebServices(expressApp);
+  await connector.registerWebServices(expressApp, wsApi);
 
   await connector.transact({
     web3SigningCredential: {

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-deploy-contract-from-json.test.ts
@@ -35,7 +35,8 @@ import express from "express";
 import bodyParser from "body-parser";
 import http from "http";
 import { AddressInfo } from "net";
-import { Configuration } from "@hyperledger/cactus-core-api";
+import { Configuration, Constants } from "@hyperledger/cactus-core-api";
+import { Server as SocketIoServer } from "socket.io";
 
 const logLevel: LogLevelDesc = "INFO";
 const contractName = "HelloWorld";
@@ -120,8 +121,12 @@ test(testCase, async (t: Test) => {
   const apiConfig = new Configuration({ basePath: apiHost });
   const apiClient = new QuorumApi(apiConfig);
 
+  const wsApi = new SocketIoServer(server, {
+    path: Constants.SocketIoConnectionPathV1,
+  });
+
   await connector.getOrCreateWebServices();
-  await connector.registerWebServices(expressApp);
+  await connector.registerWebServices(expressApp, wsApi);
 
   await connector.transact({
     web3SigningCredential: {

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-invoke-contract-json-object-endpoints.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-invoke-contract-json-object-endpoints.test.ts
@@ -28,7 +28,8 @@ import express from "express";
 import bodyParser from "body-parser";
 import http from "http";
 import { AddressInfo } from "net";
-import { Configuration } from "@hyperledger/cactus-core-api";
+import { Configuration, Constants } from "@hyperledger/cactus-core-api";
+import { Server as SocketIoServer } from "socket.io";
 
 const logLevel: LogLevelDesc = "INFO";
 
@@ -87,8 +88,12 @@ test("Quorum Ledger Connector Plugin", async (t: Test) => {
   const apiConfig = new Configuration({ basePath: apiHost });
   const apiClient = new QuorumApi(apiConfig);
 
+  const wsApi = new SocketIoServer(server, {
+    path: Constants.SocketIoConnectionPathV1,
+  });
+
   await connector.getOrCreateWebServices();
-  await connector.registerWebServices(expressApp);
+  await connector.registerWebServices(expressApp, wsApi);
 
   await connector.transact({
     web3SigningCredential: {

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-deploy-contract-from-json-json-object-endpoints.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-deploy-contract-from-json-json-object-endpoints.test.ts
@@ -31,8 +31,9 @@ import express from "express";
 import bodyParser from "body-parser";
 import http from "http";
 import { AddressInfo } from "net";
-import { Configuration } from "@hyperledger/cactus-core-api";
+import { Configuration, Constants } from "@hyperledger/cactus-core-api";
 import { PluginRegistry } from "@hyperledger/cactus-core";
+import { Server as SocketIoServer } from "socket.io";
 
 const logLevel: LogLevelDesc = "INFO";
 
@@ -98,8 +99,12 @@ test(testCase, async (t: Test) => {
   const apiConfig = new Configuration({ basePath: apiHost });
   const apiClient = new QuorumApi(apiConfig);
 
+  const wsApi = new SocketIoServer(server, {
+    path: Constants.SocketIoConnectionPathV1,
+  });
+
   await connector.getOrCreateWebServices();
-  await connector.registerWebServices(expressApp);
+  await connector.registerWebServices(expressApp, wsApi);
 
   await connector.transact({
     web3SigningCredential: {

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-deploy-contract-from-json-json-object.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-deploy-contract-from-json-json-object.test.ts
@@ -31,8 +31,9 @@ import express from "express";
 import bodyParser from "body-parser";
 import http from "http";
 import { AddressInfo } from "net";
-import { Configuration } from "@hyperledger/cactus-core-api";
+import { Configuration, Constants } from "@hyperledger/cactus-core-api";
 import { PluginRegistry } from "@hyperledger/cactus-core";
+import { Server as SocketIoServer } from "socket.io";
 
 const logLevel: LogLevelDesc = "INFO";
 
@@ -98,8 +99,12 @@ test(testCase, async (t: Test) => {
   const apiConfig = new Configuration({ basePath: apiHost });
   const apiClient = new QuorumApi(apiConfig);
 
+  const wsApi = new SocketIoServer(server, {
+    path: Constants.SocketIoConnectionPathV1,
+  });
+
   await connector.getOrCreateWebServices();
-  await connector.registerWebServices(expressApp);
+  await connector.registerWebServices(expressApp, wsApi);
 
   await connector.transact({
     web3SigningCredential: {

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-deploy-contract-from-json.test.ts
@@ -33,7 +33,8 @@ import express from "express";
 import bodyParser from "body-parser";
 import http from "http";
 import { AddressInfo } from "net";
-import { Configuration } from "@hyperledger/cactus-core-api";
+import { Configuration, Constants } from "@hyperledger/cactus-core-api";
+import { Server as SocketIoServer } from "socket.io";
 
 const testCase = "Quorum Ledger Connector Plugin";
 
@@ -63,6 +64,9 @@ describe(testCase, () => {
     keychainEntryValue: string,
     keychainPlugin: PluginKeychainMemory,
     firstHighNetWorthAccount: string;
+  const wsApi = new SocketIoServer(server, {
+    path: Constants.SocketIoConnectionPathV1,
+  });
 
   afterAll(async () => await Servers.shutdown(server));
   beforeAll(async () => {
@@ -133,7 +137,7 @@ describe(testCase, () => {
     );
     // Instantiate connector with the keychain plugin that already has the
     // private key we want to use for one of our tests
-    await connector.registerWebServices(expressApp);
+    await connector.registerWebServices(expressApp, wsApi);
 
     await connector.transact({
       web3SigningCredential: {

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-invoke-contract-json-object-endpoints.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-invoke-contract-json-object-endpoints.test.ts
@@ -23,7 +23,8 @@ import {
   IAccount,
 } from "@hyperledger/cactus-test-tooling";
 import { PluginRegistry } from "@hyperledger/cactus-core";
-import { Configuration } from "@hyperledger/cactus-core-api";
+import { Configuration, Constants } from "@hyperledger/cactus-core-api";
+import { Server as SocketIoServer } from "socket.io";
 
 import express from "express";
 import bodyParser from "body-parser";
@@ -87,8 +88,12 @@ test("Quorum Ledger Connector Plugin", async (t: Test) => {
   const apiConfig = new Configuration({ basePath: apiHost });
   const apiClient = new QuorumApi(apiConfig);
 
+  const wsApi = new SocketIoServer(server, {
+    path: Constants.SocketIoConnectionPathV1,
+  });
+
   await connector.getOrCreateWebServices();
-  await connector.registerWebServices(expressApp);
+  await connector.registerWebServices(expressApp, wsApi);
 
   await connector.transact({
     web3SigningCredential: {

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-invoke-web3-contract-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-invoke-web3-contract-v1.test.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2020-2022 Hyperledger Cactus Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//////////////////////////////////
+// Constants
+//////////////////////////////////
+
+const testLogLevel = "info";
+const sutLogLevel = "info";
+
+const containerImageVersion = "2021-05-03-quorum-v21.4.1";
+
+import "jest-extended";
+import { v4 as uuidv4 } from "uuid";
+import { PluginRegistry } from "@hyperledger/cactus-core";
+import {
+  EthContractInvocationType,
+  InvokeRawWeb3EthContractV1Request,
+  PluginLedgerConnectorQuorum,
+  Web3SigningCredentialType,
+} from "../../../../../main/typescript/index";
+import {
+  QuorumTestLedger,
+  IQuorumGenesisOptions,
+  IAccount,
+  pruneDockerAllIfGithubAction,
+} from "@hyperledger/cactus-test-tooling";
+import { Logger, LoggerProvider } from "@hyperledger/cactus-common";
+import { AbiItem } from "web3-utils";
+
+import HelloWorldContractJson from "../../../../solidity/hello-world-contract/HelloWorld.json";
+import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory";
+
+// Unit Test logger setup
+const log: Logger = LoggerProvider.getOrCreate({
+  label: "v21.4.1-invoke-web3-contract-v1.test",
+  level: testLogLevel,
+});
+log.info("Test started");
+
+describe("invokeRawWeb3EthContract Tests", () => {
+  let quorumTestLedger: QuorumTestLedger;
+  let connector: PluginLedgerConnectorQuorum;
+  let firstHighNetWorthAccount: string;
+  let contractAbi: AbiItem[];
+  let contractAddress: string;
+
+  //////////////////////////////////
+  // Environment Setup
+  //////////////////////////////////
+
+  beforeAll(async () => {
+    log.info("Prune Docker...");
+    await pruneDockerAllIfGithubAction({ logLevel: testLogLevel });
+
+    log.info("Start QuorumTestLedger...");
+    log.debug("Quorum version:", containerImageVersion);
+    quorumTestLedger = new QuorumTestLedger({
+      containerImageVersion,
+    });
+    await quorumTestLedger.start();
+
+    log.info("Get highNetWorthAccounts...");
+    const quorumGenesisOptions: IQuorumGenesisOptions = await quorumTestLedger.getGenesisJsObject();
+    expect(quorumGenesisOptions).toBeTruthy();
+    expect(quorumGenesisOptions.alloc).toBeTruthy();
+
+    const highNetWorthAccounts: string[] = Object.keys(
+      quorumGenesisOptions.alloc,
+    ).filter((address: string) => {
+      const anAccount: IAccount = quorumGenesisOptions.alloc[address];
+      const theBalance = parseInt(anAccount.balance, 10);
+      return theBalance > 10e7;
+    });
+    [firstHighNetWorthAccount] = highNetWorthAccounts;
+
+    const rpcApiHttpHost = await quorumTestLedger.getRpcApiHttpHost();
+    log.debug("rpcApiHttpHost:", rpcApiHttpHost);
+
+    log.info("Create PluginKeychainMemory...");
+    const keychainPlugin = new PluginKeychainMemory({
+      instanceId: uuidv4(),
+      keychainId: uuidv4(),
+      logLevel: sutLogLevel,
+    });
+    keychainPlugin.set(
+      HelloWorldContractJson.contractName,
+      JSON.stringify(HelloWorldContractJson),
+    );
+
+    log.info("Create PluginLedgerConnectorQuorum...");
+    connector = new PluginLedgerConnectorQuorum({
+      rpcApiHttpHost: rpcApiHttpHost,
+      logLevel: sutLogLevel,
+      instanceId: uuidv4(),
+      pluginRegistry: new PluginRegistry({ plugins: [keychainPlugin] }),
+    });
+
+    log.info("Deploy contract to interact with...");
+    const deployOut = await connector.deployContract({
+      contractName: HelloWorldContractJson.contractName,
+      keychainId: keychainPlugin.getKeychainId(),
+      web3SigningCredential: {
+        ethAccount: firstHighNetWorthAccount,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+      gas: 1000000,
+    });
+    expect(deployOut).toBeTruthy();
+    expect(deployOut.transactionReceipt).toBeTruthy();
+    expect(deployOut.transactionReceipt.contractAddress).toBeTruthy();
+    expect(deployOut.transactionReceipt.status).toBeTrue();
+
+    contractAbi = HelloWorldContractJson.abi as AbiItem[];
+    contractAddress = deployOut.transactionReceipt.contractAddress as string;
+  });
+
+  afterAll(async () => {
+    log.info("Shutdown connector");
+    await connector.shutdown();
+
+    log.info("Stop and destroy the test ledger...");
+    await quorumTestLedger.stop();
+    await quorumTestLedger.destroy();
+
+    log.info("Prune docker...");
+    await pruneDockerAllIfGithubAction({ logLevel: testLogLevel });
+  });
+
+  test("invokeRawWeb3EthContract send and call to valid contract works correctly", async () => {
+    const newName = "QuorumCactus";
+
+    // 1. Set new value (send)
+    const sendInvocationArgs = {
+      from: firstHighNetWorthAccount,
+    };
+
+    const sendInvokeArgs: InvokeRawWeb3EthContractV1Request = {
+      abi: contractAbi,
+      address: contractAddress,
+      invocationType: EthContractInvocationType.Send,
+      invocationParams: sendInvocationArgs,
+      contractMethod: "setName",
+      contractMethodArgs: [newName],
+    };
+
+    const resultsSend = await connector.invokeRawWeb3EthContract(
+      sendInvokeArgs,
+    );
+    expect(resultsSend).toBeTruthy();
+    expect(resultsSend.status).toBeTrue();
+
+    // // 2. Get new, updated value (call)
+    const callInvokeArgs: InvokeRawWeb3EthContractV1Request = {
+      abi: contractAbi,
+      address: contractAddress,
+      invocationType: EthContractInvocationType.Call,
+      contractMethod: "getName",
+    };
+
+    const resultsCall = await connector.invokeRawWeb3EthContract(
+      callInvokeArgs,
+    );
+    expect(resultsCall).toBeTruthy();
+    expect(resultsCall).toEqual(newName);
+  });
+
+  test("invokeRawWeb3EthContract throws error when called on wrong contract", async () => {
+    const callInvokeArgs: InvokeRawWeb3EthContractV1Request = {
+      abi: contractAbi,
+      address: "0x0321",
+      invocationType: EthContractInvocationType.Call,
+      contractMethod: "getName",
+    };
+
+    await expect(connector.invokeRawWeb3EthContract(callInvokeArgs)).toReject();
+  });
+
+  test("invokeRawWeb3EthContract throws error when requested wrong invocation method", async () => {
+    const callInvokeArgs: InvokeRawWeb3EthContractV1Request = {
+      abi: contractAbi,
+      address: contractAddress,
+      invocationType: "foo" as EthContractInvocationType,
+      contractMethod: "getName",
+    };
+
+    await expect(connector.invokeRawWeb3EthContract(callInvokeArgs)).toReject();
+  });
+
+  test("invokeRawWeb3EthContract throws error when called non existent contract method", async () => {
+    const callInvokeArgs: InvokeRawWeb3EthContractV1Request = {
+      abi: contractAbi,
+      address: contractAddress,
+      invocationType: EthContractInvocationType.Call,
+      contractMethod: "nonExistingFoo",
+    };
+
+    await expect(connector.invokeRawWeb3EthContract(callInvokeArgs)).toReject();
+  });
+});

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-invoke-web3-method-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v21.4.1-invoke-web3-method-v1.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2020-2022 Hyperledger Cactus Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//////////////////////////////////
+// Constants
+//////////////////////////////////
+
+const testLogLevel = "info";
+const sutLogLevel = "info";
+
+const containerImageVersion = "2021-05-03-quorum-v21.4.1";
+
+import "jest-extended";
+import { v4 as uuidv4 } from "uuid";
+import { PluginRegistry } from "@hyperledger/cactus-core";
+import { PluginLedgerConnectorQuorum } from "../../../../../main/typescript/index";
+import {
+  QuorumTestLedger,
+  pruneDockerAllIfGithubAction,
+} from "@hyperledger/cactus-test-tooling";
+import { Logger, LoggerProvider } from "@hyperledger/cactus-common";
+import Web3 from "web3";
+
+// Unit Test logger setup
+const log: Logger = LoggerProvider.getOrCreate({
+  label: "v21.4.1-invoke-web3-method-v1.test",
+  level: testLogLevel,
+});
+log.info("Test started");
+
+describe("invokeRawWeb3EthMethod Tests", () => {
+  let quorumTestLedger: QuorumTestLedger;
+  let connector: PluginLedgerConnectorQuorum;
+  let web3: Web3;
+
+  //////////////////////////////////
+  // Environment Setup
+  //////////////////////////////////
+
+  beforeAll(async () => {
+    log.info("Prune Docker...");
+    await pruneDockerAllIfGithubAction({ logLevel: testLogLevel });
+
+    log.info("Start QuorumTestLedger...");
+    log.debug("Quorum version:", containerImageVersion);
+    quorumTestLedger = new QuorumTestLedger({
+      containerImageVersion,
+    });
+    await quorumTestLedger.start();
+
+    const rpcApiHttpHost = await quorumTestLedger.getRpcApiHttpHost();
+    log.debug("rpcApiHttpHost:", rpcApiHttpHost);
+
+    log.info("Create PluginLedgerConnectorQuorum...");
+    connector = new PluginLedgerConnectorQuorum({
+      rpcApiHttpHost: rpcApiHttpHost,
+      logLevel: sutLogLevel,
+      instanceId: uuidv4(),
+      pluginRegistry: new PluginRegistry(),
+    });
+
+    web3 = new Web3(rpcApiHttpHost);
+  });
+
+  afterAll(async () => {
+    log.info("Shutdown connector");
+    await connector.shutdown();
+
+    log.info("Stop and destroy the test ledger...");
+    await quorumTestLedger.stop();
+    await quorumTestLedger.destroy();
+
+    log.info("Prune docker...");
+    await pruneDockerAllIfGithubAction({ logLevel: testLogLevel });
+  });
+
+  test("invokeRawWeb3EthMethod with 0-argument method works (getGasPrice)", async () => {
+    const connectorResponse = await connector.invokeRawWeb3EthMethod({
+      methodName: "getGasPrice",
+    });
+    expect(connectorResponse).toBeTruthy();
+    expect(connectorResponse).toEqual("0"); // gas is free on quorum
+  });
+
+  test("invokeRawWeb3EthMethod with 1-argument method works (getBlock)", async () => {
+    const connectorResponse = await connector.invokeRawWeb3EthMethod({
+      methodName: "getBlock",
+      params: ["earliest"],
+    });
+    expect(connectorResponse).toBeTruthy();
+    expect(connectorResponse.hash.length).toBeGreaterThan(5);
+
+    // Compare with direct web3 response
+    const web3Response = await web3.eth.getBlock("earliest");
+    expect(web3Response).toBeTruthy();
+    expect(web3Response).toEqual(connectorResponse);
+  });
+
+  test("invokeRawWeb3EthMethod with 2-argument method works (getStorageAt)", async () => {
+    const genesisAccount = await quorumTestLedger.getGenesisAccount();
+    log.debug("genesisAccount:", genesisAccount);
+
+    const connectorResponse = await connector.invokeRawWeb3EthMethod({
+      methodName: "getStorageAt",
+      params: [genesisAccount, 0],
+    });
+    expect(connectorResponse).toBeTruthy();
+
+    // Compare with direct web3 response
+    const web3Response = await web3.eth.getStorageAt(genesisAccount, 0);
+    expect(web3Response).toBeTruthy();
+    expect(web3Response).toEqual(connectorResponse);
+  });
+
+  test("invokeRawWeb3EthMethod with missing arg throws error (getBlock)", async () => {
+    try {
+      const connectorResponse = connector.invokeRawWeb3EthMethod({
+        methodName: "getBlock",
+      });
+
+      await connectorResponse;
+      fail("Calling getBlock with missing argument should throw an error");
+    } catch (err) {
+      expect(err).toBeTruthy();
+    }
+  });
+
+  test("invokeRawWeb3EthMethod with invalid arg throws error (getBlock)", async () => {
+    try {
+      const connectorResponse = connector.invokeRawWeb3EthMethod({
+        methodName: "getBlock",
+        params: ["foo"],
+      });
+
+      await connectorResponse;
+      fail("Calling getBlock with argument should throw an error");
+    } catch (err) {
+      expect(err).toBeTruthy();
+    }
+  });
+
+  test("invokeRawWeb3EthMethod with non existing method throws error", async () => {
+    try {
+      const connectorResponse = connector.invokeRawWeb3EthMethod({
+        methodName: "foo",
+        params: ["foo"],
+      });
+
+      await connectorResponse;
+      fail("Calling non existing method should throw an error");
+    } catch (err) {
+      expect(err).toBeTruthy();
+    }
+  });
+});

--- a/packages/cactus-test-api-client/package.json
+++ b/packages/cactus-test-api-client/package.json
@@ -56,8 +56,6 @@
     "@hyperledger/cactus-core": "1.0.0",
     "@hyperledger/cactus-core-api": "1.0.0",
     "@hyperledger/cactus-plugin-consortium-manual": "1.0.0",
-    "@hyperledger/cactus-plugin-ledger-connector-quorum": "1.0.0",
-    "@hyperledger/cactus-verifier-client": "1.0.0",
     "jose": "4.1.0",
     "web3": "1.5.2"
   },

--- a/packages/cactus-test-plugin-ledger-connector-besu/package.json
+++ b/packages/cactus-test-plugin-ledger-connector-besu/package.json
@@ -56,6 +56,7 @@
     "@hyperledger/cactus-plugin-keychain-memory": "1.0.0",
     "@hyperledger/cactus-plugin-ledger-connector-besu": "1.0.0",
     "@hyperledger/cactus-test-tooling": "1.0.0",
+    "@hyperledger/cactus-verifier-client": "1.0.0",
     "key-encoder": "2.0.3",
     "web3": "1.5.2",
     "web3-eea": "0.11.0"

--- a/packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/api-client/verifier-integration-with-besu-connector.test.ts
+++ b/packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/api-client/verifier-integration-with-besu-connector.test.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2022 Hyperledger Cactus Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Besu setup code based on:
 //  packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/v21-deploy-contract-from-json.test.ts
 
@@ -53,7 +58,7 @@ const log: Logger = LoggerProvider.getOrCreate({
 });
 log.info("Test started");
 
-describe("Verifier integration with openapi connectors tests", () => {
+describe("Verifier integration with besu connector tests", () => {
   let besuTestLedger: BesuTestLedger;
   let server: http.Server;
   let connector: PluginLedgerConnectorBesu;

--- a/packages/cactus-test-plugin-ledger-connector-quorum/package.json
+++ b/packages/cactus-test-plugin-ledger-connector-quorum/package.json
@@ -56,6 +56,7 @@
     "@hyperledger/cactus-core-api": "1.0.0",
     "@hyperledger/cactus-plugin-keychain-memory": "1.0.0",
     "@hyperledger/cactus-plugin-ledger-connector-quorum": "1.0.0",
+    "@hyperledger/cactus-verifier-client": "1.0.0",
     "web3": "1.5.2"
   },
   "devDependencies": {

--- a/packages/cactus-test-plugin-ledger-connector-quorum/src/test/typescript/integration/api-client/verifier-integration-with-quorum-connector.test.ts
+++ b/packages/cactus-test-plugin-ledger-connector-quorum/src/test/typescript/integration/api-client/verifier-integration-with-quorum-connector.test.ts
@@ -1,0 +1,631 @@
+/*
+ * Copyright 2022 Hyperledger Cactus Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//////////////////////////////////
+// Constants
+//////////////////////////////////
+
+const testLogLevel = "info";
+const sutLogLevel = "info";
+
+// @todo Replace with cactus ghcr when this image will be available
+const containerImageName = "ghcr.io/outsh/cactus-quorum-multi-party-all-in-one";
+const containerImageVersion = "2022-03-10-b298004";
+
+import "jest-extended";
+import lodash from "lodash";
+import { v4 as uuidv4 } from "uuid";
+import Web3 from "web3";
+import { AbiItem } from "web3-utils";
+import { PluginRegistry } from "@hyperledger/cactus-core";
+import {
+  PluginLedgerConnectorQuorum,
+  QuorumApiClient,
+  WatchBlocksV1Progress,
+  Web3BlockHeader,
+  Web3SigningCredentialType,
+} from "@hyperledger/cactus-plugin-ledger-connector-quorum";
+import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory";
+import { Logger, LoggerProvider } from "@hyperledger/cactus-common";
+import {
+  ICactusPlugin,
+  IVerifierEventListener,
+  LedgerEvent,
+} from "@hyperledger/cactus-core-api";
+import { AddressInfo } from "net";
+import {
+  ApiServer,
+  AuthorizationProtocol,
+  ConfigService,
+} from "@hyperledger/cactus-cmd-api-server";
+
+import { Verifier, VerifierFactory } from "@hyperledger/cactus-verifier-client";
+import {
+  pruneDockerAllIfGithubAction,
+  QuorumMultiPartyTestLedger,
+} from "@hyperledger/cactus-test-tooling";
+
+import HelloWorldContractJson from "../../../solidity/hello-world-contract/HelloWorld.json";
+
+const log: Logger = LoggerProvider.getOrCreate({
+  label: "verifier-integration-with-quorum-connector.test",
+  level: testLogLevel,
+});
+
+log.info("Test started");
+
+describe("Verifier integration with quorum connector tests", () => {
+  let quorumTestLedger: QuorumMultiPartyTestLedger;
+  let apiServer: ApiServer;
+  let connector: PluginLedgerConnectorQuorum;
+  let web3: Web3;
+  let keychainPlugin: PluginKeychainMemory;
+  let connectionProfile: ReturnType<
+    typeof QuorumMultiPartyTestLedger.prototype.getKeys
+  > extends Promise<infer T>
+    ? T
+    : never;
+
+  const quorumValidatorId = "testQuorumId";
+  let globalVerifierFactory: VerifierFactory;
+
+  //////////////////////////////////
+  // Environment Setup
+  //////////////////////////////////
+
+  beforeAll(async () => {
+    log.info("Prune Docker...");
+    await pruneDockerAllIfGithubAction({ logLevel: testLogLevel });
+
+    // Start Ledger
+    log.info("Start QuorumMultiPartyTestLedger...");
+    log.debug("QuorumMultiParty image:", containerImageName);
+    log.debug("QuorumMultiParty version:", containerImageVersion);
+    quorumTestLedger = new QuorumMultiPartyTestLedger({
+      containerImageName,
+      containerImageVersion,
+      logLevel: sutLogLevel,
+      emitContainerLogs: false,
+      //useRunningLedger: true,
+    });
+    await quorumTestLedger.start();
+
+    connectionProfile = await quorumTestLedger.getKeys();
+    log.debug("connectionProfile:", connectionProfile);
+
+    // Setup ApiServer plugins
+    const plugins: ICactusPlugin[] = [];
+    const pluginRegistry = new PluginRegistry({ plugins });
+
+    log.info("Create PluginKeychainMemory...");
+    keychainPlugin = new PluginKeychainMemory({
+      instanceId: uuidv4(),
+      keychainId: uuidv4(),
+      logLevel: sutLogLevel,
+    });
+    keychainPlugin.set(
+      HelloWorldContractJson.contractName,
+      JSON.stringify(HelloWorldContractJson),
+    );
+    plugins.push(keychainPlugin);
+
+    log.info("Create PluginLedgerConnectorQuorum...");
+    connector = new PluginLedgerConnectorQuorum({
+      rpcApiHttpHost: connectionProfile.quorum.member1.url,
+      rpcApiWsHost: connectionProfile.quorum.member1.wsUrl,
+      logLevel: sutLogLevel,
+      instanceId: uuidv4(),
+      pluginRegistry: new PluginRegistry({ plugins: [keychainPlugin] }),
+    });
+    plugins.push(connector);
+
+    // Create web3 provider for test
+    web3 = new Web3(connectionProfile.quorum.member1.url);
+
+    // Create Api Server
+    log.info("Create ApiServer...");
+    const configService = new ConfigService();
+    const cactusApiServerOptions = await configService.newExampleConfig();
+    cactusApiServerOptions.authorizationProtocol = AuthorizationProtocol.NONE;
+    cactusApiServerOptions.configFile = "";
+    cactusApiServerOptions.apiCorsDomainCsv = "*";
+    cactusApiServerOptions.apiTlsEnabled = false;
+    cactusApiServerOptions.apiPort = 0;
+    const config = await configService.newExampleConfigConvict(
+      cactusApiServerOptions,
+    );
+
+    apiServer = new ApiServer({
+      config: config.getProperties(),
+      pluginRegistry,
+    });
+
+    // Start ApiServer
+    const apiServerStartOut = await apiServer.start();
+    log.debug(`apiServerStartOut:`, apiServerStartOut);
+    const httpServer = apiServer.getHttpServerApi();
+
+    const addressInfo = httpServer?.address() as AddressInfo;
+    const { address, port } = addressInfo;
+    const apiHost = `http://${address}:${port}`;
+
+    // Create VerifierFactory
+    log.info("Create VerifierFactory with Quorum Validator...");
+    globalVerifierFactory = new VerifierFactory(
+      [
+        {
+          validatorID: quorumValidatorId,
+          validatorType: "QUORUM_2X",
+          basePath: apiHost,
+          logLevel: sutLogLevel,
+        },
+      ],
+      sutLogLevel,
+    );
+  });
+
+  afterAll(async () => {
+    log.info("Shutdown the server...");
+    if (apiServer) {
+      await apiServer.shutdown();
+    }
+
+    log.info("Stop and destroy the test ledger...");
+    if (quorumTestLedger) {
+      await quorumTestLedger.stop();
+      await quorumTestLedger.destroy();
+    }
+
+    log.info("Prune docker...");
+    await pruneDockerAllIfGithubAction({ logLevel: testLogLevel });
+  });
+
+  //////////////////////////////////
+  // Helper Functions
+  //////////////////////////////////
+
+  function monitorAndGetBlock(
+    options: Record<string, unknown> = {},
+  ): Promise<LedgerEvent<WatchBlocksV1Progress>> {
+    return new Promise<LedgerEvent<WatchBlocksV1Progress>>(
+      (resolve, reject) => {
+        const appId = "testMonitor";
+        const sut = globalVerifierFactory.getVerifier(quorumValidatorId);
+
+        const monitor: IVerifierEventListener<WatchBlocksV1Progress> = {
+          onEvent(ledgerEvent: LedgerEvent<WatchBlocksV1Progress>): void {
+            try {
+              log.info("Received event:", ledgerEvent);
+
+              if (!ledgerEvent.data) {
+                throw Error("No block data");
+              }
+
+              log.info(
+                "Listener received ledgerEvent, block number",
+                ledgerEvent.data.blockHeader?.number,
+              );
+
+              sut.stopMonitor(appId);
+              resolve(ledgerEvent);
+            } catch (err) {
+              reject(err);
+            }
+          },
+          onError(err: any): void {
+            log.error("Ledger monitoring error:", err);
+            reject(err);
+          },
+        };
+
+        sut.startMonitor(appId, options, monitor);
+      },
+    );
+  }
+
+  //////////////////////////////////
+  // Tests
+  //////////////////////////////////
+
+  test("Verifier of QuorumApiClient is created by VerifierFactory", () => {
+    const sut = globalVerifierFactory.getVerifier(quorumValidatorId);
+    expect(sut.ledgerApi.className).toEqual("QuorumApiClient");
+  });
+
+  describe("web3EthContract tests", () => {
+    let verifier: Verifier<QuorumApiClient>;
+    let contractCommon: {
+      abi: AbiItem[];
+      address: string;
+    };
+
+    beforeAll(async () => {
+      // Setup verifier
+      verifier = globalVerifierFactory.getVerifier(
+        quorumValidatorId,
+        "QUORUM_2X",
+      );
+
+      // Deploy contract to interact with
+      const deployOut = await connector.deployContract({
+        contractName: HelloWorldContractJson.contractName,
+        keychainId: keychainPlugin.getKeychainId(),
+        web3SigningCredential: {
+          ethAccount: connectionProfile.quorum.member2.accountAddress,
+          secret: connectionProfile.quorum.member2.privateKey,
+          type: Web3SigningCredentialType.PrivateKeyHex,
+        },
+        gas: 1000000,
+      });
+      expect(deployOut).toBeTruthy();
+      expect(deployOut.transactionReceipt).toBeTruthy();
+      expect(deployOut.transactionReceipt.contractAddress).toBeTruthy();
+      expect(deployOut.transactionReceipt.status).toBeTrue();
+
+      contractCommon = {
+        abi: HelloWorldContractJson.abi as AbiItem[],
+        address: deployOut.transactionReceipt.contractAddress as string,
+      };
+    });
+
+    test("Invalid web3EthContract calls are rejected by QuorumApiClient", async () => {
+      // Define correct input parameters
+      const correctContract: Record<string, unknown> = lodash.clone(
+        contractCommon,
+      );
+      const correctMethod: Record<string, unknown> = {
+        type: "web3EthContract",
+        command: "call",
+        function: "getName",
+        params: [],
+      };
+      const correctArgs: any = {};
+
+      // Sanity check if correct parameters work
+      const resultCorrect = await verifier.sendSyncRequest(
+        correctContract,
+        correctMethod,
+        correctArgs,
+      );
+      expect(resultCorrect.status).toEqual(200);
+
+      // Failing: Missing contract ABI
+      const missingABIContract = lodash.clone(correctContract);
+      delete missingABIContract.abi;
+
+      expect(
+        verifier.sendSyncRequest(
+          missingABIContract,
+          correctMethod,
+          correctArgs,
+        ),
+      ).toReject();
+
+      // Failing: Missing contract address
+      const missingAddressContract = lodash.clone(correctContract);
+      delete missingAddressContract.address;
+
+      expect(
+        verifier.sendSyncRequest(
+          missingAddressContract,
+          correctMethod,
+          correctArgs,
+        ),
+      ).toReject();
+
+      // Failing: Unknown invocation method
+      const unknownMethod = lodash.clone(correctMethod);
+      unknownMethod.command = "foo";
+      expect(
+        verifier.sendSyncRequest(correctContract, unknownMethod, correctArgs),
+      ).toReject();
+
+      // Failing: Empty invocation method
+      const emptyMethod = lodash.clone(correctMethod);
+      emptyMethod.command = "";
+      expect(
+        verifier.sendSyncRequest(correctContract, emptyMethod, correctArgs),
+      ).toReject();
+
+      // Failing: Empty contract method
+      const emptyContractFunction = lodash.clone(correctMethod);
+      emptyContractFunction.function = "";
+      expect(
+        verifier.sendSyncRequest(
+          correctContract,
+          emptyContractFunction,
+          correctArgs,
+        ),
+      ).toReject();
+
+      // Failing: Wrong method params format
+      const numericParam = lodash.clone(correctMethod);
+      numericParam.params = 42;
+      expect(
+        verifier.sendSyncRequest(correctContract, numericParam, correctArgs),
+      ).toReject();
+
+      const objectParam = lodash.clone(correctMethod);
+      objectParam.params = { arg1: 42 };
+      expect(
+        verifier.sendSyncRequest(correctContract, objectParam, correctArgs),
+      ).toReject();
+    });
+
+    test("Send unsigned transaction and use call to check results works", async () => {
+      const newName = "QuorumCactus";
+
+      // 1. Set new value (send)
+      // Will use signing key of the node we're connected to (member1)
+      const methodSend = {
+        type: "web3EthContract",
+        command: "send",
+        function: "setName",
+        params: [newName],
+      };
+      const argsSend = {
+        args: {
+          from: connectionProfile.quorum.member1.accountAddress,
+        },
+      };
+
+      const resultsSend = await verifier.sendSyncRequest(
+        contractCommon,
+        methodSend,
+        argsSend,
+      );
+      expect(resultsSend.status).toEqual(200);
+      expect(resultsSend.data.status).toBeTrue();
+
+      // 2. Get new, updated value (call)
+      const methodCall = {
+        type: "web3EthContract",
+        command: "call",
+        function: "getName",
+        params: [],
+      };
+      const argsCall = {};
+
+      const resultCall = await verifier.sendSyncRequest(
+        contractCommon,
+        methodCall,
+        argsCall,
+      );
+      expect(resultCall.status).toEqual(200);
+      expect(resultCall.data).toEqual(newName);
+    });
+
+    test("encodeABI of transactions gives same results as direct web3 call", async () => {
+      // Send encodeABI request to connector
+      const methodEncode = {
+        type: "web3EthContract",
+        command: "encodeABI",
+        function: "setName",
+        params: ["QuorumCactusEncode"],
+      };
+      const argsEncode = {
+        args: {
+          from: connectionProfile.quorum.member1.accountAddress,
+        },
+      };
+
+      const resultsEncode = await verifier.sendSyncRequest(
+        contractCommon,
+        methodEncode,
+        argsEncode,
+      );
+      expect(resultsEncode.status).toEqual(200);
+      expect(resultsEncode.data.length).toBeGreaterThan(5);
+
+      // Compare encoded data with direct web3 call
+      const web3Contract = new web3.eth.Contract(
+        contractCommon.abi,
+        contractCommon.address,
+      );
+      const web3Encode = await web3Contract.methods
+        .setName(...methodEncode.params)
+        .encodeABI(argsEncode);
+      expect(resultsEncode.data).toEqual(web3Encode);
+    });
+
+    test("estimateGas of transactions gives same results as direct web3 call", async () => {
+      // Send estimateGas request to connector
+      const methodEstimateGas = {
+        type: "web3EthContract",
+        command: "estimateGas",
+        function: "setName",
+        params: ["QuorumCactusGas"],
+      };
+      const argsEstimateGas = {};
+
+      const resultsEstimateGas = await verifier.sendSyncRequest(
+        contractCommon,
+        methodEstimateGas,
+        argsEstimateGas,
+      );
+      expect(resultsEstimateGas.status).toEqual(200);
+      expect(resultsEstimateGas.data).toBeGreaterThan(0);
+
+      // Compare gas estimate with direct web3 call
+      const web3Contract = new web3.eth.Contract(
+        contractCommon.abi,
+        contractCommon.address,
+      );
+      const web3Encode = await web3Contract.methods
+        .setName(...methodEstimateGas.params)
+        .estimateGas(argsEstimateGas);
+      expect(resultsEstimateGas.data).toEqual(web3Encode);
+    });
+
+    test("Sending transaction with sendAsyncRequest works", async () => {
+      const newName = "QuorumCactusAsync";
+
+      // 1. Set new value with async call (send)
+      // Will use signing key of the node we're connected to (member1)
+      const methodSendAsync = {
+        type: "web3EthContract",
+        command: "send",
+        function: "setName",
+        params: [newName],
+      };
+      const argsSendAsync = {
+        args: {
+          from: connectionProfile.quorum.member1.accountAddress,
+        },
+      };
+
+      await verifier.sendAsyncRequest(
+        contractCommon,
+        methodSendAsync,
+        argsSendAsync,
+      );
+
+      // 2. Wait for transaction commit
+      // We assume transaction will be included in the next block
+      await monitorAndGetBlock();
+
+      // 3. Get new, updated value (call)
+      const methodCall = {
+        type: "web3EthContract",
+        command: "call",
+        function: "getName",
+        params: [],
+      };
+      const argsCall = {};
+
+      const resultsCall = await verifier.sendSyncRequest(
+        contractCommon,
+        methodCall,
+        argsCall,
+      );
+      expect(resultsCall.status).toEqual(200);
+      expect(resultsCall.data).toEqual(newName);
+    });
+  });
+
+  test("Verifier of QuorumApiClient supports web3Eth function", async () => {
+    // web3Eth.getBalance
+    const contract = {};
+    const method = { type: "web3Eth", command: "getBalance" };
+    const args = { args: [connectionProfile.quorum.member2.accountAddress] };
+
+    const results = await globalVerifierFactory
+      .getVerifier(quorumValidatorId)
+      .sendSyncRequest(contract, method, args);
+    expect(results.status).toEqual(200);
+    expect(results.data.length).toBeGreaterThan(0);
+  });
+
+  test("Invalid web3Eth calls are rejected by QuorumApiClient", async () => {
+    // Define correct input parameters
+    const correctContract = {};
+    const correctMethod: Record<string, unknown> = {
+      type: "web3Eth",
+      command: "getBalance",
+    };
+    const correctArgs: any = {
+      args: [connectionProfile.quorum.member2.accountAddress],
+    };
+    const verifier = globalVerifierFactory.getVerifier(quorumValidatorId);
+
+    // Sanity check if correct parameters work
+    const resultCorrect = await verifier.sendSyncRequest(
+      correctContract,
+      correctMethod,
+      correctArgs,
+    );
+    expect(resultCorrect.status).toEqual(200);
+
+    // Failing: Empty web3.eth method
+    const emptyMethod = lodash.clone(correctMethod);
+    emptyMethod.command = "";
+
+    expect(
+      verifier.sendSyncRequest(correctContract, emptyMethod, correctArgs),
+    ).toReject();
+
+    // Failing: Wrong args format
+    const numericArgsFormat = lodash.clone(correctArgs);
+    numericArgsFormat.args = 42;
+
+    expect(
+      verifier.sendSyncRequest(correctContract, numericArgsFormat, correctArgs),
+    ).toReject();
+
+    const objectArgsFormat = lodash.clone(correctArgs);
+    objectArgsFormat.args = { arg1: 42 };
+
+    expect(
+      verifier.sendSyncRequest(correctContract, objectArgsFormat, correctArgs),
+    ).toReject();
+  });
+
+  test("QuorumApiClient web3Eth throws error on unknown method", async () => {
+    const contract = {};
+    const method = { type: "web3Eth", command: "foo" };
+    const args = {};
+
+    const results = await globalVerifierFactory
+      .getVerifier(quorumValidatorId)
+      .sendSyncRequest(contract, method, args);
+
+    expect(results).toBeTruthy();
+    expect(results.status).toEqual(504);
+    expect(results.errorDetail).toBeTruthy();
+  });
+
+  function assertBlockHeader(header: Web3BlockHeader) {
+    // Check if defined and with expected type
+    // Ignore nullable / undefine-able fields
+    expect(typeof header.parentHash).toEqual("string");
+    expect(typeof header.sha3Uncles).toEqual("string");
+    expect(typeof header.miner).toEqual("string");
+    expect(typeof header.stateRoot).toEqual("string");
+    expect(typeof header.logsBloom).toEqual("string");
+    expect(typeof header.number).toEqual("number");
+    expect(typeof header.gasLimit).toEqual("number");
+    expect(typeof header.gasUsed).toEqual("number");
+    expect(typeof header.extraData).toEqual("string");
+    expect(typeof header.nonce).toEqual("string");
+    expect(typeof header.hash).toEqual("string");
+    expect(typeof header.difficulty).toEqual("string");
+  }
+
+  test("Monitor new blocks headers on Quorum", async () => {
+    const ledgerEvent = await monitorAndGetBlock();
+    // assert well-formed output
+    expect(ledgerEvent.id).toEqual("");
+    expect(ledgerEvent.verifierId).toEqual(quorumValidatorId);
+    expect(ledgerEvent.data).toBeTruthy();
+
+    // blockData should not be present if called with empty options
+    expect(ledgerEvent.data?.blockData).toBeUndefined();
+    expect(ledgerEvent.data?.blockHeader).toBeTruthy();
+
+    // check some fields
+    assertBlockHeader(ledgerEvent.data?.blockHeader as Web3BlockHeader);
+  });
+
+  test("Monitor new blocks data on Quorum", async () => {
+    const ledgerEvent = await monitorAndGetBlock({ getBlockData: true });
+    // assert well-formed output
+    expect(ledgerEvent.id).toEqual("");
+    expect(ledgerEvent.verifierId).toEqual(quorumValidatorId);
+    expect(ledgerEvent.data).toBeTruthy();
+
+    // blockHeader should not be present if called with getBlockData option
+    expect(ledgerEvent.data?.blockHeader).toBeFalsy();
+    expect(ledgerEvent.data?.blockData).toBeTruthy();
+
+    // check some fields
+    assertBlockHeader(ledgerEvent.data?.blockData as Web3BlockHeader);
+    expect(typeof ledgerEvent.data?.blockData?.size).toEqual("number");
+    expect(typeof ledgerEvent.data?.blockData?.totalDifficulty).toEqual(
+      "string",
+    );
+    expect(typeof ledgerEvent.data?.blockData?.uncles).toEqual("object");
+    expect(typeof ledgerEvent.data?.blockData?.transactions).toEqual("object");
+  });
+});

--- a/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
@@ -486,18 +486,27 @@ export class Containers {
     });
   }
 
+  public static async getByPredicate(
+    pred: (ci: ContainerInfo) => boolean,
+  ): Promise<ContainerInfo> {
+    const docker = new Dockerode();
+    const containerList = await docker.listContainers();
+    const containerInfo = containerList.find(pred);
+
+    if (!containerInfo) {
+      throw new Error(`No container that matches given predicate!`);
+    }
+
+    return containerInfo;
+  }
+
   public static async getById(containerId: string): Promise<ContainerInfo> {
     const fnTag = `Containers#getById()`;
-
     Checks.nonBlankString(containerId, `${fnTag}:containerId`);
 
-    const docker = new Dockerode();
-    const containerInfos = await docker.listContainers({});
-    const aContainerInfo = containerInfos.find((ci) => ci.Id === containerId);
-
-    if (aContainerInfo) {
-      return aContainerInfo;
-    } else {
+    try {
+      return this.getByPredicate((ci) => ci.Id === containerId);
+    } catch {
       throw new Error(`${fnTag} no container by ID"${containerId}"`);
     }
   }

--- a/packages/cactus-test-tooling/src/main/typescript/public-api.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/public-api.ts
@@ -21,6 +21,11 @@ export {
 } from "./quorum/quorum-test-ledger";
 
 export {
+  QuorumMultiPartyTestLedger,
+  IQuorumMultiPartyTestLedgerOptions,
+} from "./quorum/quorum-mp-test-ledger";
+
+export {
   CordaTestLedger,
   ICordaTestLedgerConstructorOptions,
   CORDA_TEST_LEDGER_DEFAULT_OPTIONS,

--- a/packages/cactus-test-tooling/src/main/typescript/quorum/quorum-mp-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/quorum/quorum-mp-test-ledger.ts
@@ -1,0 +1,220 @@
+import { EventEmitter } from "events";
+import Docker, { Container, ContainerCreateOptions } from "dockerode";
+import {
+  Logger,
+  LoggerProvider,
+  LogLevelDesc,
+} from "@hyperledger/cactus-common";
+import { ITestLedger } from "../i-test-ledger";
+import { Containers } from "../common/containers";
+
+export interface IQuorumMultiPartyTestLedgerOptions {
+  readonly containerImageName?: string;
+  readonly containerImageVersion?: string;
+  readonly logLevel?: LogLevelDesc;
+  readonly emitContainerLogs?: boolean;
+  readonly envVars?: string[];
+}
+
+export class QuorumMultiPartyTestLedger implements ITestLedger {
+  public readonly containerImageName: string;
+  public readonly containerImageVersion: string;
+  private readonly logLevel: LogLevelDesc;
+  private readonly emitContainerLogs: boolean;
+  private readonly envVars: string[];
+
+  private readonly log: Logger;
+  public container: Container | undefined;
+  public containerId: string | undefined;
+
+  constructor(public readonly options?: IQuorumMultiPartyTestLedgerOptions) {
+    this.containerImageName =
+      options?.containerImageName ||
+      "ghcr.io/hyperledger/cactus-quorum-all-in-one";
+    this.containerImageVersion =
+      options?.containerImageVersion || "2021-01-08-7a055c3";
+    this.logLevel = options?.logLevel || "info";
+    if (options?.emitContainerLogs != undefined) {
+      this.emitContainerLogs = options.emitContainerLogs;
+    } else {
+      this.emitContainerLogs = true;
+    }
+    this.envVars = options?.envVars || [];
+    this.log = LoggerProvider.getOrCreate({
+      level: this.logLevel,
+      label: "quorum-multi-party-test-ledger",
+    });
+  }
+
+  public get fullContainerImageName(): string {
+    return [this.containerImageName, this.containerImageVersion].join(":");
+  }
+
+  public async start(omitPull = false): Promise<Container> {
+    this.log.info(
+      `Starting Quorum Test Ledger: ${this.fullContainerImageName}`,
+    );
+
+    if (this.container) {
+      await this.container.stop();
+      await this.container.remove();
+      this.container = undefined;
+      this.containerId = undefined;
+    }
+
+    if (!omitPull) {
+      await Containers.pullImage(
+        this.fullContainerImageName,
+        {},
+        this.logLevel,
+      );
+    }
+
+    const createOptions: ContainerCreateOptions = {
+      ExposedPorts: {
+        "8545/tcp": {}, // HTTP RPC
+        "8546/tcp": {}, // WS RPC
+        "20000/tcp": {}, // Member1 HTTP RPC
+        "20001/tcp": {}, // Member1 WS RPC
+        "9081/tcp": {}, // Member1 Tessera
+        "20002/tcp": {}, // Member2 HTTP RPC
+        "20003/tcp": {}, // Member2 WS RPC
+        "9082/tcp": {}, // Member2 Tessera
+        "20004/tcp": {}, // Member3 HTTP RPC
+        "20005/tcp": {}, // Member3 WS RPC
+        "9083/tcp": {}, // Member3 Tessera
+      },
+
+      Env: this.envVars,
+
+      HostConfig: {
+        PublishAllPorts: true,
+        Privileged: true,
+      },
+    };
+
+    return new Promise<Container>((resolve, reject) => {
+      const docker = new Docker();
+      const eventEmitter: EventEmitter = docker.run(
+        this.fullContainerImageName,
+        [],
+        [],
+        createOptions,
+        {},
+        (err: any) => {
+          if (err) {
+            reject(err);
+          }
+        },
+      );
+
+      eventEmitter.once("start", async (container: Container) => {
+        this.container = container;
+        this.containerId = container.id;
+
+        if (this.emitContainerLogs) {
+          const fnTag = `[${this.fullContainerImageName}]`;
+          await Containers.streamLogs({
+            container: this.container,
+            tag: fnTag,
+            log: this.log,
+          });
+        }
+
+        try {
+          await Containers.waitForHealthCheck(this.containerId);
+          resolve(container);
+        } catch (ex) {
+          this.log.error(ex);
+          reject(ex);
+        }
+      });
+    });
+  }
+
+  public stop(): Promise<unknown> {
+    if (this.container) {
+      return Containers.stop(this.container);
+    } else {
+      return Promise.reject(
+        new Error(
+          `QuorumMultiPartyTestLedger#destroy() Container was never created, nothing to stop.`,
+        ),
+      );
+    }
+  }
+
+  public destroy(): Promise<unknown> {
+    if (this.container) {
+      return this.container.remove();
+    } else {
+      return Promise.reject(
+        new Error(
+          `QuorumMultiPartyTestLedger#destroy() Container was never created, nothing to destroy.`,
+        ),
+      );
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  public async getKeys() {
+    if (!this.containerId) {
+      throw new Error("Missing container ID");
+    }
+
+    const container = await Containers.getById(this.containerId);
+
+    const member1HttpPort = await Containers.getPublicPort(20000, container);
+    const member1WsPort = await Containers.getPublicPort(20001, container);
+    const member1PrivPort = await Containers.getPublicPort(9081, container);
+
+    const member2HttpPort = await Containers.getPublicPort(20002, container);
+    const member2WsPort = await Containers.getPublicPort(20003, container);
+    const member2PrivPort = await Containers.getPublicPort(9082, container);
+
+    const member3HttpPort = await Containers.getPublicPort(20004, container);
+    const member3WsPort = await Containers.getPublicPort(20005, container);
+    const member3PrivPort = await Containers.getPublicPort(9083, container);
+
+    // This configuration comes from quorum-dev-quickstart@smart_contracts/scripts/keys.js
+    return {
+      tessera: {
+        member1: {
+          publicKey: "BULeR8JyUWhiuuCMU/HLA0Q5pzkYT+cHII3ZKBey3Bo=",
+        },
+        member2: {
+          publicKey: "QfeDAys9MPDs2XHExtc84jKGHxZg/aj52DTh0vtA3Xc=",
+        },
+        member3: {
+          publicKey: "1iTZde/ndBHvzhcl7V68x44Vx7pl8nwx9LqnM/AfJUg=",
+        },
+      },
+      quorum: {
+        member1: {
+          url: `http://127.0.0.1:${member1HttpPort}`,
+          wsUrl: `ws://127.0.0.1:${member1WsPort}`,
+          privateUrl: `http://127.0.0.1:${member1PrivPort}`,
+          privateKey:
+            "b9a4bd1539c15bcc83fa9078fe89200b6e9e802ae992f13cd83c853f16e8bed4",
+          accountAddress: "f0e2db6c8dc6c681bb5d6ad121a107f300e9b2b5",
+        },
+        member2: {
+          url: `http://127.0.0.1:${member2HttpPort}`,
+          wsUrl: `ws://127.0.0.1:${member2WsPort}`,
+          privateUrl: `http://127.0.0.1:${member2PrivPort}`,
+          privateKey:
+            "f18166704e19b895c1e2698ebc82b4e007e6d2933f4b31be23662dd0ec602570",
+          accountAddress: "ca843569e3427144cead5e4d5999a3d0ccf92b8e",
+        },
+        member3: {
+          url: `http://127.0.0.1:${member3HttpPort}`,
+          wsUrl: `ws://127.0.0.1:${member3WsPort}`,
+          privateUrl: `http://127.0.0.1:${member3PrivPort}`,
+          privateKey:
+            "4107f0b6bf67a3bc679a15fe36f640415cf4da6a4820affaac89c8b280dfd1b3",
+          accountAddress: "0fbdc686b912d7722dc86510934589e0aaf3b55a",
+        },
+      },
+    };
+  }
+}

--- a/packages/cactus-verifier-client/package.json
+++ b/packages/cactus-verifier-client/package.json
@@ -53,6 +53,7 @@
     "@hyperledger/cactus-common": "1.0.0",
     "@hyperledger/cactus-core-api": "1.0.0",
     "@hyperledger/cactus-plugin-ledger-connector-besu": "1.0.0",
+    "@hyperledger/cactus-plugin-ledger-connector-quorum": "1.0.0",
     "jest-extended": "0.11.5",
     "rxjs": "7.3.0"
   }

--- a/packages/cactus-verifier-client/src/main/typescript/get-validator-api-client.ts
+++ b/packages/cactus-verifier-client/src/main/typescript/get-validator-api-client.ts
@@ -15,6 +15,11 @@ import {
   BesuApiClientOptions,
 } from "@hyperledger/cactus-plugin-ledger-connector-besu";
 
+import {
+  QuorumApiClient,
+  QuorumApiClientOptions,
+} from "@hyperledger/cactus-plugin-ledger-connector-quorum";
+
 /**
  * Configuration of ApiClients currently supported by Verifier and VerifierFactory
  * Each entry key defines the name of the connection type that has to be specified in VerifierFactory config.
@@ -33,6 +38,10 @@ export type ClientApiConfig = {
   BESU_2X: {
     in: BesuApiClientOptions;
     out: BesuApiClient;
+  };
+  QUORUM_2X: {
+    in: QuorumApiClientOptions;
+    out: QuorumApiClient;
   };
 };
 
@@ -55,6 +64,8 @@ export function getValidatorApiClient<K extends keyof ClientApiConfig>(
     case "BESU_1X":
     case "BESU_2X":
       return new BesuApiClient(options as BesuApiClientOptions);
+    case "QUORUM_2X":
+      return new QuorumApiClient(options as QuorumApiClientOptions);
     default:
       // Will not compile if any ClientApiConfig key was not handled by this switch
       const _: never = validatorType;

--- a/tools/docker/quorum-multi-party-all-in-one/Dockerfile
+++ b/tools/docker/quorum-multi-party-all-in-one/Dockerfile
@@ -1,115 +1,53 @@
+################################
+# STAGE 1
+# Setup quorum-dev-quickstart
+################################
+
+FROM node:16 AS quorum-dev-quickstart-setup
+
+ENV QUORUM_QUICKSTART_VERSION=0.0.53
+ENV ROOT_DIR=/opt/quorum-dev-quickstart
+
+WORKDIR "${ROOT_DIR}"
+RUN npm install -g "quorum-dev-quickstart@${QUORUM_QUICKSTART_VERSION}"
+RUN quorum-dev-quickstart --clientType goquorum --outputPath ./ --monitoring default --privacy true --orchestrate false
+
+################################
+# STAGE 2
+# docker-compose base
+################################
+
 FROM docker:20.10.3-dind
 
-ARG BESU_VERSION=21.1.2
-ARG QUORUM_VERSION=21.4.1
-ARG QUORUM_TESSERA_VERSION=21.1.1
-ARG CA_VERSION=1.4.9
+ENV ROOT_DIR=/opt/quorum-dev-quickstart
 
-WORKDIR /
+# Install docker-compose and quorum-dev-quickstart setup dependencies
+RUN apk update \
+  && apk add --no-cache \
+    py-pip \
+    python3-dev \
+    libffi-dev \
+    openssl-dev \
+    gcc \
+    libc-dev \
+    rust \
+    cargo \
+    make \
+    bash \
+    ncurses \
+    supervisor \
+  && pip install docker-compose
 
-RUN apk update
-
-# Install dependencies of Docker Compose
-RUN apk add py-pip python3-dev libffi-dev openssl-dev gcc libc-dev make
-
-# Install python/pip - We need this because DinD 18.x has Python 2
-# And we cannot upgrade to DinD 19 because of
-# https://github.com/docker-library/docker/issues/170
-ENV PYTHONUNBUFFERED=1
-RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
-RUN python3 -m ensurepip
-RUN pip3 install --no-cache --upgrade "pip>=21" setuptools
-
-# Without this the docker-compose installation crashes, complaining about
-# a lack of rust compiler...
-# RUN pip install setuptools_rust
-ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
-
-# Install Docker Compose which is a dependency of Fabric Samples
-RUN pip install docker-compose
-
-# Need git to clone the sources of the Fabric Samples repository from GitHub
-RUN apk add --no-cache git
-
-# Fabric Samples needs bash, sh is not good enough here
-RUN apk add --no-cache bash
-
-# The file binary is used to inspect exectubles when debugging container image issues
-RUN apk add --no-cache file
-
-# Need NodeJS tooling for the Typescript contracts
-RUN apk add --no-cache npm nodejs
-
-# Needed because the Fabric binaries need the GNU libc dynamic linker to be executed
-# and alpine does not have that by default
-# @see https://askubuntu.com/a/1035037/1008695
-# @see https://github.com/gliderlabs/docker-alpine/issues/219#issuecomment-254741346
-RUN apk add --no-cache libc6-compat
-
-RUN apk add --no-cache --update chromium
-
-ENV CACTUS_CFG_PATH=/etc/hyperledger/cactus
-RUN mkdir -p $CACTUS_CFG_PATH
-# OpenSSH - need to have it so we can shell in and install/instantiate contracts
-RUN apk add --no-cache openssh augeas
-
-# Configure the OpenSSH server we just installed
-RUN augtool 'set /files/etc/ssh/sshd_config/AuthorizedKeysFile ".ssh/authorized_keys /etc/authorized_keys/%u"'
-RUN augtool 'set /files/etc/ssh/sshd_config/PermitRootLogin yes'
-RUN augtool 'set /files/etc/ssh/sshd_config/PasswordAuthentication no'
-RUN augtool 'set /files/etc/ssh/sshd_config/PermitEmptyPasswords no'
-RUN augtool 'set /files/etc/ssh/sshd_config/Port 22'
-RUN augtool 'set /files/etc/ssh/sshd_config/LogLevel DEBUG2'
-RUN augtool 'set /files/etc/ssh/sshd_config/LoginGraceTime 10'
-# Create the server's key - without this sshd will refuse to start
-RUN ssh-keygen -A
-
-# Generate an RSA keypair on the fly to avoid having to hardcode one in the image
-# which technically does not pose a security threat since this is only a development
-# image, but we do it like this anyway.
-RUN mkdir ~/.ssh
-RUN chmod 700 ~/.ssh/
-RUN touch ~/.ssh/authorized_keys
-RUN ["/bin/bash", "-c", "ssh-keygen -t rsa -N '' -f $CACTUS_CFG_PATH/quorum-aio-image <<< y"]
-RUN mv $CACTUS_CFG_PATH/quorum-aio-image $CACTUS_CFG_PATH/quorum-aio-image.key
-RUN cp $CACTUS_CFG_PATH/quorum-aio-image.pub ~/.ssh/authorized_keys
-
-RUN apk add --no-cache util-linux
-
-# FIXME - make it so that SSHd does not need this to work
-RUN echo "root:$(uuidgen)" | chpasswd
-
-RUN git clone https://github.com/travis-payne/quorum-dev-quickstart.git
-
-WORKDIR /quorum-dev-quickstart
-
-RUN git fetch
-
-RUN git checkout e029993
-
-RUN npm i
-
-RUN npm run build
-
-RUN npm run start -- --clientType goquorum --outputPath ./ --monitoring default --privacy true --orchestrate false
-
-RUN chmod -R a+rwx ../quorum-dev-quickstart/
-
-RUN apk add --no-cache supervisor
-RUN apk add --no-cache ncurses
+# Copy quorum-dev-quickstart from the base
+COPY --from=quorum-dev-quickstart-setup "${ROOT_DIR}" "${ROOT_DIR}"
+WORKDIR "${ROOT_DIR}"
 
 COPY healthcheck.sh /healthcheck.sh
-COPY supervisord.conf /etc/supervisord.conf
-
-# # Extend the parent image's entrypoint
-# # https://superuser.com/questions/1459466/can-i-add-an-additional-docker-entrypoint-script
-ENTRYPOINT ["/usr/bin/supervisord"]
-CMD ["--configuration", "/etc/supervisord.conf", "--nodaemon"]
-
 HEALTHCHECK --interval=10s --timeout=5s --start-period=60s --retries=500 CMD /healthcheck.sh
 
-# OpenSSH Server
-EXPOSE 22
+COPY supervisord.conf /etc/supervisord.conf
+ENTRYPOINT ["/usr/bin/supervisord"]
+CMD ["--configuration", "/etc/supervisord.conf", "--nodaemon"]
 
 # Grafana
 EXPOSE 3000
@@ -123,9 +61,6 @@ EXPOSE 9001
 # Prometheus
 EXPOSE 9090
 
-# ETH signer proxy
-EXPOSE 18545
-
 # Quorum member 1: HTTP; WebSocket Providers; Tessera
 EXPOSE 20000 20001 9081
 
@@ -137,3 +72,6 @@ EXPOSE 20004 20005 9083
 
 # Web block explorer
 EXPOSE 25000
+
+# Geth logs location
+VOLUME [ "/root/logs/quorum" ]

--- a/tools/docker/quorum-multi-party-all-in-one/README.md
+++ b/tools/docker/quorum-multi-party-all-in-one/README.md
@@ -4,15 +4,14 @@
 
 - [Summary](#summary)
 - [Usage via Public Container Registry](#usage-via-public-container-registry)
-- [List endpoints and services](#list-endpoints-and-services)
-- [2021-08-17 09:39:45,048 DEBG 'quorum-network' stdout output:](#2021-08-17-093945048-debg-quorum-network-stdout-output)
-- [List endpoints and services](#list-endpoints-and-services-1)
+- [Endpoints](#endpoints)
+- [Building the Image Locally](#building-the-image-locally)
 
 ## Summary
-
 A container image that hosts a Quorum network which is
-- Has multiple nodes and validators
-- Supports transaction privacy (`privateFrom` and `privateFor`)
+- Has multiple nodes and validators.
+- Supports transaction privacy (`privateFrom` and `privateFor`).
+- Based on official `quorum-dev-quickstart` setup.
 
 ## Usage via Public Container Registry
 
@@ -38,37 +37,15 @@ docker run \
   --publish 20005:20005 \
   --publish 25000:25000 \
   ghcr.io/hyperledger/cactus-quorum-multi-party-all-in-one:latest
-
 ```
 
-*************************************
-Quorum Dev Quickstart 
-*************************************
-
-----------------------------------
-List endpoints and services
-----------------------------------
+## Endpoints
+```sh
 JSON-RPC HTTP service endpoint                 : http://localhost:8545
-2021-08-17 09:39:45,048 DEBG 'quorum-network' stdout output:
-----------------------------------
-List endpoints and services
-----------------------------------
-JSON-RPC HTTP service endpoint                 : http://localhost:8545
-
 JSON-RPC WebSocket service endpoint            : ws://localhost:8546
 Web block explorer address                     : http://localhost:25000/
-2021-08-17 09:39:45,049 DEBG 'quorum-network' stdout output:
-JSON-RPC WebSocket service endpoint            : ws://localhost:8546
-Web block explorer address                     : http://localhost:25000/
-
-
-For more information on the endpoints and services, refer to README.md in the installation directory.
-****************************************************************
-2021-08-17 09:39:47,429 DEBG 'quorum-network' stdout output:
-
-For more information on the endpoints and services, refer to README.md in the installation directory.
-****************************************************************
-
+Prometheus address                             : http://localhost:9090/graph
+Grafana address                                : http://localhost:3000/d/a1lVy7ycin9Yv/goquorum-overview?orgId=1&refresh=10s&from=now-30m&to=now&var-system=All
 ```
 
 ## Building the Image Locally

--- a/tools/docker/quorum-multi-party-all-in-one/healthcheck.sh
+++ b/tools/docker/quorum-multi-party-all-in-one/healthcheck.sh
@@ -6,8 +6,7 @@ set -e
 wget -O- --post-data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' --header 'Content-Type: application/json' http://localhost:20000
 
 # # Quorum Member 2
-wget -O- --post-data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' --header 'Content-Type: application/json' http://localhost:20000
+wget -O- --post-data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' --header 'Content-Type: application/json' http://localhost:20002
 
 # # Quorum Member 3
-wget -O- --post-data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' --header 'Content-Type: application/json' http://localhost:20000
-
+wget -O- --post-data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' --header 'Content-Type: application/json' http://localhost:20004

--- a/tools/docker/quorum-multi-party-all-in-one/supervisord.conf
+++ b/tools/docker/quorum-multi-party-all-in-one/supervisord.conf
@@ -4,15 +4,6 @@ logfile_maxbytes = 50MB
 logfile_backups=10
 loglevel = debug
 
-[program:sshd]
-command=/usr/sbin/sshd -D
-autostart=true
-autorestart=true
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-
 [program:dockerd]
 command=dockerd-entrypoint.sh
 autostart=true
@@ -23,7 +14,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:quorum-network]
-command=/quorum-dev-quickstart/run.sh
+command=%(ENV_ROOT_DIR)s/run.sh
 autostart=true
 autorestart=false
 stderr_logfile=/dev/stderr
@@ -33,4 +24,3 @@ stdout_logfile_maxbytes=0
 
 [inet_http_server]
 port = 0.0.0.0:9001
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -4630,6 +4630,13 @@
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
   integrity sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==
 
+"@types/sanitize-html@2.6.2":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@types/sanitize-html/-/sanitize-html-2.6.2.tgz#9c47960841b9def1e4c9dfebaaab010a3f6e97b9"
+  integrity sha512-7Lu2zMQnmHHQGKXVvCOhSziQMpa+R2hMHFefzbYoYMHeaXR0uXqNeOc3JeQQQ8/6Xa2Br/P1IQTLzV09xxAiUQ==
+  dependencies:
+    htmlparser2 "^6.0.0"
+
 "@types/scheduler@*":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
@@ -12342,7 +12349,7 @@ htmlparser2@^3.9.1:
     inherits "^2.0.1"
     readable-stream "^3.1.1"
 
-htmlparser2@^6.1.0:
+htmlparser2@^6.0.0, htmlparser2@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
   integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
@@ -17689,6 +17696,11 @@ parse-path@^4.0.0:
     qs "^6.9.4"
     query-string "^6.13.8"
 
+parse-srcset@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parse-srcset/-/parse-srcset-1.0.2.tgz#f2bd221f6cc970a938d88556abc589caaaa2bde1"
+  integrity sha1-8r0iH2zJcKk42IVWq8WJyqqiveE=
+
 parse-url@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-6.0.0.tgz#f5dd262a7de9ec00914939220410b66cff09107d"
@@ -18523,6 +18535,15 @@ postcss@^8.2.15, postcss@^8.3.5, postcss@^8.3.7:
   version "8.4.7"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.7.tgz#f99862069ec4541de386bf57f5660a6c7a0875a8"
   integrity sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==
+  dependencies:
+    nanoid "^3.3.1"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
+postcss@^8.3.11:
+  version "8.4.12"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.12.tgz#1e7de78733b28970fa4743f7da6f3763648b1905"
+  integrity sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==
   dependencies:
     nanoid "^3.3.1"
     picocolors "^1.0.0"
@@ -19850,6 +19871,18 @@ sanitize-filename@1.6.3:
   integrity sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==
   dependencies:
     truncate-utf8-bytes "^1.0.0"
+
+sanitize-html@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.7.0.tgz#e106205b468aca932e2f9baf241f24660d34e279"
+  integrity sha512-jfQelabOn5voO7FAfnQF7v+jsA6z9zC/O4ec0z3E35XPEtHYJT/OdUziVWlKW4irCr2kXaQAyXTXDHWAibg1tA==
+  dependencies:
+    deepmerge "^4.2.2"
+    escape-string-regexp "^4.0.0"
+    htmlparser2 "^6.0.0"
+    is-plain-object "^5.0.0"
+    parse-srcset "^1.0.2"
+    postcss "^8.3.11"
 
 sass-loader@12.1.0:
   version "12.1.0"


### PR DESCRIPTION
- Add three new endpoints to quorum ledger connector achieve legacy verifier compatibility.
  - `InvokeRawWeb3EthContractEndpoint` can be used to form any call to deployed contract.
  - `InvokeRawWeb3EthMethodEndpoint` can be used to call any web3.eth function. Both are marked as low-level functions, should be used only when there's no designated endpoint for given functionality yet.
  - `WatchBlocksV1Endpoint` can be used to monitor new block headers / data from the ledger. Type of the output is determined from input option flag.
- Extend `QuorumApiClient` to support Verifier interface, that is: block monitoring, and sending sync/async requests. Sending requests is marked as deprecated, because user can use direct REST calls from generated ApiClient, nevertheless this API was requested by one of the teams.
- Added functional tests for two new, request based endpoints.
- Moved verifier-besu integration test to besu-test package.
- Added verifier-quorum integration test, it supplements direct endpoint tests and provides a reference for API usage.
- Added support for `QuorumApiClient` in Verifier.

Closes: https://github.com/hyperledger/cactus/issues/1604
Signed-off-by: Michal Bajer <michal.bajer@fujitsu.com>

### Notes
- I can't make CodeQL to cooperate, it reports dynamic call errors, even though I explicitly check if methods are defined on a contract / object (also assert they type is a function). Tried different methods to make the scanner notice it but did not succeed. Please double check and mark as false positive if possible.