### PR TITLE
fix: resolve some CodeQL warnings

### DIFF
--- a/examples/cactus-check-connection-ethereum-validator/check-ethereum-validator.ts
+++ b/examples/cactus-check-connection-ethereum-validator/check-ethereum-validator.ts
@@ -1,13 +1,10 @@
 import { Router, NextFunction, Request, Response } from "express";
 import { getLogger } from "log4js";
 import { TransactionManagement } from "../../packages/cactus-cmd-socketio-server/src/main/typescript/routing-interface/TransactionManagement";
-import {
-  RIFError,
-  BadRequestError,
-} from "../../packages/cactus-cmd-socketio-server/src/main/typescript/routing-interface/RIFError";
+import { RIFError } from "../../packages/cactus-cmd-socketio-server/src/main/typescript/routing-interface/RIFError";
 import { ConfigUtil } from "../../packages/cactus-cmd-socketio-server/src/main/typescript/routing-interface/util/ConfigUtil";
 import { TestEthereumVerifier } from "./TestEthereumVerifier";
-import { request } from "http";
+import escapeHtml from "escape-html";
 
 const config: any = ConfigUtil.getConfig();
 const moduleName = "check-ethereum-validator";
@@ -21,7 +18,7 @@ function isRifError(err: any, res: Response): boolean {
   if (err instanceof RIFError) {
     logger.error(`RIFError caught, ${err.statusCode}, ${err.message}`);
     res.status(err.statusCode);
-    res.send(err.message);
+    res.send(escapeHtml(err.message));
     return true;
   }
   logger.error(`Error caught: ${err.statusCode}, ${err.message}`);

--- a/examples/cactus-check-connection-ethereum-validator/package.json
+++ b/examples/cactus-check-connection-ethereum-validator/package.json
@@ -14,7 +14,11 @@
     "init-check-connection-ethereum-validator": "ln -s ../examples/cactus-check-connection-ethereum-validator/node_modules ../../dist/node_modules"
   },
   "dependencies": {
+    "socket.io": "4.4.1",
+    "escape-html": "1.0.3"
+  },
+  "devDependencies": {
     "@types/node": "15.14.7",
-    "socket.io": "4.4.1"
+    "@types/escape-html": "1.0.1"
   }
 }

--- a/examples/discounted-cartrade/package.json
+++ b/examples/discounted-cartrade/package.json
@@ -15,6 +15,7 @@
     "body-parser": "1.19.2",
     "cookie-parser": "1.4.6",
     "debug": "2.6.9",
+    "escape-html": "1.0.3",
     "ethereumjs-common": "1.5.2",
     "ethereumjs-tx": "2.1.2",
     "express": "4.16.4",
@@ -35,11 +36,12 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.33.0",
+    "@types/escape-html": "1.0.1",
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.4.0",
     "eslint-plugin-prettier": "4.0.0",
     "prettier": "2.5.1",
     "tslint": "6.0.0",
-    "typescript": "3.9.10"
+    "typescript": "4.3.5"
   }
 }

--- a/examples/discounted-cartrade/trades.ts
+++ b/examples/discounted-cartrade/trades.ts
@@ -12,6 +12,7 @@ import { ConfigUtil } from "@hyperledger/cactus-cmd-socket-server";
 
 const fs = require("fs");
 const path = require("path");
+import escapeHtml from "escape-html";
 const config: any = ConfigUtil.getConfig();
 import { getLogger } from "log4js";
 const moduleName = "trades";
@@ -40,7 +41,7 @@ router.post("/", (req: Request, res: Response, next: NextFunction) => {
   } catch (err) {
     if (err instanceof RIFError) {
       res.status(err.statusCode);
-      res.send(err.message);
+      res.send(escapeHtml(err.message));
       return;
     }
 
@@ -60,7 +61,7 @@ router.get("/:id", (req: Request, res: Response, next: NextFunction) => {
   } catch (err) {
     if (err instanceof RIFError) {
       res.status(err.statusCode);
-      res.send(err.message);
+      res.send(escapeHtml(err.message));
       return;
     }
 

--- a/examples/electricity-trade/electricity-trade.ts
+++ b/examples/electricity-trade/electricity-trade.ts
@@ -11,6 +11,7 @@ import {
   RIFError,
   ConfigUtil,
 } from "@hyperledger/cactus-cmd-socket-server";
+import escapeHtml from "escape-html";
 
 const config: any = ConfigUtil.getConfig();
 import { getLogger } from "log4js";
@@ -34,7 +35,7 @@ router.post("/", (req: Request, res: Response, next: NextFunction) => {
   } catch (err) {
     if (err instanceof RIFError) {
       res.status(err.statusCode);
-      res.send(err.message);
+      res.send(escapeHtml(err.message));
       return;
     }
 
@@ -61,7 +62,7 @@ router.post(
     } catch (err) {
       if (err instanceof RIFError) {
         res.status(err.statusCode);
-        res.send(err.message);
+        res.send(escapeHtml(err.message));
         return;
       }
 

--- a/examples/electricity-trade/package.json
+++ b/examples/electricity-trade/package.json
@@ -12,6 +12,7 @@
     "body-parser": "1.19.2",
     "cookie-parser": "1.4.6",
     "debug": "2.6.9",
+    "escape-html": "1.0.3",
     "ethereumjs-common": "1.5.2",
     "ethereumjs-tx": "2.1.2",
     "express": "4.16.4",
@@ -31,11 +32,12 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.33.0",
+    "@types/escape-html": "1.0.1",
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.4.0",
     "eslint-plugin-prettier": "4.0.0",
     "prettier": "2.5.1",
     "tslint": "6.0.0",
-    "typescript": "3.9.10"
+    "typescript": "4.3.5"
   }
 }

--- a/examples/test-run-transaction/package.json
+++ b/examples/test-run-transaction/package.json
@@ -17,6 +17,7 @@
     "body-parser": "1.19.2",
     "cookie-parser": "1.4.6",
     "debug": "2.6.9",
+    "escape-html": "1.0.3",
     "ethereumjs-common": "1.5.2",
     "ethereumjs-tx": "2.1.2",
     "express": "4.16.4",
@@ -35,11 +36,12 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.33.0",
+    "@types/escape-html": "1.0.1",
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.4.0",
     "eslint-plugin-prettier": "4.0.0",
     "prettier": "2.5.1",
     "tslint": "6.0.0",
-    "typescript": "3.9.10"
+    "typescript": "4.3.5"
   }
 }

--- a/examples/test-run-transaction/test-run-transaction.ts
+++ b/examples/test-run-transaction/test-run-transaction.ts
@@ -10,8 +10,7 @@ import { TransactionManagement } from "../../packages/cactus-cmd-socketio-server
 import { RIFError } from "../../packages/cactus-cmd-socketio-server/src/main/typescript/routing-interface/RIFError";
 import { ConfigUtil } from "../../packages/cactus-cmd-socketio-server/src/main/typescript/routing-interface/util/ConfigUtil";
 
-const fs = require("fs");
-const path = require("path");
+import escapeHtml from "escape-html";
 const config: any = ConfigUtil.getConfig();
 import { getLogger } from "log4js";
 const moduleName = "test-run-transaction";
@@ -35,7 +34,7 @@ router.post("/", (req: Request, res: Response, next: NextFunction) => {
   } catch (err) {
     if (err instanceof RIFError) {
       res.status(err.statusCode);
-      res.send(err.message);
+      res.send(escapeHtml(err.message));
       return;
     }
 

--- a/packages/cactus-cmd-socketio-server/package.json
+++ b/packages/cactus-cmd-socketio-server/package.json
@@ -17,6 +17,7 @@
     "body-parser": "1.19.2",
     "cookie-parser": "1.4.5",
     "debug": "2.6.9",
+    "escape-html": "1.0.3",
     "ethereumjs-common": "1.5.2",
     "ethereumjs-tx": "2.1.2",
     "express": "4.16.4",
@@ -40,6 +41,7 @@
     "@types/http-errors": "1.6.3",
     "@types/morgan": "1.9.1",
     "@types/shelljs": "^0.8.11",
+    "@types/escape-html": "1.0.1",
     "ts-node": "8.9.1"
   }
 }

--- a/packages/cactus-cmd-socketio-server/src/main/typescript/routing-interface/routes/index.ts
+++ b/packages/cactus-cmd-socketio-server/src/main/typescript/routing-interface/routes/index.ts
@@ -8,10 +8,10 @@
 import { Router, NextFunction, Request, Response } from "express";
 import { TransactionManagement } from "../TransactionManagement";
 import { VerifierFactory } from "../../verifier/VerifierFactory";
+import escapeHtml from "escape-html";
 
 const router: Router = Router();
-export const transactionManagement: TransactionManagement =
-  new TransactionManagement();
+export const transactionManagement: TransactionManagement = new TransactionManagement();
 export const verifierFactory: VerifierFactory = new VerifierFactory(
   transactionManagement,
 );
@@ -34,7 +34,7 @@ router.get(
     } catch (err) {
       next(err);
     }
-  }
+  },
 );
 
 // Show Specification of Business Logic
@@ -45,13 +45,13 @@ router.get(
       res.send(
         "Not Implemented (Show Specification of Business Logic" +
           ", id=" +
-          req.params.id +
-          ")\n"
+          escapeHtml(req.params.id) +
+          ")\n",
       );
     } catch (err) {
       next(err);
     }
-  }
+  },
 );
 
 // Register a Wallet
@@ -63,7 +63,7 @@ router.post(
     } catch (err) {
       next(err);
     }
-  }
+  },
 );
 
 // Show Wallet List
@@ -75,7 +75,7 @@ router.get(
     } catch (err) {
       next(err);
     }
-  }
+  },
 );
 
 // Update Existing Wallets
@@ -86,13 +86,13 @@ router.put(
       res.send(
         "Not Implemented (Update Existing Wallets" +
           ", id=" +
-          req.params.id +
-          ")\n"
+          escapeHtml(req.params.id) +
+          ")\n",
       );
     } catch (err) {
       next(err);
     }
-  }
+  },
 );
 
 // Delete a Wallet
@@ -101,12 +101,12 @@ router.delete(
   (req: Request, res: Response, next: NextFunction) => {
     try {
       res.send(
-        "Not Implemented (Delete a Wallet" + ", id=" + req.params.id + ")\n"
+        "Not Implemented (Delete a Wallet" + ", id=" + escapeHtml(req.params.id) + ")\n",
       );
     } catch (err) {
       next(err);
     }
-  }
+  },
 );
 
 export default router;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4172,6 +4172,11 @@
   dependencies:
     "@types/bn.js" "*"
 
+"@types/escape-html@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/escape-html/-/escape-html-1.0.1.tgz#b19b4646915f0ae2c306bf984dc0a59c5cfc97ba"
+  integrity sha512-4mI1FuUUZiuT95fSVqvZxp/ssQK9zsa86S43h9x3zPOSU9BBJ+BfDkXwuaU7BfsD+e7U0/cUUfJFk3iW2M4okA==
+
 "@types/eslint-scope@^3.7.0":
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.3.tgz#125b88504b61e3c8bc6f870882003253005c3224"
@@ -9846,7 +9851,7 @@ escape-goat@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-2.1.1.tgz#1b2dc77003676c457ec760b2dc68edb648188675"
   integrity sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==
 
-escape-html@~1.0.3:
+escape-html@1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=


### PR DESCRIPTION
Fix CodeQL warnings:
- Reflected cross-site scripting
- Exception text reinterpreted as HTML

In following files:
- `examples/cactus-check-connection-ethereum-validator/check-ethereum-validator.ts`
- `examples/discounted-cartrade/trades.ts`
- `examples/electricity-trade/electricity-trade.ts`
- `examples/test-run-transaction/test-run-transaction.ts`
- `packages/cactus-cmd-socketio-server/src/main/typescript/routing-interface/routes/index.ts`

Also, sample apps in `example/` did not build after last socketio upgrade, had to upgrade typescript to make them build again.

Signed-off-by: Michal Bajer <michal.bajer@fujitsu.com>