### PR TITLE
fix(deps): force minimist >=1.2.6 for CVE-2021-44906

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "ansi-html": ">0.0.8",
     "glob-parent": "5.1.2",
     "lodash": "4.17.20",
+    "minimist": ">=1.2.6",
     "underscore": "1.13.2"
   }
 }


### PR DESCRIPTION
Ensures that yarn will only install 1.2.6 or newer versions for
minimist.

The proper fix would be to have the dependencies issue releases
which upgrade their own (transitive) dependencies of minimist
so that we don't have to explicitly force it here, but at the time
of this writing these upgrades in our direct dependencies are just
not available yet.

Fixes #1943

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>