### PR TITLE
ci(tools): fix iroha AIO image build flake on CI

### DIFF
--- a/tools/docker/iroha-all-in-one/Dockerfile
+++ b/tools/docker/iroha-all-in-one/Dockerfile
@@ -2,11 +2,18 @@ FROM ubuntu:20.04 as builder
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN set -e && apt-get update && apt-get install -y --no-install-recommends \
-    file build-essential ninja-build git ca-certificates tar curl unzip cmake pkg-config zip
-RUN git clone https://github.com/hyperledger/iroha.git -b 1.2.0 
-RUN iroha/vcpkg/build_iroha_deps.sh && vcpkg/vcpkg integrate install
+    file build-essential ninja-build ca-certificates tar curl unzip cmake pkg-config zip software-properties-common
+
+RUN add-apt-repository ppa:git-core/ppa
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends git
+
+RUN git clone https://github.com/hyperledger/iroha.git -b 1.4.0 
+RUN iroha/vcpkg/build_iroha_deps.sh
+RUN /vcpkg-build/vcpkg integrate install
 WORKDIR /iroha/build/
-RUN cmake -DCMAKE_TOOLCHAIN_FILE=/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TYPE=Release -DPACKAGE_DEB=ON -G "Ninja" ..
+
+RUN cmake -DCMAKE_TOOLCHAIN_FILE=/vcpkg-build/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TYPE=Release -DPACKAGE_DEB=ON -G "Ninja" ..
 RUN cmake --build . --target package -- -j$(nproc)
 
 FROM ubuntu:20.04


### PR DESCRIPTION
Install git into the builder image directly from the git-core ppa
so that we get the latest available instead of what's in Ubuntu
by default. This means that insteadd of 2.2x we get 2.35 as of
the time of this writing which is exactly what we needed to
fix the problem with the build of vcpkg (which itself is a build
dependency of iroha).
The older git version was not supporting a certain commit ref
syntax/mechanism that some vcpkg dependencies were declared
with and this is where the build would error out.
With the new git version used inside the build image, the problem
no longer exists.

Note: Also upgraded the version of iroha to be used to v1.4.0
because it contains some bug-fixes that we needed for certain
connector features IIRC (don't remember the details though...)

Fixes #1566

Fixes #1262

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>