### PR TITLE
test(connector-fabric-socketio): add functional test, bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,6 @@ site/
 !.yarn/versions
 .pnp.*
 
-!packages/cactus-plugin-verifier-cc/src/main/typescript/ledger-plugin/*/validator/src/build
-!packages/cactus-plugin-verifier-cc/src/main/typescript/ledger-plugin/*/validator/src/core/bin
+!packages/cactus-plugin-ledger-connector-*-socketio/src/main/typescript/common/core/bin
 
 tools/docker/geth-testnet/data-geth1/

--- a/packages/cactus-plugin-ledger-connector-fabric-socketio/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric-socketio/package.json
@@ -2,6 +2,9 @@
   "name": "@hyperledger/cactus-plugin-ledger-connector-fabric-socketio",
   "version": "1.0.0",
   "license": "Apache-2.0",
+  "main": "dist/common/core/bin/www.js",
+  "module": "dist/common/core/bin/www.js",
+  "types": "dist/common/core/bin/www.d.ts",
   "scripts": {
     "start": "cd ./dist && node common/core/bin/www.js",
     "debug": "nodemon --inspect ./dist/common/core/bin/www.js",
@@ -30,6 +33,7 @@
     "socket.io": "4.4.1"
   },
   "devDependencies": {
+    "@hyperledger/cactus-api-client": "1.0.0",
     "@types/config": "0.0.41",
     "ts-node": "9.1.1"
   }

--- a/packages/cactus-plugin-ledger-connector-fabric-socketio/src/main/typescript/common/core/bin/www.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric-socketio/src/main/typescript/common/core/bin/www.ts
@@ -11,17 +11,11 @@
  * Connector: a part independent of end-chains
  */
 
-/**
- * Module dependencies.
- */
-
 import app from "../app";
-const debug = require("debug")("connector:server");
 import https = require("https");
 import * as config from "../config";
 import fs = require("fs");
 import { Server } from "socket.io"
-
 // Log settings
 import { getLogger } from "log4js";
 const logger = getLogger("connector_main[" + process.pid + "]");
@@ -29,212 +23,84 @@ logger.level = config.read('logLevel', 'info');
 
 // implementation class of a part dependent of end-chains (server plugin)
 import { ServerPlugin } from "../../../connector/ServerPlugin";
-const Splug = new ServerPlugin();
 
 // destination dependency (MONITOR) implementation class
 import { ServerMonitorPlugin } from "../../../connector/ServerMonitorPlugin";
-const Smonitor = new ServerMonitorPlugin();
 
-/**
- * Get port from environment and store in Express.
- */
+export async function startFabricSocketIOConnector() {
+  const Splug = new ServerPlugin();
+  const Smonitor = new ServerMonitorPlugin();
 
-const sslport = normalizePort(process.env.PORT || config.read('sslParam.port'));
-app.set("port", sslport);
+  // Get port from environment and store in Express.
+  const sslport = normalizePort(process.env.PORT || config.read('sslParam.port'));
+  app.set("port", sslport);
 
-// Specify private key and certificate
-const sslParam = {
-  key: fs.readFileSync(config.read('sslParam.key')),
-  cert: fs.readFileSync(config.read('sslParam.cert')),
-};
-
-/**
- * Create HTTPS server.
- */
-
-const server = https.createServer(sslParam, app); // Start as an https server.
-const io = new Server(server);
-
-/**
- * Listen on provided port, on all network interfaces.
- */
-
-server.listen(sslport, function () {
-  console.log("listening on *:" + sslport);
-});
-server.on("error", onError);
-server.on("listening", onListening);
-
-/**
- * Normalize a port into a number, string, or false.
- */
-
-function normalizePort(val: string) {
-  const port = parseInt(val, 10);
-
-  if (isNaN(port)) {
-    // named pipe
-    return val;
+  // Specify private key and certificate
+  let keyString: string;
+  let certString: string;
+  try {
+    keyString = config.read<string>('sslParam.keyValue');
+    certString = config.read<string>('sslParam.certValue');
+  } catch {
+    keyString = fs.readFileSync(config.read('sslParam.key'), "ascii");
+    certString = fs.readFileSync(config.read('sslParam.cert'), "ascii");
   }
 
-  if (port >= 0) {
-    // port number
-    return port;
-  }
+  // Create HTTPS server.
+  const server = https.createServer({
+    key: keyString,
+    cert: certString,
+  }, app); // Start as an https server.
+  const io = new Server(server);
 
-  return false;
-}
-
-/**
- * Event listener for HTTPS server "error" event.
- */
-
-function onError(error: any) {
-  if (error.syscall !== "listen") {
-    throw error;
-  }
-
-  const bind =
-    typeof sslport === "string" ? "Pipe " + sslport : "Port " + sslport;
-
-  // handle specific listen errors with friendly messages
-  switch (error.code) {
-    case "EACCES":
-      console.error(bind + " requires elevated privileges");
-      process.exit(1);
-      break;
-    case "EADDRINUSE":
-      console.error(bind + " is already in use");
-      process.exit(1);
-      break;
-    default:
+  // Event listener for HTTPS server "error" event.
+  server.on("error", (error: any) => {
+    if (error.syscall !== "listen") {
       throw error;
-  }
-}
-
-/**
- * Event listener for HTTPS server "listening" event.
- */
-
-function onListening() {
-  const addr = server.address();
-
-  if (!addr) {
-    logger.error("Could not get running server address - exit.");
-    process.exit(1);
-  }
-
-  const bind = typeof addr === "string" ? "pipe " + addr : "port " + addr.port;
-  debug("Listening on " + bind);
-}
-
-io.on("connection", function (client) {
-  logger.info("Client " + client.id + " connected.");
-
-  /**
-   * request: The server plugin's request to execute a function
-   * @param {JSON} data: Request Body (following format)
-   * JSON: {
-   *          "func":        (string) Function name ,// For example : "transferNumericAsset"
-   *          "args":        (Object) argument// for example , {"from" : "xxx" , "to" : "yyy" , "value" : "10,000"}
-   *       }
-   **/
-  client.on("request", function (data) {
-    const func = data.func;
-    const args = data.args;
-    if (data.reqID !== undefined) {
-      logger.info(`##add reqID: ${data.reqID}`);
-      args["reqID"] = data.reqID;
     }
-    logger.info("##[HL-BC] Invoke smart contract to transfer asset(D1)");
-    logger.info("*** REQUEST ***");
-    logger.info("Client ID :" + client.id);
-    logger.info("Data  :" + JSON.stringify(data));
 
-    // Check for the existence of the specified function and call it if it exists.
-    if (Splug.isExistFunction(func)) {
-      // Can be called with Server plugin function name.
-      (Splug as any)[func](args)
-        .then((respObj: unknown) => {
-          logger.info("*** RESPONSE ***");
-          logger.info("Client ID :" + client.id);
-          logger.info("Response  :" + JSON.stringify(respObj));
-          client.emit("response", respObj);
-        })
-        .catch((errObj: unknown) => {
-          logger.error("*** ERROR ***");
-          logger.error("Client ID :" + client.id);
-          logger.error("Detail    :" + JSON.stringify(errObj));
-          client.emit("connector_error", errObj);
-        });
-    } else {
-      // No such function
-      const emsg = "Function " + func + " not found!";
-      logger.error(emsg);
-      const retObj = {
-        status: 504,
-        errorDetail: emsg,
-      };
-      client.emit("connector_error", retObj);
+    const bind =
+      typeof sslport === "string" ? "Pipe " + sslport : "Port " + sslport;
+
+    // handle specific listen errors with friendly messages
+    switch (error.code) {
+      case "EACCES":
+        logger.error(bind + " requires elevated privileges");
+        process.exit(1);
+        break;
+      case "EADDRINUSE":
+        logger.error(bind + " is already in use");
+        process.exit(1);
+        break;
+      default:
+        throw error;
     }
   });
 
-  client.on("request2", function (data) {
-    const func = data.method.method;
-    let args: Record<string, any> = {
-      contract: data.contract,
-      method: data.method,
-      args: data.args,
-    };
+  io.on("connection", function (client) {
+    logger.info("Client " + client.id + " connected.");
 
-    if (data.reqID !== undefined) {
-      logger.info(`##add reqID: ${data.reqID}`);
-      args["reqID"] = data.reqID;
-    }
+    /**
+     * request: The server plugin's request to execute a function
+     * @param {JSON} data: Request Body (following format)
+     * JSON: {
+     *          "func":        (string) Function name ,// For example : "transferNumericAsset"
+     *          "args":        (Object) argument// for example , {"from" : "xxx" , "to" : "yyy" , "value" : "10,000"}
+     *       }
+     **/
+    client.on("request", function (data) {
+      const func = data.func;
+      const args = data.args;
+      if (data.reqID !== undefined) {
+        logger.info(`##add reqID: ${data.reqID}`);
+        args["reqID"] = data.reqID;
+      }
+      logger.info("##[HL-BC] Invoke smart contract to transfer asset(D1)");
+      logger.info("*** REQUEST ***");
+      logger.info("Client ID :" + client.id);
+      logger.info("Data  :" + JSON.stringify(data));
 
-    logger.info("##[HL-BC] Invoke smart contract to transfer asset(D1)");
-    logger.info("*** REQUEST ***");
-    logger.info("Client ID :" + client.id);
-    logger.info("Data  :" + JSON.stringify(data));
-
-    // Check for the presence of a request ID.
-    if (
-      data.method.type === "evaluateTransaction" ||
-      data.method.type === "submitTransaction"
-    ) {
-      // Call a synchronous method.
-      Splug.contractTransaction(args)
-        .then((respObj) => {
-          logger.info("*** RESPONSE ***");
-          logger.info("Client ID :" + client.id);
-          logger.info("Response  :" + JSON.stringify(respObj));
-          client.emit("response", respObj);
-        })
-        .catch((errObj) => {
-          logger.error("*** ERROR ***");
-          logger.error("Client ID :" + client.id);
-          logger.error("Detail    :" + JSON.stringify(errObj));
-          client.emit("connector_error", errObj);
-        });
-    } else if (data.method.type === "sendSignedTransaction") {
-      // Call an asynchronous method.
-      Splug.sendSignedTransaction(args)
-        .then((respObj) => {
-          logger.info("*** RESPONSE ***");
-          logger.info("Client ID :" + client.id);
-          logger.info("Response  :" + JSON.stringify(respObj));
-          client.emit("response", respObj);
-        })
-        .catch((errObj) => {
-          logger.error("*** ERROR ***");
-          logger.error("Client ID :" + client.id);
-          logger.error("Detail    :" + JSON.stringify(errObj));
-          client.emit("connector_error", errObj);
-        });
-    } else if (data.method.type === "function") {
-      const func = args["method"].command;
-      logger.info(`##method.type: function, function: ${func}`);
-      // logger.info(`##args: ${JSON.stringify(args)}`);
+      // Check for the existence of the specified function and call it if it exists.
       if (Splug.isExistFunction(func)) {
         // Can be called with Server plugin function name.
         (Splug as any)[func](args)
@@ -260,50 +126,169 @@ io.on("connection", function (client) {
         };
         client.emit("connector_error", retObj);
       }
-    } else {
-      // No such function
-      const emsg = "Function " + func + " not found!";
-      logger.error(emsg);
-      const retObj = {
-        status: 504,
-        errorDetail: emsg,
+    });
+
+    client.on("request2", function (data) {
+      const func = data.method.method;
+      let args: Record<string, any> = {
+        contract: data.contract,
+        method: data.method,
+        args: data.args,
       };
-      client.emit("connector_error", retObj);
-    }
-  });
 
-  /**
-   * startMonitor: starting block generation event monitoring
-   **/
-  client.on("startMonitor", function () {
-    // Callback to receive monitoring results
-    const cb = function (callbackData: Record<string, any>) {
-      let emitType = "";
-      if (callbackData.status == 200) {
-        emitType = "eventReceived";
-        logger.info("event data callbacked.");
-      } else {
-        emitType = "monitor_error";
+      if (data.reqID !== undefined) {
+        logger.info(`##add reqID: ${data.reqID}`);
+        args["reqID"] = data.reqID;
       }
-      client.emit(emitType, callbackData);
-    };
+      logger.info("##[HL-BC] Invoke smart contract to transfer asset(D1)");
+      logger.info("*** REQUEST ***");
+      logger.info("Client ID :" + client.id);
+      logger.info("Data  :" + JSON.stringify(data));
 
-    Smonitor.startMonitor(client.id, cb);
+      // Check for the presence of a request ID.
+      if (
+        data.method.type === "evaluateTransaction" ||
+        data.method.type === "submitTransaction"
+      ) {
+        // Call a synchronous method.
+        Splug.contractTransaction(args)
+          .then((respObj) => {
+            logger.info("*** RESPONSE ***");
+            logger.info("Client ID :" + client.id);
+            logger.info("Response  :" + JSON.stringify(respObj));
+            client.emit("response", respObj);
+          })
+          .catch((errObj) => {
+            logger.error("*** ERROR ***");
+            logger.error("Client ID :" + client.id);
+            logger.error("Detail    :" + JSON.stringify(errObj));
+            client.emit("connector_error", errObj);
+          });
+      } else if (data.method.type === "sendSignedTransaction") {
+        // Call an asynchronous method.
+        Splug.sendSignedTransaction(args)
+          .then((respObj) => {
+            logger.info("*** RESPONSE ***");
+            logger.info("Client ID :" + client.id);
+            logger.info("Response  :" + JSON.stringify(respObj));
+            client.emit("response", respObj);
+          })
+          .catch((errObj) => {
+            logger.error("*** ERROR ***");
+            logger.error("Client ID :" + client.id);
+            logger.error("Detail    :" + JSON.stringify(errObj));
+            client.emit("connector_error", errObj);
+          });
+      } else if (data.method.type === "function") {
+        const func = args["method"].command;
+        logger.info(`##method.type: function, function: ${func}`);
+        // logger.info(`##args: ${JSON.stringify(args)}`);
+        if (Splug.isExistFunction(func)) {
+          // Can be called with Server plugin function name.
+          (Splug as any)[func](args)
+            .then((respObj: unknown) => {
+              logger.info("*** RESPONSE ***");
+              logger.info("Client ID :" + client.id);
+              logger.info("Response  :" + JSON.stringify(respObj));
+              client.emit("response", respObj);
+            })
+            .catch((errObj: unknown) => {
+              logger.error("*** ERROR ***");
+              logger.error("Client ID :" + client.id);
+              logger.error("Detail    :" + JSON.stringify(errObj));
+              client.emit("connector_error", errObj);
+            });
+        } else {
+          // No such function
+          const emsg = "Function " + func + " not found!";
+          logger.error(emsg);
+          const retObj = {
+            status: 504,
+            errorDetail: emsg,
+          };
+          client.emit("connector_error", retObj);
+        }
+      } else {
+        // No such function
+        const emsg = "Function " + func + " not found!";
+        logger.error(emsg);
+        const retObj = {
+          status: 504,
+          errorDetail: emsg,
+        };
+        client.emit("connector_error", retObj);
+      }
+    });
+
+    /**
+     * startMonitor: starting block generation event monitoring
+     **/
+    client.on("startMonitor", function () {
+      Smonitor.startMonitor(client.id, (event) => {
+        let emitType = "";
+
+        if (event.status == 200) {
+          emitType = "eventReceived";
+          logger.info("event data callbacked.");
+        } else {
+          emitType = "monitor_error";
+        }
+
+        client.emit(emitType, event);
+      });
+    });
+
+    /**
+     * stopMonitor: block generation events monitoring stopping
+     **/
+    // I think it is more common to stop from the disconnect described later, but I will prepare for it.
+    client.on("stopMonitor", function (reason) {
+      Smonitor.stopMonitor(client.id);
+    });
+
+    client.on("disconnect", function (reason) {
+      // Unexpected disconnect as well as explicit disconnect request can be received here
+      logger.info("Client " + client.id + " disconnected.");
+      logger.info("Reason    :" + reason);
+      // Stop monitoring if disconnected client is for event monitoring
+      Smonitor.stopMonitor(client.id);
+    });
   });
 
-  /**
-   * stopMonitor: block generation events monitoring stopping
-   **/
-  // I think it is more common to stop from the disconnect described later, but I will prepare for it.
-  client.on("stopMonitor", function (reason) {
-    Smonitor.stopMonitor(client.id);
-  });
+  // Listen on provided port, on all network interfaces.
+  return new Promise<https.Server>((resolve) => server.listen(sslport, () => resolve(server)));
+};
 
-  client.on("disconnect", function (reason) {
-    // Unexpected disconnect as well as explicit disconnect request can be received here
-    logger.info("Client " + client.id + " disconnected.");
-    logger.info("Reason    :" + reason);
-    // Stop monitoring if disconnected client is for event monitoring
-    Smonitor.stopMonitor(client.id);
+// Normalize a port into a number, string, or false.
+function normalizePort(val: string) {
+  const port = parseInt(val, 10);
+
+  if (isNaN(port)) {
+    // named pipe
+    return val;
+  }
+
+  if (port >= 0) {
+    // port number
+    return port;
+  }
+
+  return false;
+}
+
+if (require.main === module) {
+  // When this file executed as a script, not loaded as module - run the connector
+  startFabricSocketIOConnector().then((server) => {
+    const addr = server.address();
+
+    if (!addr) {
+      logger.error("Could not get running server address - exit.");
+      process.exit(1);
+    }
+
+    const bind = typeof addr === "string" ? "pipe " + addr : "port " + addr.port;
+    logger.debug("Listening on " + bind);
+  }).catch((err) => {
+    logger.error("Could not start fabric-socketio connector:", err);
   });
-});
+}

--- a/packages/cactus-plugin-ledger-connector-fabric-socketio/src/main/typescript/connector/ServerMonitorPlugin.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric-socketio/src/main/typescript/connector/ServerMonitorPlugin.ts
@@ -17,7 +17,7 @@
 const process = require("process");
 import FabricClient from "fabric-client";
 // IF declaration for fabric
-import { getClientAndChannel, getSubmitterAndEnroll } from "./fabricaccess.js";
+import { getClientAndChannel, getSubmitterAndEnroll } from "./fabricaccess";
 // config file
 import * as config from "../common/core/config";
 // Log settings

--- a/packages/cactus-plugin-ledger-connector-fabric-socketio/src/main/typescript/connector/ValidatorAuthentication.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric-socketio/src/main/typescript/connector/ValidatorAuthentication.ts
@@ -13,20 +13,24 @@ import { getLogger } from "log4js";
 const logger = getLogger("ValidatorAuthentication[" + process.pid + "]");
 logger.level = config.read("logLevel", "info");
 
-const privateKey = fs.readFileSync(
-  path.resolve(__dirname, config.read("sslParam.key")),
-);
+let privateKey: string;
 
 export class ValidatorAuthentication {
   static sign(payload: object): string {
+    if (!privateKey) {
+      try {
+        privateKey = config.read<string>('sslParam.keyValue');
+      } catch {
+        privateKey = fs.readFileSync(config.read('sslParam.key'), "ascii");
+      }
+    }
+
     const option = {
       algorithm: "ES256",
-      expiresIn: "1000",
+      expiresIn: 60 * 15, // 15 minutes
     };
 
-    // logger.debug(`payload = ${JSON.stringify(payload)}`);
     const signature: string = jwt.sign(payload, privateKey, option);
-    // logger.debug(`signature = ${signature}`);
     logger.debug(`signature: OK`);
     return signature;
   }

--- a/packages/cactus-plugin-ledger-connector-fabric-socketio/src/main/typescript/index.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric-socketio/src/main/typescript/index.ts
@@ -1,0 +1,1 @@
+export * from "./public-api";

--- a/packages/cactus-plugin-ledger-connector-fabric-socketio/src/main/typescript/public-api.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric-socketio/src/main/typescript/public-api.ts
@@ -1,0 +1,1 @@
+export { startFabricSocketIOConnector } from "./common/core/bin/www"

--- a/packages/cactus-plugin-ledger-connector-fabric-socketio/src/test/typescript/integration/fabric-setup-helpers.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric-socketio/src/test/typescript/integration/fabric-setup-helpers.ts
@@ -1,0 +1,165 @@
+/**
+ * Fabric helpers to be used by functional tests.
+ * Works with Fabric SDK 1.4 - that's why it's not included in fabric ledger test class.
+ * Most functions are based on fabric-samples and utils scripts from tools/docker/fabric-all-in-one/asset-transfer-basic-utils
+ */
+
+import { LoggerProvider, Logger } from "@hyperledger/cactus-common";
+import { FileSystemWallet, Gateway, X509WalletMixin } from "fabric-network";
+import FabricCAServices from "fabric-ca-client";
+
+// Unit Test logger setup
+const log: Logger = LoggerProvider.getOrCreate({
+  label: "fabric-setup-helpers",
+  level: "info",
+});
+
+/**
+ * Enroll admin user on fabric and store it's credential in local filesystem wallet.
+ *
+ * @param connectionProfile - Fabric connection profile JSON.
+ * @param walletPath - Local filesystem wallet path.
+ * @param enrollmentID - admin username.
+ * @param enrollmentSecret - admin secret.
+ */
+export async function enrollAdmin(
+  connectionProfile: any,
+  walletPath: string,
+  enrollmentID: string,
+  enrollmentSecret: string,
+) {
+  log.info(
+    `Enroll admin user with enrollmentID='${enrollmentID}' and enrollmentSecret='${enrollmentSecret}'`,
+  );
+
+  // Create a new CA client for interacting with the CA.
+  const caName = connectionProfile.organizations.Org1.certificateAuthorities[0];
+  const caInfo = connectionProfile.certificateAuthorities[caName];
+  const caTLSCACerts = caInfo.tlsCACerts.pem;
+  const ca = new FabricCAServices(
+    caInfo.url,
+    { trustedRoots: caTLSCACerts, verify: false },
+    caInfo.caName,
+  );
+
+  // Create a new file system based wallet for managing identities.
+  const wallet = new FileSystemWallet(walletPath);
+
+  // Enroll admin user if not exist yet
+  const adminExists = await wallet.exists(enrollmentID);
+  if (!adminExists) {
+    const enrollment = await ca.enroll({
+      enrollmentID,
+      enrollmentSecret,
+    });
+    const identity = X509WalletMixin.createIdentity(
+      connectionProfile.organizations.Org1.mspid,
+      enrollment.certificate,
+      enrollment.key.toBytes(),
+    );
+    await wallet.import(enrollmentID, identity);
+    log.info(
+      `Successfully enrolled admin user ${enrollmentID} and imported it into the wallet. Current state:`,
+      await wallet.list(),
+    );
+  }
+}
+
+/**
+ * Enroll a user on fabric and store it's credential in local filesystem wallet.
+ * Must be called after `enrollAdmin()`
+ *
+ * @param connectionProfile - Fabric connection profile JSON.
+ * @param walletPath - Local filesystem wallet path.
+ * @param userName - regular username to enroll.
+ * @param adminUserName - admin username (must be already enrolled)
+ */
+export async function enrollUser(
+  connectionProfile: any,
+  walletPath: string,
+  userName: string,
+  adminUserName: string,
+) {
+  log.info(`Enroll user with userName='${userName}'`);
+
+  // Create a new file system based wallet for managing identities.
+  const wallet = new FileSystemWallet(walletPath);
+
+  // Check to see if we've already enrolled the user.
+  const userExists = await wallet.exists(userName);
+  if (userExists) {
+    console.log(
+      "An identity for the user userName already exists in the wallet",
+    );
+    return;
+  }
+
+  // Check to see if we've already enrolled the admin user.
+  const adminExists = await wallet.exists(adminUserName);
+  if (!adminExists) {
+    throw new Error(
+      "An identity for the admin user adminUserName does not exist in the wallet",
+    );
+  }
+
+  // Create a new gateway for connecting to our peer node.
+  const gateway = new Gateway();
+  await gateway.connect(connectionProfile, {
+    wallet,
+    identity: adminUserName,
+    discovery: { enabled: true, asLocalhost: true },
+  });
+
+  // Get the CA client object from the gateway for interacting with the CA.
+  const ca = gateway.getClient().getCertificateAuthority();
+  const adminIdentity = gateway.getCurrentIdentity();
+
+  // Register the user, enroll the user, and import the new identity into the wallet.
+  const secret = await ca.register(
+    {
+      affiliation: "org1.department1",
+      enrollmentID: userName,
+      role: "client",
+    },
+    adminIdentity,
+  );
+  const enrollment = await ca.enroll({
+    enrollmentID: userName,
+    enrollmentSecret: secret,
+  });
+  const userIdentity = X509WalletMixin.createIdentity(
+    connectionProfile.organizations.Org1.mspid,
+    enrollment.certificate,
+    enrollment.key.toBytes(),
+  );
+  await wallet.import(userName, userIdentity);
+  log.info(
+    `Successfully enrolled user ${userName} and imported it into the wallet. Current state:`,
+    await wallet.list(),
+  );
+}
+
+/**
+ * Get cryptographic data for specified user from local filesystem wallet.
+ * Can be used to sign transactions as specified user.
+ *
+ * @param name - Username enrolled in wallet.
+ * @param walletPath - Local filesystem wallet path.
+ * @returns A tuple [certificatePem, privateKeyPem]
+ */
+export async function getUserCryptoFromWallet(
+  name: string,
+  walletPath: string,
+): Promise<[string, string]> {
+  const wallet = new FileSystemWallet(walletPath);
+
+  const submitterExists = await wallet.exists(name);
+  if (!submitterExists) {
+    throw new Error(`User ${name} does not exist in wallet ${walletPath}`);
+  }
+
+  const submitterIdentity = await wallet.export(name);
+  const certPem = (submitterIdentity as any).certificate;
+  const privateKeyPem = (submitterIdentity as any).privateKey;
+  return [certPem, privateKeyPem];
+}

--- a/packages/cactus-plugin-ledger-connector-fabric-socketio/src/test/typescript/integration/fabric-socketio-connector.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric-socketio/src/test/typescript/integration/fabric-socketio-connector.test.ts
@@ -1,0 +1,516 @@
+/**
+ * Functional test of basic operations on connector-fabric-socketio (packages/cactus-plugin-ledger-connector-fabric-socketio)
+ * Assumes sample CC was is deployed on the test ledger.
+ * Tests include sending and evaluation transactions, and monitoring for events.
+ */
+
+//////////////////////////////////
+// Constants
+//////////////////////////////////
+
+// Ledger settings
+const imageName = "ghcr.io/hyperledger/cactus-fabric2-all-in-one";
+const imageVersion = "2021-09-02--fix-876-supervisord-retries";
+const fabricEnvVersion = "2.2.0";
+const fabricEnvCAVersion = "1.4.9";
+const ledgerUserName = "appUser";
+const ledgerChannelName = "mychannel";
+const ledgerContractName = "basic";
+
+// Log settings
+const testLogLevel: LogLevelDesc = "info";
+const sutLogLevel: LogLevelDesc = "info";
+
+import {
+  FabricTestLedgerV1,
+  pruneDockerAllIfGithubAction,
+} from "@hyperledger/cactus-test-tooling";
+
+import {
+  LogLevelDesc,
+  LoggerProvider,
+  Logger,
+} from "@hyperledger/cactus-common";
+
+import { SocketIOApiClient } from "@hyperledger/cactus-api-client";
+
+import {
+  enrollAdmin,
+  enrollUser,
+  getUserCryptoFromWallet,
+} from "./fabric-setup-helpers";
+
+import fs from "fs";
+import path from "path";
+import os from "os";
+import "jest-extended";
+import { Server as HttpsServer } from "https";
+
+// Logger setup
+const log: Logger = LoggerProvider.getOrCreate({
+  label: "fabric-socketio-connector.test",
+  level: testLogLevel,
+});
+
+// Path to sample CA used by the test - creating new EC certs for each run is to verbose for our purpose
+const sampleFabricCAPath = path.join(
+  process.cwd(),
+  "packages",
+  "cactus-plugin-ledger-connector-fabric-socketio",
+  "sample-config",
+  "CA",
+);
+const connectorCertPath = path.join(sampleFabricCAPath, "connector.crt");
+const connectorPrivKeyPath = path.join(sampleFabricCAPath, "connector.priv");
+
+/**
+ * Main test suite
+ */
+describe("Fabric-SocketIO connector tests", () => {
+  let ledger: FabricTestLedgerV1;
+  let connectorCertValue: string;
+  let connectorPrivKeyValue: string;
+  let tmpWalletDir: string;
+  let connectorServer: HttpsServer;
+  let apiClient: SocketIOApiClient;
+
+  //////////////////////////////////
+  // Environment Setup
+  //////////////////////////////////
+
+  /**
+   * @param connectionProfile - Fabric connection profile JSON
+   * @param connectorCert - connector-fabric-socketio server certificate
+   * @param connectorPrivKey - connector-fabric-socketio server private key
+   * @param walletDir - connector-fabric-socketio internal wallet path
+   * @param adminName - ledger admin username
+   * @param adminSecret - ledger admin secret
+   * @returns fabric-socketio conenctor config JSON
+   */
+  function createFabricConnectorConfig(
+    connectionProfile: Record<string, any>,
+    connectorCert: string,
+    connectorPrivKey: string,
+    walletDir: string,
+    adminName: string,
+    adminSecret: string,
+  ) {
+    // Get Org CA
+    const caId = connectionProfile.organizations.Org1.certificateAuthorities[0];
+    log.debug("Use CA:", caId);
+
+    // Get Orderer ID
+    const ordererId = connectionProfile.channels[ledgerChannelName].orderers[0];
+    log.debug("Use Orderer:", ordererId);
+
+    const connectorConfig: any = {
+      sslParam: {
+        port: 0, // random port
+        keyValue: connectorPrivKey,
+        certValue: connectorCert,
+      },
+      logLevel: sutLogLevel,
+      fabric: {
+        mspid: connectionProfile.organizations.Org1.mspid,
+        keystore: walletDir,
+        connUserName: ledgerUserName,
+        contractName: ledgerContractName,
+        peers: [], // will be filled below
+        orderer: {
+          name:
+            connectionProfile.orderers[ordererId].grpcOptions[
+              "ssl-target-name-override"
+            ],
+          url: connectionProfile.orderers[ordererId].url,
+          tlscaValue: connectionProfile.orderers[ordererId].tlsCACerts.pem,
+        },
+        ca: {
+          name: connectionProfile.certificateAuthorities[caId].caName,
+          url: connectionProfile.certificateAuthorities[caId].url,
+        },
+        submitter: {
+          name: adminName,
+          secret: adminSecret,
+        },
+        channelName: ledgerChannelName,
+        chaincodeId: ledgerContractName,
+      },
+    };
+
+    // Add peers
+    connectionProfile.organizations.Org1.peers.forEach((peerName: string) => {
+      log.debug("Add Peer:", peerName);
+      const peer = connectionProfile.peers[peerName];
+      connectorConfig.fabric.peers.push({
+        name: peer.grpcOptions["ssl-target-name-override"],
+        requests: peer.url,
+        tlscaValue: peer.tlsCACerts.pem,
+      });
+    });
+
+    const configJson = JSON.stringify(connectorConfig);
+    log.debug("Connector Config:", configJson);
+    return configJson;
+  }
+
+  beforeAll(async () => {
+    log.info("Prune Docker...");
+    await pruneDockerAllIfGithubAction({ logLevel: testLogLevel });
+
+    log.info("Start FabricTestLedgerV1...");
+    log.debug("Version:", fabricEnvVersion, "CA Version:", fabricEnvCAVersion);
+    ledger = new FabricTestLedgerV1({
+      emitContainerLogs: false,
+      publishAllPorts: true,
+      logLevel: testLogLevel,
+      imageName,
+      imageVersion,
+      envVars: new Map([
+        ["FABRIC_VERSION", fabricEnvVersion],
+        ["CA_VERSION", fabricEnvCAVersion],
+      ]),
+    });
+    log.debug("Fabric image:", ledger.getContainerImageName());
+    await ledger.start();
+
+    // Get connection profile
+    log.info("Get fabric connection profile for Org1...");
+    const connectionProfile = await ledger.getConnectionProfileOrg1();
+    expect(connectionProfile).toBeTruthy();
+
+    // Get admin credentials
+    const [adminName, adminSecret] = ledger.adminCredentials;
+
+    // Setup wallet
+    log.info("Create temp dir for wallet - will be removed later...");
+    tmpWalletDir = fs.mkdtempSync(path.join(os.tmpdir(), "fabric-test-wallet"));
+    expect(tmpWalletDir).toBeTruthy();
+    await enrollAdmin(connectionProfile, tmpWalletDir, adminName, adminSecret);
+    await enrollUser(
+      connectionProfile,
+      tmpWalletDir,
+      ledgerUserName,
+      adminName,
+    );
+
+    // Read connector private key and certificate
+    connectorCertValue = fs.readFileSync(connectorCertPath, "ascii");
+    connectorPrivKeyValue = fs.readFileSync(connectorPrivKeyPath, "ascii");
+
+    // Get connector config
+    log.info("Export connector config before loading the module...");
+    process.env["NODE_CONFIG"] = createFabricConnectorConfig(
+      connectionProfile,
+      connectorCertValue,
+      connectorPrivKeyValue,
+      tmpWalletDir,
+      adminName,
+      adminSecret,
+    );
+
+    // Load connector module
+    const connectorModule = await import("../../../main/typescript/index");
+
+    // Run the connector
+    connectorServer = await connectorModule.startFabricSocketIOConnector();
+    expect(connectorServer).toBeTruthy();
+    const connectorAddress = connectorServer.address();
+    if (!connectorAddress || typeof connectorAddress === "string") {
+      throw new Error("Unexpected fabric connector AddressInfo type");
+    }
+    log.info(
+      "Fabric-SocketIO Connector started on:",
+      `${connectorAddress.address}:${connectorAddress.port}`,
+    );
+
+    // Create ApiClient instance
+    const apiConfigOptions = {
+      validatorID: "fabric-socketio-test",
+      validatorURL: `https://localhost:${connectorAddress.port}`,
+      validatorKeyValue: connectorCertValue,
+      logLevel: sutLogLevel,
+      maxCounterRequestID: 1000,
+      syncFunctionTimeoutMillisecond: 10000,
+      socketOptions: {
+        rejectUnauthorized: false,
+        reconnection: false,
+        timeout: 60000,
+      },
+    };
+    log.debug("ApiClient config:", apiConfigOptions);
+    apiClient = new SocketIOApiClient(apiConfigOptions);
+  });
+
+  afterAll(async () => {
+    log.info("FINISHING THE TESTS");
+
+    if (ledger) {
+      log.info("Stop the fabric ledger...");
+      await ledger.stop();
+      await ledger.destroy();
+    }
+
+    if (apiClient) {
+      log.info("Close ApiClient connection...");
+      apiClient.close();
+    }
+
+    if (connectorServer) {
+      log.info("Stop the fabric connector...");
+      await new Promise<void>((resolve) =>
+        connectorServer.close(() => resolve()),
+      );
+    }
+
+    if (tmpWalletDir) {
+      log.info("Remove tmp wallet dir", tmpWalletDir);
+      fs.rmSync(tmpWalletDir, { recursive: true });
+    }
+
+    log.info("Prune Docker...");
+    await pruneDockerAllIfGithubAction({ logLevel: testLogLevel });
+  });
+
+  //////////////////////////////////
+  // Test Helpers
+  //////////////////////////////////
+
+  /**
+   * Calls `GetAllAssets` from `basic` CC on the ledger using apiClient.sendSyncRequest
+   * @returns List of assets
+   */
+  async function getAllAssets() {
+    const contract = {
+      channelName: ledgerChannelName,
+      contractName: ledgerContractName,
+    };
+    const method = {
+      type: "evaluateTransaction",
+      command: "GetAllAssets",
+    };
+    const args = { args: [] };
+
+    const results = await apiClient.sendSyncRequest(contract, method, args);
+
+    expect(results).toBeTruthy();
+    expect(results.status).toBe(200);
+    expect(results.data).toBeTruthy();
+    expect(results.data.length).toBeGreaterThanOrEqual(5); // we assume at least 5 assets in future tests
+    return results.data as { ID: string }[];
+  }
+
+  /**
+   * Calls `GetAllAssets` from `basic` CC on the ledger using apiClient.sendSyncRequest
+   *
+   * @param assetID - Asset to read from the ledger.
+   * @returns asset object
+   */
+  async function readAsset(assetID: string) {
+    const contract = {
+      channelName: ledgerChannelName,
+      contractName: ledgerContractName,
+    };
+    const method = {
+      type: "evaluateTransaction",
+      command: "ReadAsset",
+    };
+    const args = { args: [assetID] };
+
+    const results = await apiClient.sendSyncRequest(contract, method, args);
+
+    expect(results).toBeTruthy();
+    expect(results.status).toBe(200);
+    expect(results.data).toBeTruthy();
+    return results.data;
+  }
+
+  /**
+   * Calls connector function `sendSignedProposal`, assert correct response, and returns signed proposal.
+   * @param txProposal - Transaction data we want to send (CC function name, arguments, chancode ID, channel ID)
+   * @returns Signed proposal that can be feed into `sendSignedProposal`
+   */
+  async function getSignedProposal(txProposal: {
+    fcn: string;
+    args: string[];
+    chaincodeId: string;
+    channelId: string;
+  }) {
+    const [certPem, privateKeyPem] = await getUserCryptoFromWallet(
+      ledgerUserName,
+      tmpWalletDir,
+    );
+    const contract = { channelName: ledgerChannelName };
+    const method = { type: "function", command: "sendSignedProposal" };
+    const argsParam = {
+      args: {
+        transactionProposalReq: txProposal,
+        certPem,
+        privateKeyPem,
+      },
+    };
+
+    const response = await apiClient.sendSyncRequest(
+      contract,
+      method,
+      argsParam,
+    );
+    expect(response).toBeTruthy();
+    expect(response.status).toBe(200);
+    expect(response.data).toBeTruthy();
+    expect(response.data.signedCommitProposal).toBeTruthy();
+    expect(response.data.commitReq).toBeTruthy();
+    expect(response.data.txId).toBeTruthy();
+
+    const { signedCommitProposal, commitReq } = response.data;
+
+    // signedCommitProposal must be Buffer
+    signedCommitProposal.signature = Buffer.from(
+      signedCommitProposal.signature,
+    );
+    signedCommitProposal.proposal_bytes = Buffer.from(
+      signedCommitProposal.proposal_bytes,
+    );
+
+    return { signedCommitProposal, commitReq };
+  }
+
+  //////////////////////////////////
+  // Tests
+  //////////////////////////////////
+
+  /**
+   * Read all assets, get single asset, comapre that they return the same asset value without any errors.
+   */
+  test("Evaluate transaction returns correct data (GetAllAssets and ReadAsset)", async () => {
+    const allAssets = await getAllAssets();
+    const firstAsset = allAssets.pop();
+    if (!firstAsset) {
+      throw new Error("Unexpected missing firstAsset");
+    }
+    const readSingleAsset = await readAsset(firstAsset.ID);
+    expect(readSingleAsset).toEqual(firstAsset);
+  });
+
+  /**
+   * Send transaction proposal to be signed with keys attached to the request (managed by BLP),
+   * and then send signed transaction to the ledger.
+   */
+  test("Signining proposal and sending it to the ledger works", async () => {
+    // Get asset data to be transfered
+    const allAssets = await getAllAssets();
+    const assetId = allAssets[1].ID;
+    const newOwnerName = "SignAndSendXXX";
+
+    // Prepare signed proposal
+    const txProposal = {
+      fcn: "TransferAsset",
+      args: [assetId, newOwnerName],
+      chaincodeId: ledgerContractName,
+      channelId: ledgerChannelName,
+    };
+    const signedProposal = await getSignedProposal(txProposal);
+
+    // Send transaction
+    const contract = { channelName: ledgerChannelName };
+    const method = { type: "sendSignedTransaction" };
+    const args = { args: [signedProposal] };
+
+    const response = await apiClient.sendSyncRequest(contract, method, args);
+    expect(response).toBeTruthy();
+    expect(response.status).toBe(200);
+    expect(response.data).toBeTruthy();
+    expect(response.data.status).toEqual("SUCCESS");
+  });
+
+  /**
+   * Send transaction proposal to be signed with keys from connector wallet (managed by the connector).
+   * Verify correct response from the call.
+   */
+  test("Signining proposal with connector wallet keys work", async () => {
+    // Get asset data to be transfered
+    const allAssets = await getAllAssets();
+    const assetId = allAssets[2].ID;
+    const newOwnerName = "SignWithConnectorXXX";
+
+    // Prepare signed proposal
+    const contract = { channelName: ledgerChannelName };
+    const method = { type: "function", command: "sendSignedProposal" };
+    const argsParam = {
+      args: {
+        transactionProposalReq: {
+          fcn: "TransferAsset",
+          args: [assetId, newOwnerName],
+          chaincodeId: ledgerContractName,
+          channelId: ledgerChannelName,
+        },
+      },
+    };
+
+    const response = await apiClient.sendSyncRequest(
+      contract,
+      method,
+      argsParam,
+    );
+    expect(response).toBeTruthy();
+    expect(response.status).toBe(200);
+    expect(response.data).toBeTruthy();
+    expect(response.data.signedCommitProposal).toBeTruthy();
+    expect(response.data.commitReq).toBeTruthy();
+    expect(response.data.txId).toBeTruthy();
+  });
+
+  /**
+   * Start monitoring for fabric events.
+   * Send new transaction to the ledger (async)
+   * Finish after receiving event for matching transaction function.
+   * This function needs separate timeout, in case of error (no event was received).
+   */
+  test(
+    "Monitoring for transaction sending works",
+    async () => {
+      // Get asset data to be transfered
+      const allAssets = await getAllAssets();
+      const assetId = allAssets[3].ID;
+      const newOwnerName = "MonitorChangedXXX";
+      const txFunctionName = "TransferAsset";
+
+      // Start monitoring
+      const monitorPromise = new Promise<void>((resolve, reject) => {
+        apiClient.watchBlocksV1().subscribe({
+          next(event) {
+            expect(event.status).toBe(200);
+
+            const matchingEvents = event.blockData.filter(
+              (e) => e.func === txFunctionName,
+            );
+
+            if (matchingEvents.length > 0) {
+              resolve();
+            }
+          },
+          error(err) {
+            log.error("watchBlocksV1() error:", err);
+            reject(err);
+          },
+        });
+      });
+
+      // Get signed proposal
+      const signedProposal = await getSignedProposal({
+        fcn: txFunctionName,
+        args: [assetId, newOwnerName],
+        chaincodeId: ledgerContractName,
+        channelId: ledgerChannelName,
+      });
+
+      // Send transaction (async)
+      const contract = { channelName: ledgerChannelName };
+      const method = { type: "sendSignedTransaction" };
+      const args = { args: [signedProposal] };
+      apiClient.sendAsyncRequest(contract, method, args);
+
+      expect(monitorPromise).toResolve();
+    },
+    60 * 1000,
+  );
+});

--- a/packages/cactus-plugin-ledger-connector-fabric-socketio/tsconfig.json
+++ b/packages/cactus-plugin-ledger-connector-fabric-socketio/tsconfig.json
@@ -11,5 +11,10 @@
     "./src/main/typescript/common/core/bin/*.ts",
     "./src/main/typescript/common/core/config/*.ts",
     "./src/main/typescript/connector/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../cactus-api-client/tsconfig.json"
+    }
   ]
 }

--- a/packages/cactus-test-tooling/src/main/typescript/fabric/fabric-test-ledger-v1.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/fabric/fabric-test-ledger-v1.ts
@@ -248,6 +248,13 @@ export class FabricTestLedgerV1 implements ITestLedger {
     }
   }
 
+  /**
+   * Tuple of [adminUsername, adminSecret]
+   */
+  public get adminCredentials(): [string, string] {
+    return ["admin", "adminpw"];
+  }
+
   public async enrollAdmin(): Promise<[X509Identity, Wallet]> {
     const fnTag = `${this.className}#enrollAdmin()`;
     try {
@@ -255,7 +262,10 @@ export class FabricTestLedgerV1 implements ITestLedger {
       const wallet = await Wallets.newInMemoryWallet();
 
       // Enroll the admin user, and import the new identity into the wallet.
-      const request = { enrollmentID: "admin", enrollmentSecret: "adminpw" };
+      const request = {
+        enrollmentID: this.adminCredentials[0],
+        enrollmentSecret: this.adminCredentials[1],
+      };
       const enrollment = await ca.enroll(request);
 
       const mspId = this.getDefaultMspId();
@@ -983,7 +993,7 @@ export class FabricTestLedgerV1 implements ITestLedger {
     const fnTag = `FabricTestLedger#addOrgX()`;
     const { log } = this;
     log.debug(`
-    Adding ${orgName} on ${channel}, with state database ${database}. 
+    Adding ${orgName} on ${channel}, with state database ${database}.
     Certification authority: ${certificateAuthority}.
     Default port: ${peerPort}
     Path to original source files: ${addOrgXDirectoryPath}`);

--- a/packages/cactus-verifier-client/src/test/typescript/unit/get-validator-api-client.test.ts
+++ b/packages/cactus-verifier-client/src/test/typescript/unit/get-validator-api-client.test.ts
@@ -18,7 +18,7 @@ test("Create legacy socketio client", () => {
   const clientOptions: SocketIOApiClientOptions = {
     validatorID: "someValId",
     validatorURL: "invalid-url123asd",
-    validatorKeyPath: "key.pem",
+    validatorKeyValue: "xxxxxxxxxxxxx",
   };
 
   const clientApi: SocketIOApiClient = getValidatorApiClient(

--- a/packages/cactus-verifier-client/src/test/typescript/unit/verifier-factory.test.ts
+++ b/packages/cactus-verifier-client/src/test/typescript/unit/verifier-factory.test.ts
@@ -17,7 +17,7 @@ describe("Constructor Tests", () => {
         validatorID: "sUr7d10R",
         validatorType: "legacy-socketio",
         validatorURL: "https://sawtooth-validator:5140",
-        validatorKeyPath: "./validatorKey/sUr7d10R/keysUr7d10R.crt",
+        validatorKeyValue: "xxxxxxxx",
         ledgerInfo: {
           ledgerAbstract: "Sawtooth Ledger",
         },
@@ -46,7 +46,7 @@ describe("Constructor Tests", () => {
         validatorID: "sUr7d10R",
         validatorType: "legacy-socketio",
         validatorURL: "https://sawtooth-validator:5140",
-        validatorKeyPath: "./validatorKey/sUr7d10R/keysUr7d10R.crt",
+        validatorKeyValue: "xxxxxxxx",
         ledgerInfo: {
           ledgerAbstract: "Sawtooth Ledger",
         },
@@ -75,7 +75,7 @@ describe("getVerifier Tests", () => {
       validatorID: "mySocketSawtoothValidatorId",
       validatorType: "legacy-socketio",
       validatorURL: "https://sawtooth-validator:5140",
-      validatorKeyPath: "./validatorKey/sUr7d10R/keysUr7d10R.crt",
+      validatorKeyValue: "xxxxxxxx",
       ledgerInfo: {
         ledgerAbstract: "Sawtooth Ledger",
       },


### PR DESCRIPTION
Added functional jest test `fabric-socketio-connector.test` that can be run during CI process. It checks evaluate/sending transactions and monitoring for new events. Connector had to be refactored to be testable, tests also discovered some bugs that had to be fixed in order to pass.

### SocketIOApiClient refactors:
- Added option for supplying `validatorKeyValue` instead of `validatorKeyPath`.
- JWT validation function works with key value now (instead of reading the key).
- Validator can now return messages that are not encrypted (it throwed error previously).
- Adjusted unit tests.

### connector-fabric-socketio refactors:
- Connector can be run both as a standalone app and loaded as a module `www.js`. Caller can use exported `startFabricSocketIOConnector` function to run the connector. Configuration must be supplied in file or in env variable like it's done in functional test.
- All cryptographic data (keys, certificates, etc…) can now be supplied as a value (previously it supported only path to a file).
- `sendSignedTransaction` can now be called synchronously (it had wrong response format before).
- Fixed a bug introduced during my last changes in this component, which caused fabric-client session to be disconnected but still reused by follow-up requests. I didn't know that gateway disconnects client it operates on.
- Increased JWT expiration to 15 minutes to prevent constant JWT expiration error (I'm pretty sure 15 minutes is still secure period).
- Minor improvements (logging, formatting, etc…)

### fabric-test-ledger-v1 changes:
- Added `adminCredentials()` to have programatic access to admin credentials on currently used ledger
 (unlikely, but can change in the future).

Depends on: https://github.com/hyperledger/cactus/pull/1975

Closes: https://github.com/hyperledger/cactus/issues/1976

Signed-off-by: Michal Bajer <michal.bajer@fujitsu.com>