### PR TITLE
refactor(electricity-trade): use cactus-verifier-client

### DIFF
--- a/examples/electricity-trade/BalanceManagement.ts
+++ b/examples/electricity-trade/BalanceManagement.ts
@@ -7,9 +7,12 @@
 
 import {
   LPInfoHolder,
-  Verifier,
   ConfigUtil,
 } from "@hyperledger/cactus-cmd-socket-server";
+import {
+  VerifierFactory,
+  VerifierFactoryConfig,
+} from "@hyperledger/cactus-verifier-client";
 
 const config: any = ConfigUtil.getConfig();
 import { getLogger } from "log4js";
@@ -19,21 +22,18 @@ logger.level = config.logLevel;
 
 export class BalanceManagement {
   private connectInfo: LPInfoHolder = null; // connection information
-  private verifierEthereum: Verifier = null;
+  private readonly verifierFactory: VerifierFactory;
 
   constructor() {
     this.connectInfo = new LPInfoHolder();
+    this.verifierFactory = new VerifierFactory(
+      this.connectInfo.ledgerPluginInfo as VerifierFactoryConfig,
+      config.logLevel,
+    );
   }
 
   getBalance(account: string): Promise<any> {
     return new Promise((resolve, reject) => {
-      if (this.verifierEthereum === null) {
-        logger.debug("create verifierEthereum");
-        const ledgerPluginInfo: string =
-          this.connectInfo.getLegerPluginInfo("84jUisrs");
-        this.verifierEthereum = new Verifier(ledgerPluginInfo);
-      }
-
       // for LedgerOperation
       // const execData = {"referedAddress": account};
       // const ledgerOperation: LedgerOperation = new LedgerOperation("getNumericBalance", "", execData);
@@ -46,7 +46,8 @@ export class BalanceManagement {
       // const method = "default";
       // const args = {"method": {type: "web3Eth", command: "getBalance"}, "args": {"args": [account]}};
 
-      this.verifierEthereum
+      this.verifierFactory
+        .getVerifier("84jUisrs")
         .sendSyncRequest(contract, method, args)
         .then((result) => {
           const response = {

--- a/examples/electricity-trade/BusinessLogicElectricityTrade.ts
+++ b/examples/electricity-trade/BusinessLogicElectricityTrade.ts
@@ -12,11 +12,11 @@ import { MeterInfo } from "./MeterInfo";
 import {
   TradeInfo,
   routesTransactionManagement,
-  routesVerifierFactory,
   BusinessLogicBase,
   LedgerEvent,
   json2str,
   ConfigUtil,
+  LPInfoHolder,
 } from "@hyperledger/cactus-cmd-socket-server";
 import { makeRawTransaction } from "./TransactionEthereum";
 
@@ -25,9 +25,19 @@ const yaml = require("js-yaml");
 //const config: any = JSON.parse(fs.readFileSync("/etc/cactus/default.json", 'utf8'));
 const config: any = ConfigUtil.getConfig();
 import { getLogger } from "log4js";
+import {
+  VerifierFactory,
+  VerifierFactoryConfig,
+} from "@hyperledger/cactus-verifier-client";
+
 const moduleName = "BusinessLogicElectricityTrade";
 const logger = getLogger(`${moduleName}`);
 logger.level = config.logLevel;
+const connectInfo = new LPInfoHolder();
+const routesVerifierFactory = new VerifierFactory(
+  connectInfo.ledgerPluginInfo as VerifierFactoryConfig,
+  config.logLevel,
+);
 
 export class BusinessLogicElectricityTrade extends BusinessLogicBase {
   businessLogicID: string;
@@ -75,8 +85,11 @@ export class BusinessLogicElectricityTrade extends BusinessLogicBase {
     //        const verifierSawtooth = transactionManagement.getVerifier(useValidator['validatorID'][0], options);
     const verifierSawtooth = routesVerifierFactory.getVerifier(
       useValidator["validatorID"][0],
+    );
+    verifierSawtooth.startMonitor(
       "BusinessLogicElectricityTrade",
       options,
+      routesTransactionManagement,
     );
     logger.debug("getVerifierSawtooth");
   }
@@ -119,7 +132,11 @@ export class BusinessLogicElectricityTrade extends BusinessLogicBase {
     //        const verifierEthereum = routesTransactionManagement.getVerifier(useValidator['validatorID'][1]);
     const verifierEthereum = routesVerifierFactory.getVerifier(
       useValidator["validatorID"][1],
+    );
+    verifierEthereum.startMonitor(
       "BusinessLogicElectricityTrade",
+      {},
+      routesTransactionManagement,
     );
     logger.debug("getVerifierEthereum");
 

--- a/examples/electricity-trade/Dockerfile
+++ b/examples/electricity-trade/Dockerfile
@@ -1,11 +1,14 @@
 FROM cactus-cmd-socketio-server:latest
 
+ARG NPM_PKG_VERSION=latest
+
 ENV APP_HOME=/root/cactus
 
 WORKDIR ${APP_HOME}
 
-COPY ./dist/yarn.lock ./package.json ./
-RUN yarn add "${CACTUS_CMD_SOCKETIO_PATH}" --production --ignore-engines --non-interactive --cache-folder ./.yarnCache && \
+COPY ./dist/yarn.lock ./package.json ./dist/ethereum-connector.crt ./dist/sawtooth-connector.crt ./
+RUN yarn add "${CACTUS_CMD_SOCKETIO_PATH}" "@hyperledger/cactus-verifier-client@${NPM_PKG_VERSION}" \
+        --production --ignore-engines --non-interactive --cache-folder ./.yarnCache && \
     rm -rf ./.yarnCache
 
 COPY ./dist ./dist/

--- a/examples/electricity-trade/config/validator-registry-config.yaml
+++ b/examples/electricity-trade/config/validator-registry-config.yaml
@@ -1,9 +1,15 @@
 ledgerPluginInfo:
   -
     validatorID: 84jUisrs
-    validatorType: socketio
+    validatorType: legacy-socketio
     validatorURL: https://ethereum-validator:5050
-    validatorKeyPath: /etc/cactus/connector-go-ethereum-socketio/CA/connector.crt
+    validatorKeyPath: /root/cactus/ethereum-connector.crt
+    maxCounterRequestID: 100
+    syncFunctionTimeoutMillisecond: 5000
+    socketOptions:
+      rejectUnauthorized: false
+      reconnection: false
+      timeout: 20000
     ledgerInfo:
       ledgerAbstract: Go-Ethereum Ledger
     apiInfo:
@@ -34,9 +40,15 @@ ledgerPluginInfo:
 
   -
     validatorID: sUr7d10R
-    validatorType: socketio
+    validatorType: legacy-socketio
     validatorURL: https://sawtooth-validator:5140
-    validatorKeyPath: /etc/cactus/connector-sawtooth-socketio/CA/connector.crt
+    validatorKeyPath: /root/cactus/sawtooth-connector.crt
+    maxCounterRequestID: 100
+    syncFunctionTimeoutMillisecond: 5000
+    socketOptions:
+      rejectUnauthorized: false
+      reconnection: false
+      timeout: 20000
     ledgerInfo:
       ledgerAbstract: Sawtooth Ledger
     apiInfo: []

--- a/examples/electricity-trade/docker-compose.yml
+++ b/examples/electricity-trade/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     build:
       context: ../../packages/cactus-plugin-ledger-connector-sawtooth-socketio/
     ports:
-      - "5040:5040"
+      - "5140:5140"
     networks:
       - sawtooth_net
       - electricity-trade-net

--- a/examples/electricity-trade/package.json
+++ b/examples/electricity-trade/package.json
@@ -5,7 +5,11 @@
     "start": "docker-compose build && docker-compose up",
     "build": "npm run build-ts && npm run prepare-docker-build",
     "build-ts": "tsc -p ./tsconfig.json",
-    "prepare-docker-build": "cp -f ../../yarn.lock ./dist/"
+    "prepare-docker-build": "npm run copy-yarn-lock && npm run copy-validator-keys",
+    "copy-yarn-lock": "cp -f ../../yarn.lock ./dist/",
+    "copy-validator-keys": "npm run copy-ethereum-key && npm run copy-sawtooth-key",
+    "copy-ethereum-key": "cp -fr ../../packages/cactus-plugin-ledger-connector-go-ethereum-socketio/sample-config/CA/connector.crt ./dist/ethereum-connector.crt",
+    "copy-sawtooth-key": "cp -fr ../../packages/cactus-plugin-ledger-connector-sawtooth-socketio/sample-config/CA/connector.crt ./dist/sawtooth-connector.crt"
   },
   "dependencies": {
     "@types/node": "14.18.12",

--- a/examples/electricity-trade/tsconfig.json
+++ b/examples/electricity-trade/tsconfig.json
@@ -76,5 +76,8 @@
     {
       "path": "../../packages/cactus-cmd-socketio-server/tsconfig.json"
     },
+    {
+      "path": "../../packages/cactus-verifier-client/tsconfig.json"
+    }
   ]
 }


### PR DESCRIPTION
Sample app electricity-trade is currently using Verifier interface from cactus-cmd-socket-server.
Replace it with VerifierFactory from cactus-verifier-client package that
can work with all cactus connectors.

Related: #1982
Signed-off-by: Michal Bajer <michal.bajer@fujitsu.com>