### PR TITLE
refactor(discounted-cartrade): use cactus-verifier-client

### DIFF
--- a/examples/discounted-cartrade/AssetManagement.ts
+++ b/examples/discounted-cartrade/AssetManagement.ts
@@ -6,9 +6,12 @@
  */
 
 import { LPInfoHolder } from "@hyperledger/cactus-cmd-socket-server";
-import { Verifier } from "@hyperledger/cactus-cmd-socket-server";
 import { ContractInfoHolder } from "@hyperledger/cactus-cmd-socket-server";
 import { ConfigUtil } from "@hyperledger/cactus-cmd-socket-server";
+import {
+  VerifierFactory,
+  VerifierFactoryConfig,
+} from "@hyperledger/cactus-verifier-client";
 
 const fs = require("fs");
 const path = require("path");
@@ -21,22 +24,19 @@ logger.level = config.logLevel;
 export class AssetManagement {
   private connectInfo: LPInfoHolder = null; // connection information
   private contractInfoholder: ContractInfoHolder = null; // contract information
-  private verifierEthereum: Verifier = null;
+  private readonly verifierFactory: VerifierFactory;
 
   constructor() {
     this.connectInfo = new LPInfoHolder();
     this.contractInfoholder = new ContractInfoHolder();
+    this.verifierFactory = new VerifierFactory(
+      this.connectInfo.ledgerPluginInfo as VerifierFactoryConfig,
+      config.logLevel,
+    );
   }
 
   addAsset(amount: string): Promise<any> {
     return new Promise((resolve, reject) => {
-      if (this.verifierEthereum === null) {
-        logger.debug("create verifierEthereum");
-        const ledgerPluginInfo: string =
-          this.connectInfo.getLegerPluginInfo("84jUisrs");
-        this.verifierEthereum = new Verifier(ledgerPluginInfo);
-      }
-
       // for Neo
       const contractInfo: string =
         this.contractInfoholder.getContractInfo("AssetContract");
@@ -58,7 +58,8 @@ export class AssetManagement {
       // const method = "default";
       // const args = {"method": {type: "contract", command: "addAsset", function: "sendTransaction"}, "args": {"args": [amount, {from: coinbase}]}};
 
-      this.verifierEthereum
+      this.verifierFactory
+        .getVerifier("84jUisrs")
         .sendSyncRequest(contract, method, args)
         .then((result) => {
           const response = {
@@ -76,13 +77,6 @@ export class AssetManagement {
 
   getAsset(): Promise<any> {
     return new Promise((resolve, reject) => {
-      if (this.verifierEthereum === null) {
-        logger.debug("create verifierEthereum");
-        const ledgerPluginInfo: string =
-          this.connectInfo.getLegerPluginInfo("84jUisrs");
-        this.verifierEthereum = new Verifier(ledgerPluginInfo);
-      }
-
       // for Neo
       const contractInfo: string =
         this.contractInfoholder.getContractInfo("AssetContract");
@@ -103,7 +97,8 @@ export class AssetManagement {
       // const method = "default";
       // const args = {"method": {type: "contract", command: "getAsset", function: "call"}, "args": {"args": []}};
 
-      this.verifierEthereum
+      this.verifierFactory
+        .getVerifier("84jUisrs")
         .sendSyncRequest(contract, method, args)
         .then((result) => {
           const response = {

--- a/examples/discounted-cartrade/BusinessLogicCartrade.ts
+++ b/examples/discounted-cartrade/BusinessLogicCartrade.ts
@@ -14,15 +14,19 @@ import { TransactionData } from "./TransactionData";
 import { BusinessLogicInquireCartradeStatus } from "./BusinessLogicInquireCartradeStatus";
 import { TxInfoData } from "./TxInfoData";
 import { routesTransactionManagement } from "@hyperledger/cactus-cmd-socket-server";
-import { routesVerifierFactory } from "@hyperledger/cactus-cmd-socket-server";
 import { LedgerOperation } from "@hyperledger/cactus-cmd-socket-server";
 import { BusinessLogicBase } from "@hyperledger/cactus-cmd-socket-server";
+import { LPInfoHolder } from "@hyperledger/cactus-cmd-socket-server";
 import { makeRawTransaction } from "./TransactionEthereum";
 import { makeSignedProposal } from "./TransactionFabric";
 import { getDataFromIndy } from "./TransactionIndy";
 import { LedgerEvent, ConfigUtil } from "@hyperledger/cactus-cmd-socket-server";
 import { json2str } from "@hyperledger/cactus-cmd-socket-server";
 import { CartradeStatus } from "./define";
+import {
+  VerifierFactory,
+  VerifierFactoryConfig,
+} from "@hyperledger/cactus-verifier-client";
 
 const fs = require("fs");
 const path = require("path");
@@ -34,6 +38,12 @@ import { getLogger } from "log4js";
 const moduleName = "BusinessLogicCartrade";
 const logger = getLogger(`${moduleName}`);
 logger.level = config.logLevel;
+
+const connectInfo = new LPInfoHolder();
+const routesVerifierFactory = new VerifierFactory(
+  connectInfo.ledgerPluginInfo as VerifierFactoryConfig,
+  config.logLevel,
+);
 
 const indy = require("indy-sdk");
 const assert = require("assert");
@@ -285,7 +295,11 @@ export class BusinessLogicCartrade extends BusinessLogicBase {
     //        const verifierEthereum = routesTransactionManagement.getVerifier(useValidator['validatorID'][0]);
     const verifierEthereum = routesVerifierFactory.getVerifier(
       useValidator["validatorID"][0],
-      "BusinessLogicCartrade"
+    );
+    verifierEthereum.startMonitor(
+      "BusinessLogicCartrade",
+      {},
+      routesTransactionManagement,
     );
     logger.debug("getVerifierEthereum");
 
@@ -374,7 +388,11 @@ export class BusinessLogicCartrade extends BusinessLogicBase {
     //        const verifierFabric = routesTransactionManagement.getVerifier(useValidator['validatorID'][1]);
     const verifierFabric = routesVerifierFactory.getVerifier(
       useValidator["validatorID"][1],
-      "BusinessLogicCartrade"
+    );
+    verifierFabric.startMonitor(
+      "BusinessLogicCartrade",
+      {},
+      routesTransactionManagement,
     );
     logger.debug("getVerifierFabric");
 
@@ -449,7 +467,6 @@ export class BusinessLogicCartrade extends BusinessLogicBase {
     //        const verifierEthereum = routesTransactionManagement.getVerifier(useValidator['validatorID'][0]);
     const verifierEthereum = routesVerifierFactory.getVerifier(
       useValidator["validatorID"][0],
-      "BusinessLogicCartrade"
     );
     logger.debug("getVerifierEthereum");
 

--- a/examples/discounted-cartrade/CarsManagement.ts
+++ b/examples/discounted-cartrade/CarsManagement.ts
@@ -6,8 +6,11 @@
  */
 
 import { LPInfoHolder } from "@hyperledger/cactus-cmd-socket-server";
-import { Verifier } from "@hyperledger/cactus-cmd-socket-server";
 import { ConfigUtil } from "@hyperledger/cactus-cmd-socket-server";
+import {
+  VerifierFactory,
+  VerifierFactoryConfig,
+} from "@hyperledger/cactus-verifier-client";
 
 const config: any = ConfigUtil.getConfig();
 import { getLogger } from "log4js";
@@ -17,28 +20,26 @@ logger.level = config.logLevel;
 
 export class CarsManagement {
   private connectInfo: LPInfoHolder = null; // connection information
-  private verifierFabric: Verifier = null;
+  private readonly verifierFactory: VerifierFactory;
 
   constructor() {
     this.connectInfo = new LPInfoHolder();
+    this.verifierFactory = new VerifierFactory(
+      this.connectInfo.ledgerPluginInfo as VerifierFactoryConfig,
+      config.logLevel,
+    );
   }
 
   queryCar(carID: string): Promise<any> {
     return new Promise((resolve, reject) => {
-      if (this.verifierFabric === null) {
-        logger.debug("create verifierFabric");
-        const ledgerPluginInfo: string =
-          this.connectInfo.getLegerPluginInfo("r9IS4dDf");
-        this.verifierFabric = new Verifier(ledgerPluginInfo);
-      }
-
       const contract = { channelName: "mychannel", contractName: "basic" };
       const method = { type: "evaluateTransaction", command: "ReadAsset" };
       const args = { args: [carID] };
       // const method = "default";
       // const args = {"method": {type: "evaluateTransaction", command: "queryCar"},"args": {"args": [carID]}};
 
-      this.verifierFabric
+      this.verifierFactory
+        .getVerifier("r9IS4dDf")
         .sendSyncRequest(contract, method, args)
         .then((result) => {
           resolve(result);
@@ -52,20 +53,14 @@ export class CarsManagement {
 
   queryAllCars(): Promise<any> {
     return new Promise((resolve, reject) => {
-      if (this.verifierFabric === null) {
-        logger.debug("create verifierFabric");
-        const ledgerPluginInfo: string =
-          this.connectInfo.getLegerPluginInfo("r9IS4dDf");
-        this.verifierFabric = new Verifier(ledgerPluginInfo);
-      }
-
       const contract = { channelName: "mychannel", contractName: "basic" };
       const method = { type: "evaluateTransaction", command: "GetAllAssets" };
       const args = { args: [] };
       // const method = "default";
       // const args = {"method": {type: "evaluateTransaction", command: "queryAllCars"}, "args": {"args": []}};
 
-      this.verifierFabric
+      this.verifierFactory
+        .getVerifier("r9IS4dDf")
         .sendSyncRequest(contract, method, args)
         .then((result) => {
           resolve(result);

--- a/examples/discounted-cartrade/Dockerfile
+++ b/examples/discounted-cartrade/Dockerfile
@@ -1,5 +1,7 @@
 FROM cactus-cmd-socketio-server:latest
 
+ARG NPM_PKG_VERSION=latest
+
 ENV CARTRADE_HOME=/root/cactus
 
 WORKDIR ${CARTRADE_HOME}
@@ -15,8 +17,9 @@ RUN apt-get update \
 # Note - indy_sdk:latest  must be ABI compatible with this image OS
 COPY --from=indy-sdk-cli:latest /usr/lib/libindy.so /usr/lib/
 
-COPY ./dist/yarn.lock ./package.json ./
-RUN yarn add "${CACTUS_CMD_SOCKETIO_PATH}" --production --ignore-engines --non-interactive --cache-folder ./.yarnCache && \
+COPY ./package.json ./dist/yarn.lock ./dist/fabric-connector.crt ./dist/ethereum-connector.crt ./dist/indy-connector.crt ./
+RUN yarn add "${CACTUS_CMD_SOCKETIO_PATH}" "@hyperledger/cactus-verifier-client@${NPM_PKG_VERSION}" \
+        --production --ignore-engines --non-interactive --cache-folder ./.yarnCache && \
     rm -rf ./.yarnCache
 
 COPY ./dist ./dist/

--- a/examples/discounted-cartrade/TransactionFabric.ts
+++ b/examples/discounted-cartrade/TransactionFabric.ts
@@ -15,7 +15,8 @@
  * In this case, it is used only when transferring assets.
  */
 
-import { Verifier, ConfigUtil } from "@hyperledger/cactus-cmd-socket-server";
+import { ConfigUtil } from "@hyperledger/cactus-cmd-socket-server";
+import { Verifier } from "@hyperledger/cactus-verifier-client";
 
 const fs = require("fs");
 const path = require("path");
@@ -29,10 +30,10 @@ const moduleName = "TransactionFabric";
 const logger = getLogger(`${moduleName}`);
 logger.level = config.logLevel;
 
-export function makeSignedProposal(
+export function makeSignedProposal<T>(
   ccFncName: string,
   ccArgs: string[],
-  verifierFabric: Verifier,
+  verifierFabric: Verifier<T>,
 ): Promise<{ data: {}; txId: string }> {
   // exports.Invoke = async function(reqBody, isWait){
   // let eventhubs = []; // For the time being, give up the eventhub connection of multiple peers.

--- a/examples/discounted-cartrade/config/validator-registry-config.yaml
+++ b/examples/discounted-cartrade/config/validator-registry-config.yaml
@@ -1,9 +1,15 @@
 ledgerPluginInfo:
   -
     validatorID: 84jUisrs
-    validatorType: socketio
+    validatorType: legacy-socketio
     validatorURL: https://ethereum-validator:5050
-    validatorKeyPath: /etc/cactus/connector-go-ethereum-socketio/CA/connector.crt
+    validatorKeyPath: /root/cactus/ethereum-connector.crt
+    maxCounterRequestID: 100
+    syncFunctionTimeoutMillisecond: 5000
+    socketOptions:
+      rejectUnauthorized: false
+      reconnection: false
+      timeout: 20000
     ledgerInfo:
       ledgerAbstract: Go-Ethereum Ledger
     apiInfo:
@@ -34,9 +40,15 @@ ledgerPluginInfo:
 
   -
     validatorID: r9IS4dDf
-    validatorType: socketio
+    validatorType: legacy-socketio
     validatorURL: https://fabric-socketio-validator:5040
-    validatorKeyPath: /etc/cactus/connector-fabric-socketio/CA/connector.crt
+    validatorKeyPath: /root/cactus/fabric-connector.crt
+    maxCounterRequestID: 100
+    syncFunctionTimeoutMillisecond: 5000
+    socketOptions:
+      rejectUnauthorized: false
+      reconnection: false
+      timeout: 20000
     ledgerInfo:
        ledgerAbstract: Fabric Ledger
     apiInfo:
@@ -61,9 +73,15 @@ ledgerPluginInfo:
 
   -
     validatorID: 3PfTJw8g
-    validatorType: socketio
+    validatorType: legacy-socketio
     validatorURL: http://indy-validator-nginx:10080
-    validatorKeyPath: /etc/cactus/validator_socketio_indy/CA/connector.crt
+    validatorKeyPath: /root/cactus/indy-connector.crt
+    maxCounterRequestID: 100
+    syncFunctionTimeoutMillisecond: 5000
+    socketOptions:
+      rejectUnauthorized: false
+      reconnection: false
+      timeout: 20000
     ledgerInfo:
       ledgerAbstract: "Indy Ledger"
     apiInfo: []

--- a/examples/discounted-cartrade/package.json
+++ b/examples/discounted-cartrade/package.json
@@ -6,8 +6,13 @@
     "build": "npm run build-ts && npm run prepare-docker-build",
     "build-ts": "tsc -p ./tsconfig.json",
     "tslint": "tslint -c tslint.json -p tsconfig.json './*.ts'",
-    "prepare-docker-build": "cp -f ../../yarn.lock ./dist/",
-    "build_pip_indy_package": "cd ../../packages-python/cactus_validator_socketio_indy && python3 setup.py bdist_wheel"
+    "build_pip_indy_package": "cd ../../packages-python/cactus_validator_socketio_indy && python3 setup.py bdist_wheel",
+    "prepare-docker-build": "npm run copy-yarn-lock && npm run copy-validator-keys",
+    "copy-yarn-lock": "cp -f ../../yarn.lock ./dist/",
+    "copy-validator-keys": "npm run copy-fabric-key && npm run copy-ethereum-key && npm run copy-indy-key",
+    "copy-fabric-key": "cp -fr ../../packages/cactus-plugin-ledger-connector-fabric-socketio/sample-config/CA/connector.crt ./dist/fabric-connector.crt",
+    "copy-ethereum-key": "cp -fr ../../packages/cactus-plugin-ledger-connector-go-ethereum-socketio/sample-config/CA/connector.crt ./dist/ethereum-connector.crt",
+    "copy-indy-key": "cp -fr ../../packages-python/cactus_validator_socketio_indy/sample-CA/connector.crt ./dist/indy-connector.crt"
   },
   "dependencies": {
     "axios": "0.24.0",

--- a/examples/discounted-cartrade/tsconfig.json
+++ b/examples/discounted-cartrade/tsconfig.json
@@ -81,5 +81,8 @@
     {
       "path": "../../packages/cactus-cmd-socketio-server/tsconfig.json"
     },
+    {
+      "path": "../../packages/cactus-verifier-client/tsconfig.json"
+    }
   ]
 }


### PR DESCRIPTION
Sample app discounted-cartrade is currently using Verifier interface from cactus-cmd-socket-server.
Replace it with VerifierFactory from cactus-verifier-client package that
can work with all cactus connectors.

Related: #1982
Signed-off-by: Michal Bajer <michal.bajer@fujitsu.com>
