### PR TITLE
docs(readme): replaced rocketchat link with discord link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Can be found here: [ROADMAP.md](./ROADMAP.md)
 
 ## Contact
 * mailing list: [cactus@lists.hyperledger.org](mailto:cactus@lists.hyperledger.org)
-* rocketchat channel: [https://chat.hyperledger.org/channel/cactus](https://chat.hyperledger.org/channel/cactus).
+* discord channel: [https://discord.com/invite/hyperledger](https://discord.com/invite/hyperledger)
 
 ## Build/Development Flow
 


### PR DESCRIPTION
Since the migration from RocketChat to Discord we had our chat platform
link in the readme outdated and basically dead. This change remedies that.

Fixes: #1937

Signed-off-by: Emerson Shoichet-Bartus <emersonfieldstone@gmail.com>
Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>