### PR TITLE
docs(maintainers): add Rama and Sandeep

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,14 +6,17 @@ Maintainers
 | Name | GitHub | Chat |
 |------|--------|------|
 | Jonathan Hamilton | [jonathan-m-hamilton][jonathan-m-hamilton] | JHamilton |
-| Izuru Sato | [izuru0][izuru0] | izuru |
-| Peter Somogyvari | [petermetz][petermetz] | peter_somogyvari |
-| Takuma TAKEUCHI | [takeutak][takeutak] | takeutak |
+| Izuru Sato | [izuru0][izuru0] | Izuru Sato#6434 |
+| Peter Somogyvari | [petermetz][petermetz] | peter_somogyvari#3365 |
+| Takuma TAKEUCHI | [takeutak][takeutak] | takeutak#7220 |
 | Jagpreet Singh Sasan | [jagpreetsinghsasan][jagpreetsinghsasan] | jagpreetsinghsasan |
-
+| Venkatraman Ramakrishna | [VRamakrishna][VRamakrishna] | Ramakrishna#6645 |
+| Sandeep Nishad | [sanvenDev][sanvenDev] | sanven#1092 |
 
 [jonathan-m-hamilton]: https://github.com/jonathan-m-hamilton
 [izuru0]: https://github.com/izuru0
 [petermetz]: https://github.com/petermetz
 [takeutak]: https://github.com/takeutak
 [jagpreetsinghsasan]: https://github.com/jagpreetsinghsasan
+[VRamakrishna]: https://github.com/VRamakrishna/
+[sanvenDev]: https://github.com/sanvenDev


### PR DESCRIPTION
Adding Rama and Sandeep as maintainers.

Also updated the chat column for Takuma, Izuru, Jagpreet and Peter
so that their Discord IDs are visible there instead of the former
RocketChat user handles which are no longer in existence anyway since
the Hyperledger RocketChat got shut down in early 2022.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>