### PR TITLE
test: fix jest out of memory errors on Node v16.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "webpack": "lerna run webpack:dev",
     "webpack:dev:web": "lerna run webpack:dev:web",
     "webpack:dev:node": "lerna run webpack:dev:node",
-    "test:jest:all": "jest",
+    "test:jest:all": "NODE_OPTIONS=--max_old_space_size=3072 jest",
     "test:tap:all": "tap",
     "test:all": "yarn test:jest:all && yarn test:tap:all",
     "posttest:all": "tap --no-check-coverage --coverage-report=lcov && codecov",


### PR DESCRIPTION
[test: fix jest out of memory errors on Node v16.14.2](https://github.com/hyperledger/cactus/pull/2009/commits/756d80f7a5249cda681e40dce407b19fb681d172)

Explicitly specify the heap size (RAM) for the Jest process
that executes the tests to be 3 GB instead of the default
2 GB that NodeJS allocates by default.

This is not a good solution, but a workaround instead.

The test runner itself using this much RAM is the acutal
problem that we need to fix longer term and I'll be opening
a follow-up task specifically to address that and once that
has been fixed we can lower back the test runner's
heap size to the default 2 GB (which is still a lot BTW)

Not sure why the out of memory errors starting occuring only
on NodeJS 16.14.2, probably something made it use
slightly more memory and it finally spilled over.
My assumption is that the memory usage of the test runner
was bad already regardless.

Fixes https://github.com/hyperledger/cactus/issues/2008

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>