### PR TITLE
docs(examples): explain supply chain live development

### DIFF
--- a/examples/cactus-example-supply-chain-backend/package.json
+++ b/examples/cactus-example-supply-chain-backend/package.json
@@ -65,6 +65,7 @@
     "@hyperledger/cactus-test-tooling": "1.0.0",
     "async-exit-hook": "2.0.1",
     "axios": "0.21.4",
+    "dotenv": "16.0.0",
     "express": "4.17.1",
     "fabric-network": "2.2.10",
     "jose": "4.1.0",

--- a/examples/cactus-example-supply-chain-frontend/package.json
+++ b/examples/cactus-example-supply-chain-frontend/package.json
@@ -44,7 +44,7 @@
     "ng": "ng",
     "prepublishOnly": "ng build",
     "serve": "ng serve",
-    "serve:proxy": "ng serve -- --proxy-config proxy.conf.json",
+    "serve:proxy": "ng serve -- --port 8000 --proxy-config proxy.conf.json",
     "start": "ng serve"
   },
   "dependencies": {

--- a/examples/cactus-example-supply-chain-frontend/proxy.conf.json
+++ b/examples/cactus-example-supply-chain-frontend/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:5100",
+    "target": "http://localhost:4200",
     "secure": false,
     "logLevel": "debug"
   }

--- a/examples/supply-chain-app/README.md
+++ b/examples/supply-chain-app/README.md
@@ -72,5 +72,20 @@ On the terminal, issue the following commands (steps 1 to 6) and then perform th
 8. Within that file locate the entry named `"Example: Supply Chain App"`
 9. Copy the VSCode debug definition object from 2) to your `.vscode/launch.json` file
 10. At this point the VSCode `Run and Debug` panel on the left should have an option also titled `"Example: Supply Chain App"` which starts the application
-11. When the application finishes loading, token generated is displayed on the terminal
+11. When the application finishes loading, the JWT token generated is displayed on the terminal
 12. Visit http://localhost:3200 in a web browser with Javascript enabled and insert the token when prompted
+
+## Live Reloading the GUI Application
+
+1. `npm run install-yarn`
+2. `yarn configure`
+3. `yarn build:dev`
+4. Locate the `.vscode/template.launch.json` file
+5. Within that file locate the entry named `"Example: Supply Chain App"`
+6. Copy the VSCode debug definition object from 2) to your `.vscode/launch.json` file
+7. At this point the VSCode `Run and Debug` panel on the left should have an option also titled `"Example: Supply Chain App"` which starts the application
+8. `cd ./examples/cactus-example-supply-chain-frontend/`
+9. `yarn serve:proxy`
+10. When the application finishes loading, the JWT token generated is displayed on the terminal
+11. Visit http://localhost:8000 in a web browser with Javascript enabled and insert the token when prompted
+12. At this point if you modify the source code of the GUI application under the `./examples/cactus-example-supply-chain-frontend/` path it will automatically reload the browser window (you will need to paste in the JWT again when this happens)

--- a/yarn.lock
+++ b/yarn.lock
@@ -9339,6 +9339,11 @@ dot-prop@^6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.0.tgz#c619001253be89ebb638d027b609c75c26e47411"
+  integrity sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==
+
 dotignore@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/dotignore/-/dotignore-0.1.2.tgz#f942f2200d28c3a76fbdd6f0ee9f3257c8a2e905"


### PR DESCRIPTION
We should have documentation for how to develop the
supply chain app front-end with live-reloading enabled.
The ionic serve command has a built-in reverse-proxy
feature that makes this possible quite easily with
the right configuration in place.

How to achieve this is explained in the README.md
file of the supply chain app and the necessary updates
were made so that it actually works.

Fixes #2010

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>