### PR TITLE
test: jestify jwt endpoint authz scope enforcement

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -118,7 +118,6 @@ files:
   - ./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/openapi/openapi-validation.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/benchmark/artillery-api-benchmark.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-socketio-endpoint-authorization.test.ts
-  - ./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-endpoint-authz-scope-enforcement.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-from-github.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-without-install.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -124,7 +124,6 @@ module.exports = {
     `./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/openapi/openapi-validation.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/benchmark/artillery-api-benchmark.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-socketio-endpoint-authorization.test.ts`,
-    `./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-endpoint-authz-scope-enforcement.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-from-github.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-without-install.test.ts`,

--- a/packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-endpoint-authz-scope-enforcement.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-endpoint-authz-scope-enforcement.test.ts
@@ -1,11 +1,10 @@
-import test, { Test } from "tape-promise/tape";
+import "jest-extended";
 import { v4 as uuidv4 } from "uuid";
 import { generateKeyPair, exportSPKI, SignJWT } from "jose";
 import expressJwt from "express-jwt";
 import axios, { Method } from "axios";
-import { StatusCodes } from "http-status-codes";
 
-import { LoggerProvider, LogLevelDesc } from "@hyperledger/cactus-common";
+import { LogLevelDesc } from "@hyperledger/cactus-common";
 import { PluginRegistry } from "@hyperledger/cactus-core";
 
 import {
@@ -23,14 +22,18 @@ import { UnprotectedActionEndpoint } from "../fixtures/plugin-ledger-connector-s
 const testCase =
   "API server enforces scope requirements on top of generic authz";
 const logLevel: LogLevelDesc = "TRACE";
-const log = LoggerProvider.getOrCreate({
-  level: logLevel,
-  label: __filename,
-});
 
-test(testCase, async (t: Test) => {
-  try {
-    const jwtKeyPair = await generateKeyPair("RS256", { modulusLength: 4096 });
+describe(testCase, () => {
+  let apiServer: ApiServer;
+
+  afterAll(async () => {
+    await apiServer.shutdown();
+  });
+
+  test(testCase, async () => {
+    const jwtKeyPair = await generateKeyPair("RS256", {
+      modulusLength: 4096,
+    });
     const jwtPublicKey = await exportSPKI(jwtKeyPair.publicKey);
     const expressJwtOptions: expressJwt.Options = {
       algorithms: ["RS256"],
@@ -38,7 +41,7 @@ test(testCase, async (t: Test) => {
       audience: uuidv4(),
       issuer: uuidv4(),
     };
-    t.ok(expressJwtOptions, "Express JWT config truthy OK");
+    expect(expressJwtOptions).toBeTruthy();
 
     const unprotectedActionEp = new UnprotectedActionEndpoint({
       connector: {} as PluginLedgerConnectorStub,
@@ -72,18 +75,14 @@ test(testCase, async (t: Test) => {
     apiSrvOpts.plugins = [];
     const config = await configService.newExampleConfigConvict(apiSrvOpts);
 
-    const apiServer = new ApiServer({
+    apiServer = new ApiServer({
       config: config.getProperties(),
       pluginRegistry,
     });
-    test.onFinish(async () => await apiServer.shutdown());
-
     const startResponse = apiServer.start();
-    await t.doesNotReject(
-      startResponse,
-      "failed to start API server with dynamic plugin imports configured for it...",
-    );
-    t.ok(startResponse, "startResponse truthy OK");
+
+    await expect(startResponse).not.toReject();
+    expect(startResponse).toBeTruthy();
 
     const addressInfoApi = (await startResponse).addressInfoApi;
     const protocol = apiSrvOpts.apiTlsEnabled ? "https" : "http";
@@ -119,16 +118,13 @@ test(testCase, async (t: Test) => {
         Authorization: `Bearer ${token}`,
       },
     });
-    t.ok(res1, "stub run tx response truthy OK");
-    t.equal(res1.status, 200, "stub run tx response status === 200 OK");
-    t.equal(typeof res1.data, "object", "typeof res1.data is 'object' OK");
-    t.ok(typeof res1.data.data, "res1.data.data truthy OK");
-    t.ok(typeof res1.data.data.requestId, "res1.data.data.requestId truthy OK");
-    t.equal(
-      res1.data.data.requestId,
-      req1.requestId,
-      "res1.data.requestId === req1.requestId OK",
-    );
+
+    expect(res1).toBeTruthy();
+    expect(res1.status).toEqual(200);
+    expect(typeof res1.data).toBe("object");
+    expect(typeof res1.data.data).toBeTruthy();
+    expect(typeof res1.data.data.requestId).toBeTruthy();
+    expect(res1.data.data.requestId).toBe(req1.requestId);
 
     try {
       const deployContractEp = new DeployContractEndpoint({
@@ -142,22 +138,16 @@ test(testCase, async (t: Test) => {
           Authorization: `Bearer ${token}`,
         },
       });
-      t.fail("deploy contract response status === 403 FAIL");
-    } catch (out) {
-      t.ok(out, "error thrown for forbidden endpoint truthy OK");
-      t.ok(out.response, "deploy contract response truthy OK");
-      t.equal(
-        out.response.status,
-        StatusCodes.FORBIDDEN,
-        "deploy contract response status === 403 OK",
-      );
-      t.notok(out.response.data.data, "out.response.data.data falsy OK");
-      t.notok(out.response.data.success, "out.response.data.success falsy OK");
+    } catch (out: unknown) {
+      if (axios.isAxiosError(out)) {
+        expect(out).toBeTruthy();
+        expect(out.response).toBeTruthy();
+        expect(out).toHaveProperty(["response", "status"], 403);
+        expect(out.response?.data.data).toBeFalsy();
+        expect(out.response?.data.success).toBeFalsy();
+      } else {
+        fail("expected an axios error, got something else");
+      }
     }
-    t.end();
-  } catch (ex) {
-    log.error(ex);
-    t.fail("Exception thrown during test execution, see above for details!");
-    throw ex;
-  }
+  });
 });


### PR DESCRIPTION
File Path:
packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-endpoint-authz-scope-enforcement.test.ts

This is a PARTIAL resolution to issue #238

