### PR TITLE
test: jestify jwt-unprotected-endpoint-authz

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -121,7 +121,6 @@ files:
   - ./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-socketio-endpoint-authorization.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-endpoint-authz-scope-enforcement.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
-  - ./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-unprotected-endpoint-authz.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-from-github.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-without-install.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-keychain-memory.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -127,7 +127,6 @@ module.exports = {
     `./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-socketio-endpoint-authorization.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-endpoint-authz-scope-enforcement.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts`,
-    `./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-unprotected-endpoint-authz.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-from-github.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-without-install.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-keychain-memory.test.ts`,

--- a/packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-unprotected-endpoint-authz.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-unprotected-endpoint-authz.test.ts
@@ -1,4 +1,4 @@
-import test, { Test } from "tape-promise/tape";
+import "jest-extended";
 import { v4 as uuidv4 } from "uuid";
 import { generateKeyPair, exportSPKI } from "jose";
 import expressJwt from "express-jwt";
@@ -26,102 +26,94 @@ const log = LoggerProvider.getOrCreate({
   label: __filename,
 });
 
-test(testCase, async (t: Test) => {
-  try {
-    const jwtKeyPair = await generateKeyPair("RS256", { modulusLength: 4096 });
-    const jwtPublicKey = await exportSPKI(jwtKeyPair.publicKey);
-    const expressJwtOptions: expressJwt.Options = {
-      algorithms: ["RS256"],
-      secret: jwtPublicKey,
-      audience: uuidv4(),
-      issuer: uuidv4(),
-    };
-    t.ok(expressJwtOptions, "Express JWT config truthy OK");
+describe(testCase, () => {
+  let apiServer: ApiServer;
 
-    const ep = new UnprotectedActionEndpoint({
-      connector: {} as PluginLedgerConnectorStub,
-      logLevel,
-    });
+  afterAll(async () => {
+    await apiServer.shutdown();
+  });
 
-    const authorizationConfig: IAuthorizationConfig = {
-      unprotectedEndpointExemptions: [ep.getPath()],
-      expressJwtOptions,
-      socketIoJwtOptions: { secret: jwtPublicKey },
-    };
+  test(testCase, async () => {
+    try {
+      const jwtKeyPair = await generateKeyPair("RS256", {
+        modulusLength: 4096,
+      });
+      const jwtPublicKey = await exportSPKI(jwtKeyPair.publicKey);
+      const expressJwtOptions: expressJwt.Options = {
+        algorithms: ["RS256"],
+        secret: jwtPublicKey,
+        audience: uuidv4(),
+        issuer: uuidv4(),
+      };
+      expect(expressJwtOptions).toBeTruthy();
 
-    const pluginRegistry = new PluginRegistry();
-    const plugin = new PluginLedgerConnectorStub({
-      logLevel,
-      pluginRegistry,
-      instanceId: uuidv4(),
-    });
-    pluginRegistry.add(plugin);
+      const ep = new UnprotectedActionEndpoint({
+        connector: {} as PluginLedgerConnectorStub,
+        logLevel,
+      });
 
-    const configService = new ConfigService();
-    const apiSrvOpts = await configService.newExampleConfig();
-    apiSrvOpts.authorizationProtocol = AuthorizationProtocol.JSON_WEB_TOKEN;
-    apiSrvOpts.authorizationConfigJson = authorizationConfig;
-    apiSrvOpts.configFile = "";
-    apiSrvOpts.apiCorsDomainCsv = "*";
-    apiSrvOpts.apiPort = 0;
-    apiSrvOpts.cockpitPort = 0;
-    apiSrvOpts.grpcPort = 0;
-    apiSrvOpts.apiTlsEnabled = false;
-    apiSrvOpts.plugins = [];
-    const config = await configService.newExampleConfigConvict(apiSrvOpts);
+      const authorizationConfig: IAuthorizationConfig = {
+        unprotectedEndpointExemptions: [ep.getPath()],
+        expressJwtOptions,
+        socketIoJwtOptions: { secret: jwtPublicKey },
+      };
 
-    const apiServer = new ApiServer({
-      config: config.getProperties(),
-      pluginRegistry,
-    });
-    test.onFinish(async () => await apiServer.shutdown());
+      const pluginRegistry = new PluginRegistry();
+      const plugin = new PluginLedgerConnectorStub({
+        logLevel,
+        pluginRegistry,
+        instanceId: uuidv4(),
+      });
+      pluginRegistry.add(plugin);
 
-    const startResponse = apiServer.start();
-    await t.doesNotReject(
-      startResponse,
-      "failed to start API server with dynamic plugin imports configured for it...",
-    );
-    t.ok(startResponse, "startResponse truthy OK");
+      const configService = new ConfigService();
+      const apiSrvOpts = await configService.newExampleConfig();
+      apiSrvOpts.authorizationProtocol = AuthorizationProtocol.JSON_WEB_TOKEN;
+      apiSrvOpts.authorizationConfigJson = authorizationConfig;
+      apiSrvOpts.configFile = "";
+      apiSrvOpts.apiCorsDomainCsv = "*";
+      apiSrvOpts.apiPort = 0;
+      apiSrvOpts.cockpitPort = 0;
+      apiSrvOpts.grpcPort = 0;
+      apiSrvOpts.apiTlsEnabled = false;
+      apiSrvOpts.plugins = [];
+      const config = await configService.newExampleConfigConvict(apiSrvOpts);
 
-    const addressInfoApi = (await startResponse).addressInfoApi;
-    const protocol = apiSrvOpts.apiTlsEnabled ? "https" : "http";
-    const { address, port } = addressInfoApi;
-    const apiHost = `${protocol}://${address}:${port}`;
+      apiServer = new ApiServer({
+        config: config.getProperties(),
+        pluginRegistry,
+      });
 
-    const req1 = {
-      requestId: uuidv4(),
-    };
+      const startResponse = apiServer.start();
+      await expect(startResponse).not.toReject();
+      expect(startResponse).toBeTruthy();
 
-    // look Ma, no access token
-    const res1 = await axios.request({
-      data: req1,
-      url: `${apiHost}${ep.getPath()}`,
-      method: ep.getVerbLowerCase() as Method,
-    });
-    t.ok(res1, "stub unprotected action response truthy OK");
-    t.equal(
-      res1.status,
-      StatusCodes.OK,
-      "stub unprotected action response status === 200 OK",
-    );
-    t.equal(typeof res1.data, "object", "typeof res1.data is 'object' OK");
-    t.ok(typeof res1.data.data, "res1.data.data truthy OK");
-    t.ok(
-      typeof res1.data.data.reqBodyrequestId,
-      "res1.data.data.reqBody truthy OK",
-    );
-    t.ok(
-      typeof res1.data.data.reqBody.requestId,
-      "res1.data.data.reqBody.requestId truthy OK",
-    );
-    t.equal(
-      res1.data.data.reqBody.requestId,
-      req1.requestId,
-      "res1.data.requestId === req1.requestId OK",
-    );
-  } catch (ex) {
-    log.error(ex);
-    t.fail("Exception thrown during test execution, see above for details!");
-    throw ex;
-  }
+      const addressInfoApi = (await startResponse).addressInfoApi;
+      const protocol = apiSrvOpts.apiTlsEnabled ? "https" : "http";
+      const { address, port } = addressInfoApi;
+      const apiHost = `${protocol}://${address}:${port}`;
+
+      const req1 = {
+        requestId: uuidv4(),
+      };
+
+      // look Ma, no access token
+      const res1 = await axios.request({
+        data: req1,
+        url: `${apiHost}${ep.getPath()}`,
+        method: ep.getVerbLowerCase() as Method,
+      });
+      expect(res1).toBeTruthy();
+      expect(res1.status).toBe(StatusCodes.OK);
+      expect(typeof res1.data).toBe("object");
+      expect(typeof res1.data.data).toBeTruthy();
+      expect(typeof res1.data.data.reqBodyrequestId).toBeTruthy();
+      expect(typeof res1.data.data.reqBody.requestId).toBeTruthy();
+      expect(res1.data.data.reqBody.requestId).toBe(req1.requestId);
+    } catch (ex) {
+      log.error(ex);
+      fail("Exception thrown during test execution, see above for details!");
+      throw ex;
+    }
+  });
 });


### PR DESCRIPTION
Migrated test from Tap to Jest

File Path:
packages/cactus-cmd-api-server/src/test/
typescript/integration/
jwt-unprotected-endpoint-authz.test.ts

This is a PARTIAL resolution to issue #238