### PR TITLE
fix(cactus-verifier-client): update supported ledgers in readme

### DIFF
--- a/packages/cactus-verifier-client/README.md
+++ b/packages/cactus-verifier-client/README.md
@@ -5,9 +5,11 @@
 This package provides `Verifier` and `VerifierFactory` components that can be used to communicate with compatible Cactus ledger connectors (validators) through single, unified interface.
 
 ### Supported ledger connectors
-| validatorType          | cactus ledger connector plugin |
-| ---------------------- | ------------------------------ |
-| BESU_1X<br />BESU_2X   | cactus-plugin-ledger-connector-besu |
+| validatorType          | cactus ledger connector plugin                  |
+| ---------------------- | ----------------------------------------------- |
+| BESU_1X<br />BESU_2X   | cactus-plugin-ledger-connector-besu             |
+| QUORUM_2X              | cactus-test-plugin-ledger-connector-quorum      |
+| CORDA_4X               | cactus-plugin-ledger-connector-corda            |
 | legacy-socketio        | cactus-plugin-ledger-connector-fabric-socketio<br />cactus-plugin-ledger-connector-go-ethereum-socketio<br />cactus-plugin-ledger-connector-sawtooth-socketio |
 
 ## VerifierFactory


### PR DESCRIPTION
Update Supported ledger connectors table in `cactus-verifier-client` README file.
Add missing QUORUM_2X and CORDA_4X ledgers which are also supported.

Signed-off-by: Michal Bajer <michal.bajer@fujitsu.com>