### PR TITLE
test(connector-corda): fix flaky monitor transactions v4.8

### DIFF
--- a/packages/cactus-plugin-ledger-connector-corda/README.md
+++ b/packages/cactus-plugin-ledger-connector-corda/README.md
@@ -329,6 +329,8 @@ const res = await apiClient.invokeContractV1({
 ```json
 {
   "cactus": {
+    "threadCount": 3,
+    "sessionExpireMinutes": 10,
     "corda": {
       "node": {
         "host": "localhost"

--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/Application.kt
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/Application.kt
@@ -5,18 +5,23 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import net.corda.client.jackson.JacksonSupport
 import org.hyperledger.cactus.plugin.ledger.connector.corda.server.impl.NodeRPCConnection
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.runApplication
-import org.springframework.context.annotation.ComponentScan
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.scheduling.TaskScheduler
 import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
 
+private const val ThreadPoolCount = "cactus.threadCount"
+private const val ThreadPoolCountDefault = "3"
 
 @SpringBootApplication
 @ComponentScan(basePackages = ["org.hyperledger.cactus.plugin.ledger.connector.corda.server", "org.hyperledger.cactus.plugin.ledger.connector.corda.server.api", "org.hyperledger.cactus.plugin.ledger.connector.corda.server.model"])
 @EnableScheduling
-class Application {
+class Application(@Value("\${$ThreadPoolCount:$ThreadPoolCountDefault}") val threadCount: Int) {
     /**
      * Spring Bean that binds a Corda Jackson object-mapper to HTTP message types used in Spring.
      */
@@ -28,6 +33,13 @@ class Application {
         val converter = MappingJackson2HttpMessageConverter()
         converter.objectMapper = mapper
         return converter
+    }
+
+    @Bean
+    fun taskScheduler(): TaskScheduler? {
+        val taskScheduler = ThreadPoolTaskScheduler()
+        taskScheduler.poolSize = this.threadCount
+        return taskScheduler
     }
 }
 

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/monitor-transactions-v4.8.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/monitor-transactions-v4.8.test.ts
@@ -21,7 +21,7 @@ const testAppId = "monitor-transactions-test-app";
 // Contants: Kotlin connector server
 const kotlinServerImageName =
   "ghcr.io/hyperledger/cactus-connector-corda-server";
-const kotlinServerImageVersion = "2022-04-18-a8a7ed1--1956";
+const kotlinServerImageVersion = "2022-05-26-0ff7407--pr-2021";
 
 import "jest-extended";
 import { v4 as internalIpV4 } from "internal-ip";
@@ -263,6 +263,7 @@ describe("Monitor Tests", () => {
         },
       },
       cactus: {
+        threadCount: 2,
         sessionExpireMinutes: 10,
         corda: {
           node: { host: internalIp },


### PR DESCRIPTION
Fix race condition that caused user session removal during request processing,
that caused test to fail occasionaly.

Correlated fixes / improvements:
- Use paging when watching for vault changes.
This was necessary to perform long-running runs of a failing test.
  Without it, start monitor of a state with 200+ changes was failing instantly.
  I thought that paging was needed when there are 200+ changes in single observer push,
  but it seems that it breaks when total number of changes are that large,
  which makes it more critical to fix.
- To prevent deadlock of cleanup thread I introduced thread pool to corda kotlin server.
  Number of threads is configurable in environment variable.
  Updated readme to show this option.

Closes: #1995

Signed-off-by: Michal Bajer <michal.bajer@fujitsu.com>