### PR TITLE
docs(codeowners): sync root codowners file to maintainers.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @jonathan-m-hamilton @petermetz 
-/packages/connection-chain/ @sfuji822 @takeutak
+* @petermetz @takeutak @izuru0 @jagpreetsinghsasan @VRamakrishna @sanvenDev
+


### PR DESCRIPTION
Took the active maintainers from MAINTAINERS.md and
loaded them onto the root CODEOWNERS.md file.

We can define the more granular ownership structure
later as things crystalize.

Fixes #2024

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>