### PR TITLE
test: jestify remote plugin imports 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -995,7 +995,7 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-test-cmd-api-server/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
-      TAPE_TEST_PATTERN: '--files={./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install-version-selection.test.ts,./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install.test.ts,./packages/cactus-test-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts}'
+      TAPE_TEST_PATTERN: '--files={./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install-version-selection.test.ts,./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install.test.ts}'
       TAPE_TEST_RUNNER_DISABLED: false
     needs: build-dev
     runs-on: ubuntu-20.04

--- a/.taprc
+++ b/.taprc
@@ -36,7 +36,6 @@ files:
   - ./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/get-single-status-endpoint-invalid.test.ts
   - ./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/openapi/openapi-validation.test.ts
   - ./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/refund-endpoint.test.ts
-  - ./packages/cactus-test-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
   - ./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install.test.ts
   - ./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install-version-selection.test.ts
   - ./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/openapi/openapi-validation.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,7 +41,6 @@ module.exports = {
     `./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/get-single-status-endpoint-invalid.test.ts`,
     `./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/openapi/openapi-validation.test.ts`,
     `./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/refund-endpoint.test.ts`,
-    `./packages/cactus-test-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts`,
     `./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install.test.ts`,
     `./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install-version-selection.test.ts`,
     `./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/openapi/openapi-validation.test.ts`,

--- a/packages/cactus-test-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
+++ b/packages/cactus-test-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
@@ -1,4 +1,4 @@
-import test, { Test } from "tape-promise/tape";
+import "jest-extended";
 import { v4 as uuidv4 } from "uuid";
 
 import {
@@ -27,86 +27,94 @@ import {
   PluginImportType,
 } from "@hyperledger/cactus-core-api";
 
-test("NodeJS API server + Rust plugin work together", async (t: Test) => {
-  const vaultTestContainer = new VaultTestServer({});
-  await vaultTestContainer.start();
+const testCase = "NodeJS API server + Rust plugin work together";
 
-  const ci = await Containers.getById(vaultTestContainer.containerId);
-  const vaultIpAddr = await Containers.getContainerInternalIp(ci);
-  t.comment(`Container VaultTestServer has IPv4: ${vaultIpAddr}`);
+describe(testCase, () => {
+  let vaultTestContainer: VaultTestServer;
+  let apiServer: ApiServer;
+  let pluginContainer: any;
 
-  test.onFinish(async () => {
+  afterAll(async () => {
     await vaultTestContainer.stop();
     await vaultTestContainer.destroy();
-  });
-
-  const hostPortVault = await vaultTestContainer.getHostPortHttp();
-  t.comment(`Container VaultTestServer (Port=${hostPortVault}) started OK`);
-  const vaultHost = `http://${vaultIpAddr}:${K_DEFAULT_VAULT_HTTP_PORT}`;
-
-  const pluginContainer = new CactusKeychainVaultServer({
-    envVars: [
-      `VAULT_HOST=${vaultHost}`,
-      `VAULT_TOKEN=${K_DEFAULT_VAULT_DEV_ROOT_TOKEN}`,
-      "HOST=0.0.0.0:8080",
-    ],
-  });
-  await pluginContainer.start();
-
-  test.onFinish(async () => {
+    await apiServer.shutdown();
     await pluginContainer.stop();
     await pluginContainer.destroy();
   });
 
-  const hostPort = await pluginContainer.getHostPortHttp();
-  t.comment(`CactusKeychainVaultServer (Port=${hostPort}) started OK`);
+  test(testCase, async () => {
+    vaultTestContainer = new VaultTestServer({});
+    await vaultTestContainer.start();
 
-  const configuration = new Configuration({
-    basePath: `http://localhost:${hostPort}`,
+    const ci = await Containers.getById(vaultTestContainer.containerId);
+    const vaultIpAddr = await Containers.getContainerInternalIp(ci);
+    console.log(`Container VaultTestServer has IPv4: ${vaultIpAddr}`);
+
+    const hostPortVault = await vaultTestContainer.getHostPortHttp();
+    console.log(`Container VaultTestServer (Port=${hostPortVault}) started OK`);
+
+    const vaultHost = `http://${vaultIpAddr}:${K_DEFAULT_VAULT_HTTP_PORT}`;
+
+    pluginContainer = new CactusKeychainVaultServer({
+      envVars: [
+        `VAULT_HOST=${vaultHost}`,
+        `VAULT_TOKEN=${K_DEFAULT_VAULT_DEV_ROOT_TOKEN}`,
+        "HOST=0.0.0.0:8080",
+      ],
+    });
+    await pluginContainer.start();
+
+    const hostPort = await pluginContainer.getHostPortHttp();
+    console.log(`CactusKeychainVaultServer (Port=${hostPort}) started OK`);
+
+    const configuration = new Configuration({
+      basePath: `http://localhost:${hostPort}`,
+    });
+    const apiClient = new DefaultApi(configuration);
+
+    const configService = new ConfigService();
+    const apiServerOptions = await configService.newExampleConfig();
+    apiServerOptions.authorizationProtocol = AuthorizationProtocol.NONE;
+    apiServerOptions.configFile = "";
+    apiServerOptions.apiCorsDomainCsv = "*";
+    apiServerOptions.apiPort = 0;
+    apiServerOptions.cockpitPort = 0;
+    apiServerOptions.grpcPort = 0;
+    apiServerOptions.apiTlsEnabled = false;
+    apiServerOptions.plugins = [];
+    const config = await configService.newExampleConfigConvict(
+      apiServerOptions,
+    );
+
+    const factory = new PluginFactoryKeychain({
+      pluginImportType: PluginImportType.Remote,
+    });
+
+    const plugin: IPluginKeychain = await factory.create({
+      keychainId: "_keychainId_",
+      instanceId: "_instanceId_",
+      remoteConfig: configuration,
+    });
+
+    const pluginRegistry = new PluginRegistry({ plugins: [plugin] });
+
+    apiServer = new ApiServer({
+      config: config.getProperties(),
+      pluginRegistry,
+    });
+
+    const startResponse = apiServer.start();
+    expect(startResponse).toBeTruthy();
+    await expect(startResponse).not.toReject();
+
+    const key = uuidv4();
+    const expected = uuidv4();
+
+    await apiClient.setKeychainEntryV1({ key, value: expected });
+    const {
+      data: { value: actual },
+    } = await apiClient.getKeychainEntryV1({ key });
+
+    expect(actual).toBe(expected);
   });
-  const apiClient = new DefaultApi(configuration);
-
-  const configService = new ConfigService();
-  const apiServerOptions = await configService.newExampleConfig();
-  apiServerOptions.authorizationProtocol = AuthorizationProtocol.NONE;
-  apiServerOptions.configFile = "";
-  apiServerOptions.apiCorsDomainCsv = "*";
-  apiServerOptions.apiPort = 0;
-  apiServerOptions.cockpitPort = 0;
-  apiServerOptions.grpcPort = 0;
-  apiServerOptions.apiTlsEnabled = false;
-  apiServerOptions.plugins = [];
-  const config = await configService.newExampleConfigConvict(apiServerOptions);
-
-  const factory = new PluginFactoryKeychain({
-    pluginImportType: PluginImportType.Remote,
-  });
-
-  const plugin: IPluginKeychain = await factory.create({
-    keychainId: "_keychainId_",
-    instanceId: "_instanceId_",
-    remoteConfig: configuration,
-  });
-
-  const pluginRegistry = new PluginRegistry({ plugins: [plugin] });
-
-  const apiServer = new ApiServer({
-    config: config.getProperties(),
-    pluginRegistry,
-  });
-
-  await t.doesNotReject(apiServer.start(), "Started API server OK");
-  test.onFinish(() => apiServer.shutdown());
-
-  const key = uuidv4();
-  const expected = uuidv4();
-
-  await apiClient.setKeychainEntryV1({ key, value: expected });
-  const {
-    data: { value: actual },
-  } = await apiClient.getKeychainEntryV1({ key });
-
-  t.equal(actual, expected, "Keychain stored value matches input OK");
-
-  t.end();
 });


### PR DESCRIPTION
Migrated test from Tap to Jest

File Path:
packages/cactus-test-cmd-api-server/
src/test/typescript/integration/
remote-plugin-imports.test.ts


This is a PARTIAL resolution to issue #238