### PR TITLE
test: jestify server test from cactus common

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -76,7 +76,6 @@ files:
   - ./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/invoke-contract-xdai-json-object.test.ts
   - ./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation.test.ts
   - ./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation-no-keychain.test.ts
-  - ./packages/cactus-common/src/test/typescript/unit/servers.test.ts
   - ./packages/cactus-common/src/test/typescript/unit/key-converter.test.ts
   - ./packages/cactus-common/src/test/typescript/unit/logging/logger.test.ts
   - ./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/plugin-keychain-aws-sm.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -81,7 +81,6 @@ module.exports = {
     `./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/invoke-contract-xdai-json-object.test.ts`,
     `./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation.test.ts`,
     `./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation-no-keychain.test.ts`,
-    `./packages/cactus-common/src/test/typescript/unit/servers.test.ts`,
     `./packages/cactus-common/src/test/typescript/unit/key-converter.test.ts`,
     `./packages/cactus-common/src/test/typescript/unit/logging/logger.test.ts`,
     `./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/plugin-keychain-aws-sm.test.ts`,

--- a/packages/cactus-common/src/test/typescript/unit/servers.test.ts
+++ b/packages/cactus-common/src/test/typescript/unit/servers.test.ts
@@ -1,56 +1,59 @@
 import { createServer } from "http";
 import { AddressInfo } from "net";
 
-import test, { Test } from "tape-promise/tape";
+// import test, { Test } from "tape-promise/tape";
+import "jest-extended";
 
 import { Servers } from "../../../main/typescript/index";
 
-test("Servers", async (tParent: Test) => {
-  test("Servers#listen()", async (t: Test) => {
+const testCase = "Servers";
+
+describe(testCase, () => {
+  // test("Servers", async (tParent: Test) => {
+  test("Servers#listen()", async () => {
     {
       const server = createServer();
-      await t.rejects(
+      await expect(
         Servers.listen({
           hostname: "x",
           port: ("" as unknown) as number,
           server,
         }),
-        /options\.port/,
-        "Rejects when port specified as empty string OK",
-      );
+      ).toReject();
     }
 
     {
       const server = createServer();
-      await t.rejects(
+      await expect(
         Servers.listen({
           hostname: "localhost",
           port: (false as unknown) as number,
           server,
         }),
-        /options\.port/,
-        "Rejects when port specified as literal false boolean OK",
-      );
-      // await Servers.shutdown(server);
+      ).toReject();
+      await Servers.shutdown(server);
     }
 
     {
       const server = createServer();
-      await t.doesNotReject(
+      await expect(
         Servers.listen({ hostname: "localhost", port: 0, server }),
-        "Does not rejects when port specified as zero OK",
-      );
+      ).toResolve();
+      // await t.doesNotReject(
+      //   Servers.listen({ hostname: "localhost", port: 0, server }),
+      //   "Does not rejects when port specified as zero OK",
+      // );
       await Servers.shutdown(server);
     }
 
-    t.end();
-  });
+    // t.end();
+    // });
 
-  test("Servers#startOnPreferredPort()", async (t: Test) => {
     const prefPort = 4123;
     const host = "localhost";
     const portBlocker = createServer();
-    test.onFinish(() => portBlocker.close());
+    // test.onFinish(() => portBlocker.close());
+
     const listenOptionsBlocker = {
       server: portBlocker,
       hostname: host,
@@ -58,22 +61,36 @@ test("Servers", async (tParent: Test) => {
     };
     await Servers.listen(listenOptionsBlocker);
 
-    await t.doesNotReject(async () => {
+    await expect(async () => {
       const server = await Servers.startOnPreferredPort(prefPort, host);
-      test.onFinish(() => server.close());
-      t.ok(server, "Server returned truthy OK");
+      // test.onFinish(() => server.close());
+      // t.ok(server, "Server returned truthy OK");
+      expect(server).toBeTruthy();
       const addressInfo = server.address() as AddressInfo;
-      t.ok(addressInfo, "AddressInfo returned truthy OK");
-      t.ok(addressInfo.port, "AddressInfo.port returned truthy OK");
-      t.doesNotEqual(
-        addressInfo.port,
-        prefPort,
-        "Preferred and actually allocated ports are different, therefore fallback is considered successful OK",
-      );
-    }, "Servers.startOnPreferredPort falls back without throwing OK");
+      // t.ok(addressInfo, "AddressInfo returned truthy OK");
+      expect(addressInfo).toBeTruthy();
+      // t.ok(addressInfo.port, "AddressInfo.port returned truthy OK");
+      expect(addressInfo).toBeTruthy();
+      expect(addressInfo.port).not.toBe(prefPort);
+      // t.doesNotEqual(
+      //   addressInfo.port,
+      //   prefPort,
+      //   "Preferred and actually allocated ports are different, therefore fallback is considered successful OK",
+      // );
+    });
 
-    t.end();
+    // await t.doesNotReject(async () => {
+    //   const server = await Servers.startOnPreferredPort(prefPort, host);
+    //   test.onFinish(() => server.close());
+    //   t.ok(server, "Server returned truthy OK");
+    //   const addressInfo = server.address() as AddressInfo;
+    //   t.ok(addressInfo, "AddressInfo returned truthy OK");
+    //   t.ok(addressInfo.port, "AddressInfo.port returned truthy OK");
+    //   t.doesNotEqual(
+    //     addressInfo.port,
+    //     prefPort,
+    //     "Preferred and actually allocated ports are different, therefore fallback is considered successful OK",
+    //   );
+    // }, "Servers.startOnPreferredPort falls back without throwing OK");
   });
-
-  tParent.end();
 });

--- a/packages/cactus-common/src/test/typescript/unit/servers.test.ts
+++ b/packages/cactus-common/src/test/typescript/unit/servers.test.ts
@@ -1,7 +1,5 @@
 import { createServer } from "http";
 import { AddressInfo } from "net";
-
-// import test, { Test } from "tape-promise/tape";
 import "jest-extended";
 
 import { Servers } from "../../../main/typescript/index";
@@ -9,10 +7,16 @@ import { Servers } from "../../../main/typescript/index";
 const testCase = "Servers";
 
 describe(testCase, () => {
-  // test("Servers", async (tParent: Test) => {
+  const server = createServer();
+  const portBlocker = createServer();
+
+  afterAll(async () => {
+    await Servers.shutdown(server);
+    await portBlocker.close();
+  });
+
   test("Servers#listen()", async () => {
     {
-      const server = createServer();
       await expect(
         Servers.listen({
           hostname: "x",
@@ -23,7 +27,6 @@ describe(testCase, () => {
     }
 
     {
-      const server = createServer();
       await expect(
         Servers.listen({
           hostname: "localhost",
@@ -31,28 +34,16 @@ describe(testCase, () => {
           server,
         }),
       ).toReject();
-      await Servers.shutdown(server);
     }
 
     {
-      const server = createServer();
       await expect(
         Servers.listen({ hostname: "localhost", port: 0, server }),
       ).toResolve();
-      // await t.doesNotReject(
-      //   Servers.listen({ hostname: "localhost", port: 0, server }),
-      //   "Does not rejects when port specified as zero OK",
-      // );
-      await Servers.shutdown(server);
     }
-
-    // t.end();
-    // });
 
     const prefPort = 4123;
     const host = "localhost";
-    const portBlocker = createServer();
-    // test.onFinish(() => portBlocker.close());
 
     const listenOptionsBlocker = {
       server: portBlocker,
@@ -63,34 +54,11 @@ describe(testCase, () => {
 
     await expect(async () => {
       const server = await Servers.startOnPreferredPort(prefPort, host);
-      // test.onFinish(() => server.close());
-      // t.ok(server, "Server returned truthy OK");
       expect(server).toBeTruthy();
       const addressInfo = server.address() as AddressInfo;
-      // t.ok(addressInfo, "AddressInfo returned truthy OK");
       expect(addressInfo).toBeTruthy();
-      // t.ok(addressInfo.port, "AddressInfo.port returned truthy OK");
       expect(addressInfo).toBeTruthy();
       expect(addressInfo.port).not.toBe(prefPort);
-      // t.doesNotEqual(
-      //   addressInfo.port,
-      //   prefPort,
-      //   "Preferred and actually allocated ports are different, therefore fallback is considered successful OK",
-      // );
     });
-
-    // await t.doesNotReject(async () => {
-    //   const server = await Servers.startOnPreferredPort(prefPort, host);
-    //   test.onFinish(() => server.close());
-    //   t.ok(server, "Server returned truthy OK");
-    //   const addressInfo = server.address() as AddressInfo;
-    //   t.ok(addressInfo, "AddressInfo returned truthy OK");
-    //   t.ok(addressInfo.port, "AddressInfo.port returned truthy OK");
-    //   t.doesNotEqual(
-    //     addressInfo.port,
-    //     prefPort,
-    //     "Preferred and actually allocated ports are different, therefore fallback is considered successful OK",
-    //   );
-    // }, "Servers.startOnPreferredPort falls back without throwing OK");
   });
 });


### PR DESCRIPTION
test: jestify server test in cactus common
    
  Migrate Tap to Jest
  
  File Path:
  packages/cactus-common/src/
  test/typescript/
  unit/servers.test.ts
  
  This is a PARTIAL resolution to issue #238