### PR TITLE
style(test-tooling): fixed any type linter warns in quorum-test-ledger

### DIFF
--- a/packages/cactus-test-tooling/src/main/typescript/quorum/quorum-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/quorum/quorum-test-ledger.ts
@@ -106,14 +106,16 @@ export class QuorumTestLedger implements ITestLedger {
   }
 
   public async getFileContents(filePath: string): Promise<string> {
-    const response: any = await this.getContainer().getArchive({
-      path: filePath,
-    });
+    const response: NodeJS.ReadableStream = await this.getContainer().getArchive(
+      {
+        path: filePath,
+      },
+    );
     const extract: tar.Extract = tar.extract({ autoDestroy: true });
 
     return new Promise((resolve, reject) => {
       let fileContents = "";
-      extract.on("entry", async (header: any, stream, next) => {
+      extract.on("entry", async (header: unknown, stream, next) => {
         stream.on("error", (err: Error) => {
           reject(err);
         });


### PR DESCRIPTION
fixed 2 lint errors that were the any type error for Typescript and removed Node
Partial solution to #1375 

Signed-off-by: Alec Phong <alecphong@gmail.com>