### PR TITLE
fix(index.ts, emissionsRecordCOntract.ts, get-allowance-endpoint.ts): fixed lint errors on multiple files 

### DIFF
--- a/examples/cactus-example-carbon-accounting-backend/src/utility-emissions-channel/typescript/src/index.ts
+++ b/examples/cactus-example-carbon-accounting-backend/src/utility-emissions-channel/typescript/src/index.ts
@@ -575,4 +575,4 @@ export class EmissionsChaincode {
   }
 }
 
-export const contracts: any[] = [EmissionsChaincode];
+export const contracts: unknown[] = [EmissionsChaincode];

--- a/examples/cactus-example-carbon-accounting-backend/src/utility-emissions-channel/typescript/src/lib/emissionsRecordContract.ts
+++ b/examples/cactus-example-carbon-accounting-backend/src/utility-emissions-channel/typescript/src/lib/emissionsRecordContract.ts
@@ -46,7 +46,7 @@ export class EmissionsRecordContract {
     energyUseUom: string,
     url: string,
     md5: string,
-  ) {
+  ): Promise<Uint8Array> {
     // get emissions factors from eGRID database; convert energy use to emissions factor UOM; calculate energy use
     const lookup = await this.utilityLookupState.getUtilityLookupItem(
       utilityId,
@@ -135,7 +135,9 @@ export class EmissionsRecordContract {
     );
     return Buffer.from(JSON.stringify(records));
   }
-  async importUtilityFactor(factorI: UtilityEmissionsFactorInterface) {
+  async importUtilityFactor(
+    factorI: UtilityEmissionsFactorInterface,
+  ): Promise<Uint8Array> {
     const factor = new UtilityEmissionsFactor(factorI);
     await this.utilityEmissionsFactorState.addUtilityEmissionsFactor(
       factor,
@@ -143,7 +145,9 @@ export class EmissionsRecordContract {
     );
     return factor.toBuffer();
   }
-  async updateUtilityFactor(factorI: UtilityEmissionsFactorInterface) {
+  async updateUtilityFactor(
+    factorI: UtilityEmissionsFactorInterface,
+  ): Promise<Uint8Array> {
     const factor = new UtilityEmissionsFactor(factorI);
     await this.utilityEmissionsFactorState.updateUtilityEmissionsFactor(
       factor,

--- a/examples/cactus-example-carbon-accounting-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/dao-token/get-allowance-endpoint.ts
+++ b/examples/cactus-example-carbon-accounting-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/dao-token/get-allowance-endpoint.ts
@@ -55,7 +55,7 @@ export class GetAllowanceEndpoint implements IWebServiceEndpoint {
     };
   }
 
-  public get oasPath(): { post: any } {
+  public get oasPath(): typeof OAS.paths["/api/v1/plugins/@hyperledger/cactus-example-carbon-accounting-backend/dao-token/get-allowance"] {
     return OAS.paths[
       "/api/v1/plugins/@hyperledger/cactus-example-carbon-accounting-backend/dao-token/get-allowance"
     ];
@@ -81,10 +81,12 @@ export class GetAllowanceEndpoint implements IWebServiceEndpoint {
       const resBody = await Promise.resolve("dummy-response-fixme");
       res.status(200);
       res.json(resBody);
-    } catch (ex) {
-      this.log.debug(`${tag} Failed to serve request:`, ex);
-      res.status(500);
-      res.json({ error: ex.stack });
+    } catch (ex: unknown) {
+      if (ex instanceof Error) {
+        this.log.debug(`${tag} Failed to serve request:`, ex);
+        res.status(500);
+        res.json({ error: ex.stack });
+      }
     }
   }
 }

--- a/packages/cactus-test-tooling/src/main/typescript/quorum/quorum-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/quorum/quorum-test-ledger.ts
@@ -17,6 +17,7 @@ import { Streams } from "../common/streams";
 import { IKeyPair } from "../i-key-pair";
 import { IQuorumGenesisOptions } from "./i-quorum-genesis-options";
 import { Containers } from "../common/containers";
+import internal from "stream";
 
 export interface IQuorumTestLedgerConstructorOptions {
   containerImageVersion?: string;
@@ -274,20 +275,24 @@ export class QuorumTestLedger implements ITestLedger {
       try {
         const res = await axios.get(httpUrl);
         reachable = res.status > 199 && res.status < 300;
-      } catch (ex) {
-        reachable = false;
-        if (Date.now() >= startedAt + timeoutMs) {
-          throw new Error(`${fnTag} timed out (${timeoutMs}ms) -> ${ex.stack}`);
+      } catch (ex: unknown) {
+        if (ex instanceof Error) {
+          reachable = false;
+          if (Date.now() >= startedAt + timeoutMs) {
+            throw new Error(
+              `${fnTag} timed out (${timeoutMs}ms) -> ${ex.stack}`,
+            );
+          }
         }
       }
       await new Promise((resolve2) => setTimeout(resolve2, 100));
     } while (!reachable);
   }
 
-  public stop(): Promise<any> {
+  public stop(): Promise<unknown> {
     return new Promise((resolve, reject) => {
       if (this.container) {
-        this.container.stop({}, (err: any, result: any) => {
+        this.container.stop({}, (err: unknown, result: unknown) => {
           if (err) {
             reject(err);
           } else {
@@ -377,25 +382,28 @@ export class QuorumTestLedger implements ITestLedger {
     }
   }
 
-  private pullContainerImage(containerNameAndTag: string): Promise<any[]> {
+  private pullContainerImage(containerNameAndTag: string): Promise<unknown[]> {
     return new Promise((resolve, reject) => {
       const docker = new Docker();
-      docker.pull(containerNameAndTag, (pullError: any, stream: any) => {
-        if (pullError) {
-          reject(pullError);
-        } else {
-          docker.modem.followProgress(
-            stream,
-            (progressError: any, output: any[]) => {
-              if (progressError) {
-                reject(progressError);
-              } else {
-                resolve(output);
-              }
-            },
-          );
-        }
-      });
+      docker.pull(
+        containerNameAndTag,
+        (pullError: unknown, stream: internal.Stream) => {
+          if (pullError) {
+            reject(pullError);
+          } else {
+            docker.modem.followProgress(
+              stream,
+              (progressError: unknown, output: unknown[]) => {
+                if (progressError) {
+                  reject(progressError);
+                } else {
+                  resolve(output);
+                }
+              },
+            );
+          }
+        },
+      );
     });
   }
 

--- a/packages/cactus-test-tooling/src/main/typescript/quorum/quorum-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/quorum/quorum-test-ledger.ts
@@ -106,14 +106,16 @@ export class QuorumTestLedger implements ITestLedger {
   }
 
   public async getFileContents(filePath: string): Promise<string> {
-    const response: any = await this.getContainer().getArchive({
-      path: filePath,
-    });
+    const response: NodeJS.ReadableStream = await this.getContainer().getArchive(
+      {
+        path: filePath,
+      },
+    );
     const extract: tar.Extract = tar.extract({ autoDestroy: true });
 
     return new Promise((resolve, reject) => {
       let fileContents = "";
-      extract.on("entry", async (header: any, stream, next) => {
+      extract.on("entry", async (header: unknown, stream, next) => {
         stream.on("error", (err: Error) => {
           reject(err);
         });


### PR DESCRIPTION
Primary Change
--------------

1. Fixed lint errors on index.ts (line 578, col 25), emissionsRecordContract.ts (line 40, col 3; line 138, col 3; line 146, col 3), and endpoint.ts (line 58, col 33) 
2. In order to fix changes from any to unknown, had to change the output path to directed types: (Changed OASPath return type from any object to "typeof OAS.paths["/api/v1/plugins/@hyperledger/cactus-example-carbon-accounting-backend/dao-token/get-allowance"]"
------------------------------------------------------------
Signed-off-by: Alec Phong <alecphong@gmail.com>
Partial Fix to #1366 