### PR TITLE
style(examples): error handling and return type linter fixes

### DIFF
--- a/examples/cactus-example-carbon-accounting-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/utility-emissions-channel/enroll-admin-v1-endpoint.ts
+++ b/examples/cactus-example-carbon-accounting-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/utility-emissions-channel/enroll-admin-v1-endpoint.ts
@@ -6,6 +6,7 @@ import {
   LogLevelDesc,
   LoggerProvider,
   IAsyncProvider,
+  safeStringifyException,
 } from "@hyperledger/cactus-common";
 import {
   IEndpointAuthzOptions,
@@ -51,7 +52,7 @@ export class EnrollAdminV1Endpoint implements IWebServiceEndpoint {
     };
   }
 
-  public get oasPath(): any {
+  public get oasPath(): typeof OAS.paths["/api/v1/utilityemissionchannel/registerEnroll/admin"] {
     return OAS.paths["/api/v1/utilityemissionchannel/registerEnroll/admin"];
   }
 
@@ -75,10 +76,11 @@ export class EnrollAdminV1Endpoint implements IWebServiceEndpoint {
       const resBody = await this.opts.plugin.enrollAdminV1(reqBody);
       res.status(200);
       res.json(resBody);
-    } catch (ex) {
+    } catch (ex: unknown) {
+      const exStr = safeStringifyException(ex);
       this.log.debug(`${tag} Failed to serve request:`, ex);
       res.status(500);
-      res.json({ error: ex.stack });
+      res.json({ error: exStr });
     }
   }
 }

--- a/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/insert-bamboo-harvest-endpoint.ts
+++ b/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/insert-bamboo-harvest-endpoint.ts
@@ -6,6 +6,7 @@ import {
   LogLevelDesc,
   LoggerProvider,
   IAsyncProvider,
+  safeStringifyException,
 } from "@hyperledger/cactus-common";
 import {
   IEndpointAuthzOptions,
@@ -74,7 +75,7 @@ export class InsertBambooHarvestEndpoint implements IWebServiceEndpoint {
     this.log.debug(`Instantiated ${this.className} OK`);
   }
 
-  public getOasPath() {
+  public getOasPath(): typeof OAS.paths["/api/v1/plugins/@hyperledger/cactus-example-supply-chain-backend/insert-bamboo-harvest"] {
     return OAS.paths[
       "/api/v1/plugins/@hyperledger/cactus-example-supply-chain-backend/insert-bamboo-harvest"
     ];
@@ -126,10 +127,11 @@ export class InsertBambooHarvestEndpoint implements IWebServiceEndpoint {
       const body = { success, callOutput, transactionReceipt };
       res.status(200);
       res.json(body);
-    } catch (ex) {
+    } catch (ex: unknown) {
+      const exStr = safeStringifyException(ex);
       this.log.debug(`${tag} Failed to serve request:`, ex);
       res.status(500);
-      res.json({ error: ex.stack });
+      res.json({ error: exStr });
     }
   }
 }

--- a/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/insert-bookshelf-endpoint.ts
+++ b/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/insert-bookshelf-endpoint.ts
@@ -6,6 +6,7 @@ import {
   LogLevelDesc,
   LoggerProvider,
   IAsyncProvider,
+  safeStringifyException,
 } from "@hyperledger/cactus-common";
 import {
   IEndpointAuthzOptions,
@@ -56,7 +57,7 @@ export class InsertBookshelfEndpoint implements IWebServiceEndpoint {
     this.log = LoggerProvider.getOrCreate({ level, label });
   }
 
-  public getOasPath() {
+  public getOasPath(): typeof OAS.paths["/api/v1/plugins/@hyperledger/cactus-example-supply-chain-backend/insert-bookshelf"] {
     return OAS.paths[
       "/api/v1/plugins/@hyperledger/cactus-example-supply-chain-backend/insert-bookshelf"
     ];
@@ -114,10 +115,11 @@ export class InsertBookshelfEndpoint implements IWebServiceEndpoint {
       const body = { callOutput, transactionReceipt };
       res.status(200);
       res.json(body);
-    } catch (ex) {
+    } catch (ex: unknown) {
+      const exStr = safeStringifyException(ex);
       this.log.debug(`${tag} Failed to serve request:`, ex);
       res.status(500);
-      res.json({ error: ex.stack });
+      res.json({ error: exStr });
     }
   }
 }

--- a/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/insert-shipment-endpoint.ts
+++ b/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/insert-shipment-endpoint.ts
@@ -6,6 +6,7 @@ import {
   LogLevelDesc,
   LoggerProvider,
   IAsyncProvider,
+  safeStringifyException,
 } from "@hyperledger/cactus-common";
 import {
   IEndpointAuthzOptions,
@@ -66,7 +67,7 @@ export class InsertShipmentEndpoint implements IWebServiceEndpoint {
     return this;
   }
 
-  public getOasPath() {
+  public getOasPath(): typeof OAS.paths["/api/v1/plugins/@hyperledger/cactus-example-supply-chain-backend/insert-shipment"] {
     return OAS.paths[
       "/api/v1/plugins/@hyperledger/cactus-example-supply-chain-backend/insert-shipment"
     ];
@@ -114,10 +115,11 @@ export class InsertShipmentEndpoint implements IWebServiceEndpoint {
 
       res.json(body);
       res.status(200);
-    } catch (ex) {
+    } catch (ex: unknown) {
+      const exStr = safeStringifyException(ex);
       this.log.debug(`${tag} Failed to serve request:`, ex);
       res.status(500);
-      res.json({ error: ex.stack });
+      res.json({ error: exStr });
     }
   }
 }

--- a/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/list-bamboo-harvest-endpoint.ts
+++ b/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/list-bamboo-harvest-endpoint.ts
@@ -6,6 +6,7 @@ import {
   LogLevelDesc,
   LoggerProvider,
   IAsyncProvider,
+  safeStringifyException,
 } from "@hyperledger/cactus-common";
 import {
   IEndpointAuthzOptions,
@@ -35,7 +36,7 @@ export class ListBambooHarvestEndpoint implements IWebServiceEndpoint {
 
   private readonly log: Logger;
 
-  public get className() {
+  public get className(): string {
     return ListBambooHarvestEndpoint.CLASS_NAME;
   }
 
@@ -55,7 +56,7 @@ export class ListBambooHarvestEndpoint implements IWebServiceEndpoint {
     this.log = LoggerProvider.getOrCreate({ level, label });
   }
 
-  public getOasPath() {
+  public getOasPath(): typeof OAS.paths["/api/v1/plugins/@hyperledger/cactus-example-supply-chain-backend/list-bamboo-harvest"] {
     return OAS.paths[
       "/api/v1/plugins/@hyperledger/cactus-example-supply-chain-backend/list-bamboo-harvest"
     ];
@@ -116,10 +117,11 @@ export class ListBambooHarvestEndpoint implements IWebServiceEndpoint {
       const body = { data: rows };
       res.status(200);
       res.json(body);
-    } catch (ex) {
+    } catch (ex: unknown) {
+      const exStr = safeStringifyException(ex);
       this.log.debug(`${tag} Failed to serve request:`, ex);
       res.status(500);
-      res.json({ error: ex.stack });
+      res.json({ error: exStr });
     }
   }
 }

--- a/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/list-bookshelf-endpoint.ts
+++ b/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/list-bookshelf-endpoint.ts
@@ -6,6 +6,7 @@ import {
   LogLevelDesc,
   LoggerProvider,
   IAsyncProvider,
+  safeStringifyException,
 } from "@hyperledger/cactus-common";
 import {
   IEndpointAuthzOptions,
@@ -53,7 +54,7 @@ export class ListBookshelfEndpoint implements IWebServiceEndpoint {
     this.log = LoggerProvider.getOrCreate({ level, label });
   }
 
-  public getOasPath() {
+  public getOasPath(): typeof OAS.paths["/api/v1/plugins/@hyperledger/cactus-example-supply-chain-backend/list-bookshelf"] {
     return OAS.paths[
       "/api/v1/plugins/@hyperledger/cactus-example-supply-chain-backend/list-bookshelf"
     ];
@@ -114,10 +115,11 @@ export class ListBookshelfEndpoint implements IWebServiceEndpoint {
       const body = { data: rows };
       res.status(200);
       res.json(body);
-    } catch (ex) {
+    } catch (ex: unknown) {
+      const exStr = safeStringifyException(ex);
       this.log.debug(`${tag} Failed to serve request:`, ex);
       res.status(500);
-      res.json({ error: ex.stack });
+      res.json({ error: exStr });
     }
   }
 }

--- a/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/list-shipment-endpoint.ts
+++ b/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/business-logic-plugin/web-services/list-shipment-endpoint.ts
@@ -6,6 +6,7 @@ import {
   LogLevelDesc,
   LoggerProvider,
   IAsyncProvider,
+  safeStringifyException,
 } from "@hyperledger/cactus-common";
 import {
   IEndpointAuthzOptions,
@@ -37,7 +38,7 @@ export class ListShipmentEndpoint implements IWebServiceEndpoint {
     return ListShipmentEndpoint.CLASS_NAME;
   }
 
-  public getOasPath() {
+  public getOasPath(): typeof OAS.paths["/api/v1/plugins/@hyperledger/cactus-example-supply-chain-backend/list-shipment"] {
     return OAS.paths[
       "/api/v1/plugins/@hyperledger/cactus-example-supply-chain-backend/list-shipment"
     ];
@@ -112,10 +113,11 @@ export class ListShipmentEndpoint implements IWebServiceEndpoint {
       const body = { data: output };
       res.status(200);
       res.json(body);
-    } catch (ex) {
+    } catch (ex: unknown) {
+      const exStr = safeStringifyException(ex);
       this.log.debug(`${tag} Failed to serve request:`, ex);
       res.status(500);
-      res.json({ error: ex.stack });
+      res.json({ error: exStr });
     }
   }
 }


### PR DESCRIPTION
Edited it after the fact to correct the bugs introduced in the catch
blocks where non-Error type exceptions were getting ignored which was
not the case before the linter fixes.

The original commit message from Alec:
`=======================================================================`
Primary Change

Fixed lint errors on utility-emissions-channel/enroll-admin-v1-endpoint.ts
(line 54, col 25), insert-bamboo-harvest-endpoint.ts (line 78, col 3),
 insert-bookshelf-endpoint.ts (line 59, col 3),
 insert-shipment-endpoint.ts (line 69, col 3),
 list-bamboo-harvest-endpoint.ts (line 38, col 3; line 58, col 3; ),
  list-bookshelf-endpoint.ts (line 56, col 3), and
  list-shipment-endpoint.ts (line 40, col 3)
In order to fix changes from any to unknown, had to change the
output path to directed types: (Changed OASPath return type from any
object to "typeof OAS.paths["/api/v1/plugins/@hyperledger/
cactus-example-carbon-accounting-backend/dao-token/get-allowance"]"
Removed import statements that were never used in the file (import e)
Partial Fix to https://github.com/hyperledger/cactus/issues/1366
`=======================================================================`

Signed-off-by: Alec Phong <alecphong@gmail.com>
Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

Co-authored-by: Peter Somogyvari <peter.somogyvari@accenture.com>