### PR TITLE
fix: Lint Warnings resolved for batch 7/26 #1356 : Commit to be reviewed

### DIFF
--- a/packages/cactus-common/src/main/typescript/checks.ts
+++ b/packages/cactus-common/src/main/typescript/checks.ts
@@ -9,7 +9,7 @@ export class Checks {
    * @param code The code of the error if `checkResult is falsy.
    */
   public static truthy(
-    checkResult: any,
+    checkResult: unknown,
     subjectOfCheck = "variable",
     code = "-1",
   ): void {
@@ -28,7 +28,7 @@ export class Checks {
    * @param code The code of the error if `checkResult is falsy.
    */
   public static nonBlankString(
-    value: any,
+    value: string,
     subject = "variable",
     code = "-1",
   ): void {

--- a/packages/cactus-common/src/main/typescript/checks.ts
+++ b/packages/cactus-common/src/main/typescript/checks.ts
@@ -28,7 +28,7 @@ export class Checks {
    * @param code The code of the error if `checkResult is falsy.
    */
   public static nonBlankString(
-    value: string,
+    value: unknown,
     subject = "variable",
     code = "-1",
   ): void {

--- a/packages/cactus-common/src/main/typescript/logging/logger-provider.ts
+++ b/packages/cactus-common/src/main/typescript/logging/logger-provider.ts
@@ -26,7 +26,7 @@ export class LoggerProvider {
     LoggerProvider.logLevel = logLevel;
     if (applyToCachedLoggers) {
       LoggerProvider.loggers.forEach((logger: Logger) =>
-        logger.setLogLevel(logLevel as any),
+        logger.setLogLevel(logLevel as LogLevelDesc),
       );
     }
   }


### PR DESCRIPTION
fix: batch 7/26 of lint warning fixes #1356(fixed 5 warnings, partial solution): 

Changes made:
- Fixed lint warnings associated with any-type for truthyness and nonBlankString checking
- Fixed lint warnings associated with Unexpected any, edited type-aliases in logger