### PR TITLE
fix: compile errors in the electricity-trade example

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "lodash": ">=4.17.21",
     "minimist": ">=1.2.6",
     "node-forge": ">=1.3.0",
-    "underscore": "1.13.2"
+    "underscore": "1.13.2",
+    "@types/ssh2": "0.5.52"
   }
 }


### PR DESCRIPTION
This fix allows the cactus repository to configure without errors when `npm run configure` is run in the cactus root directory
It enables various examples like the electricity-trade to work
Signed-off-by: Jande Vincent [janvinsha@gmail.com](url) 