### PR TITLE
refactor(connector-sawtooth-socketio): fix strict flag warnings

### DIFF
--- a/packages/cactus-plugin-ledger-connector-sawtooth-socketio/src/main/typescript/common/core/bin/www.ts
+++ b/packages/cactus-plugin-ledger-connector-sawtooth-socketio/src/main/typescript/common/core/bin/www.ts
@@ -65,7 +65,7 @@ server.on("listening", onListening);
  * Normalize a port into a number, string, or false.
  */
 
-function normalizePort(val) {
+function normalizePort(val: string) {
   const port = parseInt(val, 10);
 
   if (isNaN(port)) {
@@ -85,7 +85,7 @@ function normalizePort(val) {
  * Event listener for HTTPS server "error" event.
  */
 
-function onError(error) {
+function onError(error: any) {
   if (error.syscall !== "listen") {
     throw error;
   }
@@ -114,6 +114,12 @@ function onError(error) {
 
 function onListening() {
   const addr = server.address();
+
+  if (!addr) {
+    logger.error("Could not get running server address - exit.");
+    process.exit(1);
+  }
+
   const bind = typeof addr === "string" ? "pipe " + addr : "port " + addr.port;
   debug("Listening on " + bind);
 }
@@ -125,8 +131,7 @@ io.on("connection", function (client) {
    * startMonitor: starting block generation event monitoring
    **/
   client.on("startMonitor", function (data) {
-    // Callback to receive monitoring results
-    const cb = function (callbackData) {
+    Smonitor.startMonitor(client.id, data.filterKey, (callbackData) => {
       let emitType = "";
       if (callbackData.status == 200) {
         emitType = "eventReceived";
@@ -135,8 +140,6 @@ io.on("connection", function (client) {
         emitType = "monitor_error";
       }
       client.emit(emitType, callbackData);
-    };
-
-    Smonitor.startMonitor(client.id, data.filterKey, cb);
+    });
   });
 });

--- a/packages/cactus-plugin-ledger-connector-sawtooth-socketio/src/main/typescript/connector/PluginUtil.ts
+++ b/packages/cactus-plugin-ledger-connector-sawtooth-socketio/src/main/typescript/connector/PluginUtil.ts
@@ -25,7 +25,7 @@ const cbor = require("cbor");
  *         3.78*10^14
  *         3.78e14
  */
-exports.convNum = function (value, defaultValue) {
+exports.convNum = function convNum(value: number | string, defaultValue: number | string) {
   let retValue = 0;
   let defValue = 0;
 
@@ -71,7 +71,7 @@ exports.convNum = function (value, defaultValue) {
   return retValue;
 };
 
-exports.convertBlockNumber = function (value) {
+exports.convertBlockNumber = function (value: number) {
   return "0x" + ("0000000000000000" + value.toString(16)).substr(-16);
 };
 

--- a/packages/cactus-plugin-ledger-connector-sawtooth-socketio/src/main/typescript/connector/ServerMonitorPlugin.ts
+++ b/packages/cactus-plugin-ledger-connector-sawtooth-socketio/src/main/typescript/connector/ServerMonitorPlugin.ts
@@ -24,6 +24,11 @@ logger.level = config.read("logLevel", "info");
 import { ValidatorAuthentication } from "./ValidatorAuthentication";
 const XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 
+export type MonitorCallback = (callback: {
+  status: number;
+  blockData: string;
+}) => void;
+
 /*
  * ServerMonitorPlugin
  * Class definitions of server monitoring
@@ -46,7 +51,7 @@ export class ServerMonitorPlugin {
    * @param {string} filterKey: Key to filter blocks
    * @param {function} cb: A callback function that receives monitoring results at any time.
    */
-  startMonitor(clientId, filterKey, cb) {
+  startMonitor(clientId: string, filterKey: string, cb: MonitorCallback) {
     logger.info("*** START MONITOR ***");
     logger.info("Client ID :" + clientId);
     logger.debug(`filterKey = ${filterKey}`);
@@ -75,7 +80,7 @@ export class ServerMonitorPlugin {
    * @param {string} filterKey: Key to filter blocks
    * @param {function} cb: A callback function that receives monitoring results at any time.
    */
-  periodicMonitoring(clientId, filterKey, cb) {
+  periodicMonitoring(clientId: string, filterKey: string, cb: MonitorCallback) {
     logger.info("*** START PERIODIC MONITORING ***");
 
     const that = this;

--- a/packages/cactus-plugin-ledger-connector-sawtooth-socketio/tsconfig.json
+++ b/packages/cactus-plugin-ledger-connector-sawtooth-socketio/tsconfig.json
@@ -8,7 +8,6 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "tsBuildInfoFile": "../../.build-cache/cactus-plugin-ledger-connector-sawtooth-socketio.tsbuildinfo",
-    "strict": false // TODO - True, fix warnings
   },
   "include": [
     "./src/main/typescript/common/core/*.ts",


### PR DESCRIPTION
cactus-plugin-ledger-connector-sawtooth-socketio will compile with global strict flag.

Related issue: #1671

Signed-off-by: Michal Bajer <michal.bajer@fujitsu.com>