### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,6 +11,11 @@ Maintainers
 | Takuma TAKEUCHI | [takeutak][takeutak] | takeutak#7220 |
 | Jagpreet Singh Sasan | [jagpreetsinghsasan][jagpreetsinghsasan] | jagpreetsinghsasan |
 | Venkatraman Ramakrishna | [VRamakrishna][VRamakrishna] | Ramakrishna#6645 |
+
+**Emeritus Maintainers**
+
+| Name | GitHub | Chat |
+|------|--------|------|
 | Sandeep Nishad | [sanvenDev][sanvenDev] | sanven#1092 |
 
 [jonathan-m-hamilton]: https://github.com/jonathan-m-hamilton


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>