### PR TITLE
fix(tools): ghcr-quorum-multi-party-all-in-one pip install

### DIFF
--- a/tools/docker/quorum-multi-party-all-in-one/Dockerfile
+++ b/tools/docker/quorum-multi-party-all-in-one/Dockerfile
@@ -17,7 +17,7 @@ RUN quorum-dev-quickstart --clientType goquorum --outputPath ./ --monitoring def
 # docker-compose base
 ################################
 
-FROM docker:20.10.3-dind
+FROM docker:20.10.21-dind
 
 ENV ROOT_DIR=/opt/quorum-dev-quickstart
 


### PR DESCRIPTION
Upgraded the base image version from
`docker:20.10.3-dind`
to
`docker:20.10.21-dind`
which ships with newer rust versions through apk
by default and thereby fixing the issue of the rust
compiler version being not new enough for
docker-compose.

Fixes #2183

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>