### PR TITLE
ci(github): upgrade actions/checkout to v3.1.0

### DIFF
--- a/.github/workflows/.dast-nuclei-cmd-api-server.yaml
+++ b/.github/workflows/.dast-nuclei-cmd-api-server.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Verify jq
         run: jq --version
 
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
 
       - uses: actions/setup-go@v3.0.0
         with:

--- a/.github/workflows/all-nodejs-packages-publish.yaml
+++ b/.github/workflows/all-nodejs-packages-publish.yaml
@@ -12,7 +12,7 @@ jobs:
   build-and-publish-packages:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v3.1.0
     - run: git fetch --unshallow --prune
     - uses: actions/setup-node@v2.1.2
       with:

--- a/.github/workflows/besu-all-in-one-publish.yaml
+++ b/.github/workflows/besu-all-in-one-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/cactus-whitepaper-publish.yaml
+++ b/.github/workflows/cactus-whitepaper-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - run: ./tools/ci.sh
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -83,7 +83,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -110,7 +110,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -139,7 +139,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -166,7 +166,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -193,7 +193,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -221,7 +221,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -248,7 +248,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -276,7 +276,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -304,7 +304,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -331,7 +331,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -359,7 +359,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -386,7 +386,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -415,7 +415,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -442,7 +442,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -469,7 +469,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -497,7 +497,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -525,7 +525,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -553,7 +553,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -581,7 +581,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -609,7 +609,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -637,7 +637,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -666,7 +666,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -695,7 +695,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -724,7 +724,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -751,7 +751,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -779,7 +779,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -808,7 +808,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -837,7 +837,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -865,7 +865,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -894,7 +894,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -922,7 +922,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -949,7 +949,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -976,7 +976,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -1004,7 +1004,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -1032,7 +1032,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -1060,7 +1060,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -1089,7 +1089,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -1118,7 +1118,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -1145,7 +1145,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -1174,7 +1174,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -1201,7 +1201,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: v16.14.2
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - id: yarn-cache-dir-path
         name: Get yarn cache directory path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -1217,121 +1217,121 @@ jobs:
   ghcr-besu-all-in-one:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-besu-all-in-one
         run: DOCKER_BUILDKIT=1 docker build ./tools/docker/besu-all-in-one/ -f ./tools/docker/besu-all-in-one/Dockerfile
   ghcr-cmd-api-server:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-cmd-api-server
         run: DOCKER_BUILDKIT=1 docker build . -f ./packages/cactus-cmd-api-server/Dockerfile
   ghcr-connector-besu:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-connector-besu
         run: DOCKER_BUILDKIT=1 docker build ./packages/cactus-plugin-ledger-connector-besu/ -f ./packages/cactus-plugin-ledger-connector-besu/Dockerfile
   ghcr-connector-corda-server:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-connector-corda-server
         run: DOCKER_BUILDKIT=1 docker build ./packages/cactus-plugin-ledger-connector-corda/src/main-server/ -f ./packages/cactus-plugin-ledger-connector-corda/src/main-server/Dockerfile
   ghcr-connector-fabric:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-connector-fabric
         run: DOCKER_BUILDKIT=1 docker build ./packages/cactus-plugin-ledger-connector-fabric/ -f ./packages/cactus-plugin-ledger-connector-fabric/Dockerfile
   ghcr-corda-all-in-one:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-corda-all-in-one
         run: DOCKER_BUILDKIT=1 docker build ./tools/docker/corda-all-in-one/ -f ./tools/docker/corda-all-in-one/Dockerfile
   ghcr-corda-all-in-one-flowdb:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-corda-all-in-one-flowdb
         run: DOCKER_BUILDKIT=1 docker build ./tools/docker/corda-all-in-one/corda-v4_8-flowdb/
   ghcr-corda-all-in-one-obligation:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-corda-all-in-one-obligation
         run: DOCKER_BUILDKIT=1 docker build ./tools/docker/corda-all-in-one/ -f ./tools/docker/corda-all-in-one/corda-v4_8/Dockerfile
   ghcr-dev-container-vscode:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-dev-container-vscode
         run: DOCKER_BUILDKIT=1 docker build ./.devcontainer/ -f ./.devcontainer/Dockerfile
   ghcr-example-carbon-accounting:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-example-carbon-accounting
         run: DOCKER_BUILDKIT=1 docker build . -f ./examples/carbon-accounting/Dockerfile
   ghcr-example-supply-chain-app:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-example-supply-chain-app
         run: DOCKER_BUILDKIT=1 docker build . -f ./examples/supply-chain-app/Dockerfile
   ghcr-fabric-all-in-one:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-fabric-all-in-one
         run: DOCKER_BUILDKIT=1 docker build ./tools/docker/fabric-all-in-one/ -f ./tools/docker/fabric-all-in-one/Dockerfile_v1.4.x
   ghcr-fabric2-all-in-one:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-fabric2-all-in-one
         run: DOCKER_BUILDKIT=1 docker build ./tools/docker/fabric-all-in-one/ -f ./tools/docker/fabric-all-in-one/Dockerfile_v2.x
   ghcr-iroha-all-in-one:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-iroha-all-in-one
         run: DOCKER_BUILDKIT=1 docker build ./tools/docker/iroha-all-in-one/ -f ./tools/docker/iroha-all-in-one/Dockerfile
   ghcr-keychain-vault-server:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-keychain-vault-server
         run: DOCKER_BUILDKIT=1 docker build ./packages/cactus-plugin-keychain-vault/src/cactus-keychain-vault-server/ -f ./packages/cactus-plugin-keychain-vault/src/cactus-keychain-vault-server/Dockerfile
   ghcr-quorum-all-in-one:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-quorum-all-in-one
         run: DOCKER_BUILDKIT=1 docker build ./tools/docker/quorum-all-in-one/ -f ./tools/docker/quorum-all-in-one/Dockerfile
   ghcr-quorum-multi-party-all-in-one:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-quorum-multi-party-all-in-one
         run: DOCKER_BUILDKIT=1 docker build ./tools/docker/quorum-multi-party-all-in-one/ -f ./tools/docker/quorum-multi-party-all-in-one/Dockerfile
   ghcr-rust-compiler:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-rust-compiler
         run: DOCKER_BUILDKIT=1 docker build ./tools/docker/rust-compiler/ -f ./tools/docker/rust-compiler/Dockerfile
   ghcr-test-npm-registry:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-test-npm-registry
         run: DOCKER_BUILDKIT=1 docker build ./tools/docker/test-npm-registry/ -f ./tools/docker/test-npm-registry/Dockerfile
   ghcr-whitepaper:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
       - name: ghcr.io/hyperledger/cactus-whitepaper
         run: DOCKER_BUILDKIT=1 docker build ./whitepaper/ -f ./whitepaper/Dockerfile
 name: Cactus_CI

--- a/.github/workflows/cmd-api-server-publish.yaml
+++ b/.github/workflows/cmd-api-server-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.1.0
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/commitlint-pull-request.yml
+++ b/.github/workflows/commitlint-pull-request.yml
@@ -5,7 +5,7 @@ jobs:
   commitlint:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v3.1.4

--- a/.github/workflows/connector-besu-publish.yaml
+++ b/.github/workflows/connector-besu-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/connector-corda-server-publish.yaml
+++ b/.github/workflows/connector-corda-server-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/connector-fabric-publish.yaml
+++ b/.github/workflows/connector-fabric-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/corda-4-6-all-in-one-obligation-publish.yaml
+++ b/.github/workflows/corda-4-6-all-in-one-obligation-publish.yaml
@@ -28,7 +28,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/corda-4-7-all-in-one-obligation-publish.yaml
+++ b/.github/workflows/corda-4-7-all-in-one-obligation-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/corda-4-8-all-in-one-obligation-publish.yaml
+++ b/.github/workflows/corda-4-8-all-in-one-obligation-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/dev-container-vscode-publish.yaml
+++ b/.github/workflows/dev-container-vscode-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/example-carbon-accounting-publish.yaml
+++ b/.github/workflows/example-carbon-accounting-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/example-supply-chain-app-publish.yaml
+++ b/.github/workflows/example-supply-chain-app-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/fabric-all-in-one-publish.yaml
+++ b/.github/workflows/fabric-all-in-one-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/fabric2-all-in-one-publish.yaml
+++ b/.github/workflows/fabric2-all-in-one-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/iroha-all-in-one-publish.yaml
+++ b/.github/workflows/iroha-all-in-one-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/keychain-vault-server-publish.yaml
+++ b/.github/workflows/keychain-vault-server-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/quorum-all-in-one-publish.yaml
+++ b/.github/workflows/quorum-all-in-one-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/quorum-multi-party-all-in-one-publish.yaml
+++ b/.github/workflows/quorum-multi-party-all-in-one-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/rust-compiler-publish.yaml
+++ b/.github/workflows/rust-compiler-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/sawtooth-all-in-one-publish.yaml
+++ b/.github/workflows/sawtooth-all-in-one-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/test-npm-registry-publish.yaml
+++ b/.github/workflows/test-npm-registry-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.1.0
 
       - name: Build image
         run: docker build $DOCKER_BUILD_DIR --file $DOCKERFILE_PATH --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"

--- a/BUILD.md
+++ b/BUILD.md
@@ -229,7 +229,7 @@ Locate the `ci.yml` within `.github/workflows` and add to the `ci.yml` code list
     with:
       repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-Keep in mind that the SSH upterm session should come after the checkout step (uses: actions/checkout@v2.3.4) to ensure that the CI doesn't hang without before the debugging step occurs. Editing the `ci.yml` will create a new upterm session within `.github/workflows` by adding a new build step. For more details, see the [Debug your GitHub Actions by using ssh](https://github.com/marketplace/actions/debugging-with-ssh).
+Keep in mind that the SSH upterm session should come after the checkout step (uses: actions/checkout@v3.1.0) to ensure that the CI doesn't hang without before the debugging step occurs. Editing the `ci.yml` will create a new upterm session within `.github/workflows` by adding a new build step. For more details, see the [Debug your GitHub Actions by using ssh](https://github.com/marketplace/actions/debugging-with-ssh).
 
 By creating a PR for the edited `ci.yml` file, this will the CI to run their tests. There are two ways to navigate to CIs.
   1) Go to the PR and click the `checks` tab


### PR DESCRIPTION
Project-wide search and replace for all occurrences of the
checkout GH workflow action so that it is at the current
latest stable release version which is v3.1.0

Fixes #2187

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>