### PR TITLE
build: fix release automation - try #2

### DIFF
--- a/.github/workflows/all-nodejs-packages-publish.yaml
+++ b/.github/workflows/all-nodejs-packages-publish.yaml
@@ -19,12 +19,17 @@ jobs:
         always-auth: true
         node-version: '16.14.2'
         registry-url: 'https://registry.npmjs.org'
+    - name: ./tools/ci.sh
+      run: ./tools/ci.sh
+      env:
+        DEV_BUILD_DISABLED: false
+        FULL_BUILD_DISABLED: false
+        JEST_TEST_RUNNER_DISABLED: true
+        TAPE_TEST_RUNNER_DISABLED: true
     - name: lerna-publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: |
         git config --global user.email "${GITHUB_ACTOR}"
         git config --global user.name "${GITHUB_ACTOR}"
-        yarn run configure
-        yarn run build
         yarn lerna publish from-git --yes --loglevel=debug


### PR DESCRIPTION
A second attempt at fixing the release automation.

The missing piece was that some of the Indy SDK dependencies
were not installed by default and we forgot to run the ci.sh
script to take care of that within this workflow action.

With this fix now we have an additional step in the action which
takes care of installing the OS level build dependencies for
the project.

Fixes #1951
Fixes #2069
Fixes #2175

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>