### PR TITLE
docs(codeowners): fix Rama's and Sandeep's usernames

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @petermetz @takeutak @izuru0 @jagpreetsinghsasan @VRamakrishna @sanvenDev
+* @petermetz @takeutak @izuru0 @jagpreetsinghsasan @vramakrishna @sanvendev
 


### PR DESCRIPTION
Transformed Rama's and Sandeep's usernames in the
CODEOWNERS file to all lower-case.
Hoping that this will fix the problem where GitHub
does not auto-assign them as reviewers to new PRs.

Fixes #2200

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>