### PR TITLE
fix(odap-plugin): fix bug in #2198

### DIFF
--- a/packages/cactus-plugin-odap-hermes/knex/knex.js
+++ b/packages/cactus-plugin-odap-hermes/knex/knex.js
@@ -1,4 +1,0 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const environment = process.env.ENVIRONMENT || "development";
-const config = require("../knexfile.js")[environment];
-module.exports = require("knex")(config);

--- a/packages/cactus-plugin-odap-hermes/src/main/typescript/gateway/besu-odap-gateway.ts
+++ b/packages/cactus-plugin-odap-hermes/src/main/typescript/gateway/besu-odap-gateway.ts
@@ -45,6 +45,7 @@ export class BesuOdapGateway extends PluginOdapGateway {
       ipfsPath: options.ipfsPath,
       clientHelper: options.clientHelper,
       serverHelper: options.serverHelper,
+      knexConfig: options.knexConfig,
     });
 
     if (options.besuPath != undefined) this.defineBesuConnection(options);

--- a/packages/cactus-plugin-odap-hermes/src/main/typescript/gateway/fabric-odap-gateway.ts
+++ b/packages/cactus-plugin-odap-hermes/src/main/typescript/gateway/fabric-odap-gateway.ts
@@ -44,6 +44,7 @@ export class FabricOdapGateway extends PluginOdapGateway {
       ipfsPath: options.ipfsPath,
       clientHelper: options.clientHelper,
       serverHelper: options.serverHelper,
+      knexConfig: options.knexConfig,
     });
 
     if (options.fabricPath != undefined) this.defineFabricConnection(options);

--- a/packages/cactus-plugin-odap-hermes/src/main/typescript/gateway/plugin-odap-gateway.ts
+++ b/packages/cactus-plugin-odap-hermes/src/main/typescript/gateway/plugin-odap-gateway.ts
@@ -114,6 +114,7 @@ export interface IPluginOdapGatewayConstructorOptions {
   ipfsPath?: string;
   clientHelper: ClientGatewayHelper;
   serverHelper: ServerGatewayHelper;
+  knexConfig?: Knex.Config;
 }
 export interface IOdapPluginKeyPair {
   publicKey: Uint8Array;
@@ -185,16 +186,16 @@ export abstract class PluginOdapGateway
 
     if (options.ipfsPath != undefined) this.defineIpfsConnection(options);
 
-    this.defineKnexConnection();
+    this.defineKnexConnection(options.knexConfig);
   }
 
-  public defineKnexConnection(): void {
+  public defineKnexConnection(config: Knex.Config | undefined): void {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const config = require("../../../../knex/knexfile.ts")[
+    const configFile = require("../../../../knex/knexfile.ts")[
       process.env.ENVIRONMENT || "development"
     ];
 
-    this.database = knex(config);
+    this.database = knex(config || configFile);
   }
 
   private defineIpfsConnection(

--- a/packages/cactus-plugin-odap-hermes/src/test/typescript/integration/backup-gateway-after-client-crash.test.ts
+++ b/packages/cactus-plugin-odap-hermes/src/test/typescript/integration/backup-gateway-after-client-crash.test.ts
@@ -66,6 +66,9 @@ import {
 } from "../../../main/typescript/gateway/besu-odap-gateway";
 import { ClientGatewayHelper } from "../../../main/typescript/gateway/client/client-helper";
 import { ServerGatewayHelper } from "../../../main/typescript/gateway/server/server-helper";
+
+import { knexClientConnection, knexServerConnection } from "../knex.config";
+
 /**
  * Use this to debug issues with the fabric node SDK
  * ```sh
@@ -577,6 +580,7 @@ beforeAll(async () => {
       backupGatewaysAllowed: allowedGateways,
       clientHelper: new ClientGatewayHelper(),
       serverHelper: new ServerGatewayHelper(),
+      knexConfig: knexClientConnection,
     };
 
     odapServerGatewayPluginOptions = {
@@ -591,6 +595,7 @@ beforeAll(async () => {
       besuKeychainId: besuKeychainId,
       clientHelper: new ClientGatewayHelper(),
       serverHelper: new ServerGatewayHelper(),
+      knexConfig: knexServerConnection,
     };
 
     pluginSourceGateway = new FabricOdapGateway(odapClientGatewayPluginOptions);
@@ -810,6 +815,7 @@ test("client gateway crashes after lock fabric asset", async () => {
     fabricContractName: fabricContractName,
     clientHelper: new ClientGatewayHelper(),
     serverHelper: new ServerGatewayHelper(),
+    knexConfig: knexClientConnection,
   };
 
   pluginSourceGateway = new FabricOdapGateway(odapClientGatewayPluginOptions);

--- a/packages/cactus-plugin-odap-hermes/src/test/typescript/integration/client-crash-after-delete-asset.test.ts
+++ b/packages/cactus-plugin-odap-hermes/src/test/typescript/integration/client-crash-after-delete-asset.test.ts
@@ -65,6 +65,9 @@ import {
 } from "../../../main/typescript/gateway/besu-odap-gateway";
 import { ClientGatewayHelper } from "../../../main/typescript/gateway/client/client-helper";
 import { ServerGatewayHelper } from "../../../main/typescript/gateway/server/server-helper";
+
+import { knexClientConnection, knexServerConnection } from "../knex.config";
+
 /**
  * Use this to debug issues with the fabric node SDK
  * ```sh
@@ -567,6 +570,7 @@ beforeAll(async () => {
       fabricContractName: fabricContractName,
       clientHelper: new ClientGatewayHelper(),
       serverHelper: new ServerGatewayHelper(),
+      knexConfig: knexServerConnection,
     };
 
     odapServerGatewayPluginOptions = {
@@ -581,6 +585,7 @@ beforeAll(async () => {
       besuKeychainId: besuKeychainId,
       clientHelper: new ClientGatewayHelper(),
       serverHelper: new ServerGatewayHelper(),
+      knexConfig: knexClientConnection,
     };
 
     pluginSourceGateway = new FabricOdapGateway(odapClientGatewayPluginOptions);

--- a/packages/cactus-plugin-odap-hermes/src/test/typescript/integration/client-crash-after-lock-asset.test.ts
+++ b/packages/cactus-plugin-odap-hermes/src/test/typescript/integration/client-crash-after-lock-asset.test.ts
@@ -65,6 +65,9 @@ import {
 } from "../../../main/typescript/gateway/fabric-odap-gateway";
 import { ClientGatewayHelper } from "../../../main/typescript/gateway/client/client-helper";
 import { ServerGatewayHelper } from "../../../main/typescript/gateway/server/server-helper";
+
+import { knexClientConnection, knexServerConnection } from "../knex.config";
+
 /**
  * Use this to debug issues with the fabric node SDK
  * ```sh
@@ -568,6 +571,7 @@ beforeAll(async () => {
       fabricContractName: fabricContractName,
       clientHelper: new ClientGatewayHelper(),
       serverHelper: new ServerGatewayHelper(),
+      knexConfig: knexServerConnection,
     };
 
     odapServerGatewayPluginOptions = {
@@ -582,6 +586,7 @@ beforeAll(async () => {
       besuKeychainId: besuKeychainId,
       clientHelper: new ClientGatewayHelper(),
       serverHelper: new ServerGatewayHelper(),
+      knexConfig: knexClientConnection,
     };
 
     pluginSourceGateway = new FabricOdapGateway(odapClientGatewayPluginOptions);

--- a/packages/cactus-plugin-odap-hermes/src/test/typescript/integration/client-crash-after-transfer-initiation.test.ts
+++ b/packages/cactus-plugin-odap-hermes/src/test/typescript/integration/client-crash-after-transfer-initiation.test.ts
@@ -30,6 +30,8 @@ import { FabricOdapGateway } from "../../../main/typescript/gateway/fabric-odap-
 import { ServerGatewayHelper } from "../../../main/typescript/gateway/server/server-helper";
 import { ClientGatewayHelper } from "../../../main/typescript/gateway/client/client-helper";
 
+import { knexClientConnection, knexServerConnection } from "../knex.config";
+
 const MAX_RETRIES = 5;
 const MAX_TIMEOUT = 5000;
 
@@ -116,6 +118,7 @@ beforeAll(async () => {
       keyPair: Secp256k1Keys.generateKeyPairsBuffer(),
       clientHelper: new ClientGatewayHelper(),
       serverHelper: new ServerGatewayHelper(),
+      knexConfig: knexServerConnection,
     };
 
     serverExpressApp = express();
@@ -155,6 +158,7 @@ beforeAll(async () => {
       keyPair: Secp256k1Keys.generateKeyPairsBuffer(),
       clientHelper: new ClientGatewayHelper(),
       serverHelper: new ServerGatewayHelper(),
+      knexConfig: knexClientConnection,
     };
 
     clientExpressApp = express();

--- a/packages/cactus-plugin-odap-hermes/src/test/typescript/integration/server-crash-after-create-asset.test.ts
+++ b/packages/cactus-plugin-odap-hermes/src/test/typescript/integration/server-crash-after-create-asset.test.ts
@@ -65,6 +65,9 @@ import {
 } from "../../../main/typescript/gateway/fabric-odap-gateway";
 import { ClientGatewayHelper } from "../../../main/typescript/gateway/client/client-helper";
 import { ServerGatewayHelper } from "../../../main/typescript/gateway/server/server-helper";
+
+import { knexClientConnection, knexServerConnection } from "../knex.config";
+
 /**
  * Use this to debug issues with the fabric node SDK
  * ```sh
@@ -568,6 +571,7 @@ beforeEach(async () => {
       fabricContractName: fabricContractName,
       clientHelper: new ClientGatewayHelper(),
       serverHelper: new ServerGatewayHelper(),
+      knexConfig: knexClientConnection,
     };
 
     odapServerGatewayPluginOptions = {
@@ -582,6 +586,7 @@ beforeEach(async () => {
       besuKeychainId: besuKeychainId,
       clientHelper: new ClientGatewayHelper(),
       serverHelper: new ServerGatewayHelper(),
+      knexConfig: knexServerConnection,
     };
 
     pluginSourceGateway = new FabricOdapGateway(odapClientGatewayPluginOptions);

--- a/packages/cactus-plugin-odap-hermes/src/test/typescript/integration/server-crash-after-transfer-initiation.test.ts
+++ b/packages/cactus-plugin-odap-hermes/src/test/typescript/integration/server-crash-after-transfer-initiation.test.ts
@@ -31,6 +31,8 @@ import {
 import { ClientGatewayHelper } from "../../../main/typescript/gateway/client/client-helper";
 import { ServerGatewayHelper } from "../../../main/typescript/gateway/server/server-helper";
 
+import { knexClientConnection } from "../knex.config";
+
 const MAX_RETRIES = 5;
 const MAX_TIMEOUT = 5000;
 
@@ -155,6 +157,7 @@ beforeAll(async () => {
       keyPair: Secp256k1Keys.generateKeyPairsBuffer(),
       clientHelper: new ClientGatewayHelper(),
       serverHelper: new ServerGatewayHelper(),
+      knexConfig: knexClientConnection,
     };
 
     clientExpressApp = express();

--- a/packages/cactus-plugin-odap-hermes/src/test/typescript/unit/recovery/logging.test.ts
+++ b/packages/cactus-plugin-odap-hermes/src/test/typescript/unit/recovery/logging.test.ts
@@ -33,6 +33,8 @@ import {
 import { ClientGatewayHelper } from "../../../../main/typescript/gateway/client/client-helper";
 import { ServerGatewayHelper } from "../../../../main/typescript/gateway/server/server-helper";
 
+import { knexClientConnection, knexServerConnection } from "../../knex.config";
+
 const logLevel: LogLevelDesc = "TRACE";
 
 let sourceGatewayConstructor: IFabricOdapGatewayConstructorOptions;
@@ -107,6 +109,7 @@ beforeAll(async () => {
     keyPair: Secp256k1Keys.generateKeyPairsBuffer(),
     clientHelper: new ClientGatewayHelper(),
     serverHelper: new ServerGatewayHelper(),
+    knexConfig: knexClientConnection,
   };
   recipientGatewayConstructor = {
     name: "plugin-odap-gateway#recipientGateway",
@@ -115,6 +118,7 @@ beforeAll(async () => {
     ipfsPath: ipfsApiHost,
     clientHelper: new ClientGatewayHelper(),
     serverHelper: new ServerGatewayHelper(),
+    knexConfig: knexServerConnection,
   };
 });
 

--- a/packages/cactus-plugin-odap-hermes/src/test/typescript/unit/recovery/recover-success.test.ts
+++ b/packages/cactus-plugin-odap-hermes/src/test/typescript/unit/recovery/recover-success.test.ts
@@ -27,6 +27,8 @@ import { FabricOdapGateway } from "../../../../main/typescript/gateway/fabric-od
 import { ClientGatewayHelper } from "../../../../main/typescript/gateway/client/client-helper";
 import { ServerGatewayHelper } from "../../../../main/typescript/gateway/server/server-helper";
 
+import { knexClientConnection, knexServerConnection } from "../../knex.config";
+
 const logLevel: LogLevelDesc = "TRACE";
 
 let pluginSourceGateway: PluginOdapGateway;
@@ -92,6 +94,7 @@ beforeEach(async () => {
     ipfsPath: ipfsApiHost,
     clientHelper: new ClientGatewayHelper(),
     serverHelper: new ServerGatewayHelper(),
+    knexConfig: knexClientConnection,
   };
   const recipientGatewayConstructor = {
     name: "plugin-odap-gateway#recipientGateway",
@@ -100,6 +103,7 @@ beforeEach(async () => {
     ipfsPath: ipfsApiHost,
     clientHelper: new ClientGatewayHelper(),
     serverHelper: new ServerGatewayHelper(),
+    knexConfig: knexServerConnection,
   };
 
   pluginSourceGateway = new FabricOdapGateway(sourceGatewayConstructor);

--- a/packages/cactus-plugin-odap-hermes/src/test/typescript/unit/recovery/recover-update-ack.test.ts
+++ b/packages/cactus-plugin-odap-hermes/src/test/typescript/unit/recovery/recover-update-ack.test.ts
@@ -27,6 +27,8 @@ import { FabricOdapGateway } from "../../../../main/typescript/gateway/fabric-od
 import { ClientGatewayHelper } from "../../../../main/typescript/gateway/client/client-helper";
 import { ServerGatewayHelper } from "../../../../main/typescript/gateway/server/server-helper";
 
+import { knexClientConnection, knexServerConnection } from "../../knex.config";
+
 const logLevel: LogLevelDesc = "TRACE";
 
 let pluginSourceGateway: PluginOdapGateway;
@@ -92,6 +94,7 @@ beforeEach(async () => {
     ipfsPath: ipfsApiHost,
     clientHelper: new ClientGatewayHelper(),
     serverHelper: new ServerGatewayHelper(),
+    knexConfig: knexClientConnection,
   };
   const recipientGatewayConstructor = {
     name: "plugin-odap-gateway#recipientGateway",
@@ -99,6 +102,7 @@ beforeEach(async () => {
     instanceId: uuidV4(),
     clientHelper: new ClientGatewayHelper(),
     serverHelper: new ServerGatewayHelper(),
+    knexConfig: knexServerConnection,
   };
 
   pluginSourceGateway = new FabricOdapGateway(sourceGatewayConstructor);

--- a/packages/cactus-plugin-odap-hermes/src/test/typescript/unit/recovery/recover-update.test.ts
+++ b/packages/cactus-plugin-odap-hermes/src/test/typescript/unit/recovery/recover-update.test.ts
@@ -35,6 +35,8 @@ import { FabricOdapGateway } from "../../../../main/typescript/gateway/fabric-od
 import { ClientGatewayHelper } from "../../../../main/typescript/gateway/client/client-helper";
 import { ServerGatewayHelper } from "../../../../main/typescript/gateway/server/server-helper";
 
+import { knexClientConnection, knexServerConnection } from "../../knex.config";
+
 const logLevel: LogLevelDesc = "TRACE";
 
 const MAX_RETRIES = 5;
@@ -104,6 +106,7 @@ beforeEach(async () => {
     keyPair: Secp256k1Keys.generateKeyPairsBuffer(),
     clientHelper: new ClientGatewayHelper(),
     serverHelper: new ServerGatewayHelper(),
+    knexConfig: knexClientConnection,
   };
   const recipientGatewayConstructor = {
     name: "plugin-odap-gateway#recipientGateway",
@@ -113,6 +116,7 @@ beforeEach(async () => {
     keyPair: Secp256k1Keys.generateKeyPairsBuffer(),
     clientHelper: new ClientGatewayHelper(),
     serverHelper: new ServerGatewayHelper(),
+    knexConfig: knexServerConnection,
   };
 
   pluginSourceGateway = new FabricOdapGateway(sourceGatewayConstructor);
@@ -201,9 +205,8 @@ test("check valid built of recover update message", async () => {
     data: JSON.stringify(sessionData),
   };
 
-  new Promise((resolve) => setTimeout(resolve, 1000));
   const firstTimestamp = Date.now().toString();
-  new Promise((resolve) => setTimeout(resolve, 1000));
+  await new Promise((resolve) => setTimeout(resolve, 5000));
 
   await pluginSourceGateway.storeOdapLog(odapLog1);
 
@@ -260,6 +263,7 @@ test("check valid built of recover update message", async () => {
     throw new Error("Test Failed");
   }
 
+  console.log(recoverUpdateMessage.recoveredLogs);
   expect(recoverUpdateMessage.recoveredLogs.length).toBe(3);
 
   await checkValidRecoverUpdateMessage(

--- a/packages/cactus-plugin-odap-hermes/src/test/typescript/unit/recovery/recover.test.ts
+++ b/packages/cactus-plugin-odap-hermes/src/test/typescript/unit/recovery/recover.test.ts
@@ -29,6 +29,8 @@ import { FabricOdapGateway } from "../../../../main/typescript/gateway/fabric-od
 import { ClientGatewayHelper } from "../../../../main/typescript/gateway/client/client-helper";
 import { ServerGatewayHelper } from "../../../../main/typescript/gateway/server/server-helper";
 
+import { knexClientConnection, knexServerConnection } from "../../knex.config";
+
 const logLevel: LogLevelDesc = "TRACE";
 
 let sourceGatewayConstructor: IPluginOdapGatewayConstructorOptions;
@@ -94,6 +96,7 @@ beforeAll(async () => {
     keyPair: Secp256k1Keys.generateKeyPairsBuffer(),
     clientHelper: new ClientGatewayHelper(),
     serverHelper: new ServerGatewayHelper(),
+    knexConfig: knexClientConnection,
   };
   recipientGatewayConstructor = {
     name: "plugin-odap-gateway#recipientGateway",
@@ -103,6 +106,7 @@ beforeAll(async () => {
     keyPair: Secp256k1Keys.generateKeyPairsBuffer(),
     clientHelper: new ClientGatewayHelper(),
     serverHelper: new ServerGatewayHelper(),
+    knexConfig: knexServerConnection,
   };
 });
 


### PR DESCRIPTION
Two gateways were using the same database, which was causing a test to fail.

When retrieving the logs since a certain timestamp, there were logs from the other gateway. This caused the number of logs retrieved to be higher than what was supposed to be.

Fixes #2198

Signed-off-by: André Augusto [andre.augusto@tecnico.ulisboa.pt](mailto:andre.augusto@tecnico.ulisboa.pt)