### PR TITLE
fix(test-tooling): substrate test ledger fails if WS_PORT not specified

### DIFF
--- a/packages/cactus-test-tooling/src/main/typescript/substrate-test-ledger/substrate-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/substrate-test-ledger/substrate-test-ledger.ts
@@ -93,7 +93,7 @@ export class SubstrateTestLedger {
       (pairs) => `${pairs[0]}=${pairs[1]}`,
     );
 
-    const wsPort = this.envVars.get("WS_PORT") ?? 9944;
+    const wsPort: string = this.envVars.get("WS_PORT") ?? "9944";
     const portToExpose = `${wsPort}/tcp`;
 
     // TODO: dynamically expose ports for custom port mapping


### PR DESCRIPTION
Docker expects environment variables passed to the container
to be strings.
The null coalescing code was making it so that if the test case
did not pass in a custom WS_PORT  env var, then it would default
to using a value for the port that was a number not a string.
This would crash the serialization logic within docker that was
trying to apply the environment variables to the container when
starting it.

Switching the type of 9944 default WS port to "9944" (string) fixes it.
Also specifying explicitly the `wsPort` variable's type to be
string so that the next time someone tries to make this mistake
the compiler will slap their hands right away.

Fixes #2213

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>