### PR TITLE
test(connector-go-ethereum-socketio): enable nullish coalescing checks

### DIFF
--- a/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/main/typescript/common/core/bin/www.ts
+++ b/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/main/typescript/common/core/bin/www.ts
@@ -251,11 +251,8 @@ export async function startGoEthereumSocketIOConnector() {
     /**
      * startMonitor: starting block generation event monitoring
      **/
-    client.on("startMonitor", function (monitorOptions) {
-
-      monitorOptions = monitorOptions ?? {allBlocks: false};
-      logger.debug("monitorOptions", monitorOptions);
-      Smonitor.startMonitor(client.id, monitorOptions.allBlocks, (event) => {
+    client.on("startMonitor", function (monitorOptions?: any) {
+      Smonitor.startMonitor(client.id,  monitorOptions?.allBlocks ?? false, (event) => {
         let emitType = "";
         if (event.status == 200) {
           emitType = "eventReceived";

--- a/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/integration/go-ethereum-socketio-connector.test.ts
+++ b/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/integration/go-ethereum-socketio-connector.test.ts
@@ -377,7 +377,7 @@ describe("Go-Ethereum-SocketIO connector tests", () => {
   /**
    * Test ServerMonitorPlugin startMonitor/stopMonitor functions.
    */
-  test.only(
+  test(
     "Monitoring returns new block",
     async () => {
       // Create monitoring promise and subscription


### PR DESCRIPTION
Test file was only testing monitor. Added nullish coalescing in monitor.

Signed-off-by: tomasz awramski <tomasz.awramski@fujitsu.com>