### PR TITLE
build(yarn): specify packageManager in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
       "**/iroha-helpers"
     ]
   },
+  "packageManager": "yarn@1.22.17",
   "scripts": {
     "run-ci": "./tools/ci.sh",
     "reset:node-modules": "del-cli '**/node_modules'",


### PR DESCRIPTION
There is a new method of specifying the package manager from Node v16 and
up.
The promise of this is that the package manager can be automatically
made available to project builds via this declarative property of the
package.json file without forcing contributors to manually deal with
installation of custom package managers such as yarn (which we use) or
to manually switch the version of it used (which is also important to us
because we are still using the legacy version of yarn instead of v3 -
the latest at the time of this writing)

This task is about trying out this new property to see if it helps
lowering the bar of the initial project setup for new contributors.

Fixes #2267

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>