### PR TITLE
feat(ledger-browser): show fabric network structure

### DIFF
--- a/packages/cacti-ledger-browser/README.md
+++ b/packages/cacti-ledger-browser/README.md
@@ -1,6 +1,6 @@
 # `@hyperledger/cacti-ledger-browser`
 
-This component allows viewing ledger data in Supabase or other postgreSQL compatible database. The data is fed to supabase by persistence plugins for each ledgers.
+This component allows viewing ledger data in Supabase or other PostgreSQL compatible database. The data is fed to supabase by persistence plugins for each ledgers.
 
 ## Summary
 
@@ -8,9 +8,6 @@ This component allows viewing ledger data in Supabase or other postgreSQL compat
   - [Summary](#summary)
   - [Remarks](#remarks)
   - [Getting Started](#getting-started)
-    - [Prerequisites using yarn](#prerequisites-using-yarn)
-    - [Alternative Prerequisites using npm](#alternative-prerequisites-using-npm)
-    - [Usage](#usage)
   - [Contributing](#contributing)
   - [License](#license)
   - [Acknowledgments](#acknowledgments)
@@ -22,35 +19,9 @@ This component allows viewing ledger data in Supabase or other postgreSQL compat
 
 ## Getting Started
 
-Clone the git repository on your local machine. Follow these instructions that will get you a copy of the project up and running on your local machine for development and testing purposes.
+Clone the git repository on your local machine.
 
-### Prerequisites using yarn
-
-In the root of the project, execute the command to install and build the dependencies. It will also build this GUI front-end component:
-
-```sh
-yarn run build
-```
-
-### Alternative Prerequisites using npm
-
-In the root of the project, execute the command to install and build the dependencies. It will also build this GUI front-end component:
-
-```sh
-npm install
-```
-
-### Usage
-
-- Run Supabase instance (see documentation for detailed instructions). For development purposes, you can use our image located in `tools/docker/supabase-all-in-one`.
-- Run one or more persistence plugins:
-  - [Ethereum](../cacti-plugin-persistence-ethereum)
-  - [Fabric] (../cacti-plugin-persistence-fabric)
-- Edit Supabase configuration files, set correct supabase API URL and service_role key.
-  - ./src/main/typescript/common/supabase-client.tsx
-  - ./src/main/typescript/common/queries.ts
-- Execute `yarn run start` or `npm start` in this package directory.
-- The running application address: http://localhost:3001/ (can be changed in [Vite configuration](./vite.config.ts))
+See [docs/docs/cactus/ledger-browser/setup.md](../../docs/docs/cactus/ledger-browser/setup.md) for detailed information on how to setup and use this package.
 
 ## Contributing
 

--- a/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/index.tsx
+++ b/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/index.tsx
@@ -4,6 +4,7 @@ import Dashboard from "./pages/Dashboard/Dashboard";
 import Blocks from "./pages/Blocks/Blocks";
 import Transactions from "./pages/Transactions/Transactions";
 import TransactionDetails from "./pages/TransactionDetails/TransactionDetails";
+import Discovery from "./pages/Discovery/Discovery";
 import {
   AppInstancePersistencePluginOptions,
   AppDefinition,
@@ -58,10 +59,18 @@ const fabricBrowserAppDefinition: AppDefinition = {
           title: "Dashboard",
           url: "/",
         },
+        {
+          title: "Discovery",
+          url: "/discovery",
+        },
       ],
       routes: [
         {
           element: <Dashboard />,
+        },
+        {
+          path: "discovery",
+          element: <Discovery />,
         },
         {
           path: "blocks",

--- a/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/pages/Discovery/Discovery.tsx
+++ b/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/pages/Discovery/Discovery.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+import List from "@mui/material/List/List";
+import ListItem from "@mui/material/ListItem/ListItem";
+import ListItemButton from "@mui/material/ListItemButton/ListItemButton";
+import ListItemText from "@mui/material/ListItemText/ListItemText";
+import DoubleArrowIcon from "@mui/icons-material/DoubleArrow";
+import ListItemIcon from "@mui/material/ListItemIcon/ListItemIcon";
+import CircularProgress from "@mui/material/CircularProgress/CircularProgress";
+import Divider from "@mui/material/Divider/Divider";
+
+import { DiscoveryMSP } from "../../supabase-types";
+import PageTitle from "../../../../components/ui/PageTitle";
+import { useNotification } from "../../../../common/context/NotificationContext";
+import { fabricDiscoveryMSPs } from "../../queries";
+import DiscoveryDetails from "./DiscoveryDetails";
+
+function Discovery() {
+  const { showNotification } = useNotification();
+  const [selectedMSP, setSelectedMSP] = React.useState<
+    DiscoveryMSP | undefined
+  >(undefined);
+  const { isError, isPending, data, error } = useQuery(fabricDiscoveryMSPs());
+
+  React.useEffect(() => {
+    isError &&
+      showNotification(`Could not fetch discovery MSPs: ${error}`, "error");
+  }, [isError]);
+
+  const msps = data ?? [];
+
+  return (
+    <Box>
+      <PageTitle>Discovery</PageTitle>
+
+      <Box display="flex" gap="2rem">
+        <Box flexGrow={1} maxWidth="300px">
+          <Typography variant="h5" marginTop="2rem">
+            Select MSP
+          </Typography>
+          <Box>
+            {isPending && (
+              <Box
+                paddingY="1em"
+                sx={{
+                  display: "flex",
+                  justifyContent: "center",
+                  width: "100%",
+                }}
+              >
+                <CircularProgress />
+              </Box>
+            )}
+          </Box>
+
+          {msps && (
+            <List>
+              {msps.map((msp) => (
+                <ListItem disablePadding key={msp.id}>
+                  <ListItemButton
+                    onClick={() => setSelectedMSP(msp)}
+                    selected={msp.id === (selectedMSP?.id ?? "")}
+                    sx={(theme) => ({
+                      "&.Mui-selected": {
+                        backgroundColor: theme.palette.primary.main,
+                        color: "white",
+                      },
+                    })}
+                  >
+                    <ListItemIcon>
+                      <DoubleArrowIcon />
+                    </ListItemIcon>
+                    <ListItemText primary={msp.name} />
+                  </ListItemButton>
+                </ListItem>
+              ))}
+            </List>
+          )}
+        </Box>
+
+        <Divider orientation="vertical" flexItem />
+
+        <Box flexGrow={7}>{<DiscoveryDetails msp={selectedMSP} />}</Box>
+      </Box>
+    </Box>
+  );
+}
+
+export default Discovery;

--- a/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/pages/Discovery/DiscoveryDetails.tsx
+++ b/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/pages/Discovery/DiscoveryDetails.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography/Typography";
+import Card from "@mui/material/Card/Card";
+import CardContent from "@mui/material/CardContent/CardContent";
+import List from "@mui/material/List/List";
+import ListItem from "@mui/material/ListItem/ListItem";
+import ListItemText from "@mui/material/ListItemText/ListItemText";
+import CircularProgress from "@mui/material/CircularProgress/CircularProgress";
+
+import { useNotification } from "../../../../common/context/NotificationContext";
+import { fabricDiscoveryNodes } from "../../queries";
+import { DiscoveryMSP } from "../../supabase-types";
+import PeerCardButton from "./PeerCardButton";
+import OrdererCardButton from "./OrdererCardButton";
+
+function NothingSelectedMessage() {
+  return (
+    <Box display="flex" alignItems="center" sx={{ height: "100%" }}>
+      <Typography>
+        Select MSP on the left to display ledger components.
+      </Typography>
+    </Box>
+  );
+}
+
+function LoadingSpinner() {
+  return (
+    <Box display="flex" alignItems="center" sx={{ height: "100%" }}>
+      <CircularProgress />
+    </Box>
+  );
+}
+
+interface DiscoveryDetailsProps {
+  msp: DiscoveryMSP | undefined;
+}
+
+function DiscoveryDetails({ msp }: DiscoveryDetailsProps) {
+  const { showNotification } = useNotification();
+  const { isError, isPending, data, error } = useQuery(
+    fabricDiscoveryNodes(msp?.id),
+  );
+  React.useEffect(() => {
+    isError &&
+      showNotification(
+        `Could not fetch ledger components for MSP ${msp?.name ?? "(Unknown)"}: ${error}`,
+        "error",
+      );
+  }, [isError]);
+
+  if (!msp) {
+    return <NothingSelectedMessage />;
+  }
+
+  if (isPending) {
+    return <LoadingSpinner />;
+  }
+
+  const mspOUString = JSON.parse(msp.organizational_unit_identifiers).join(
+    ", ",
+  );
+
+  const peers = data?.peers ?? [];
+  const orderers = data?.orderers ?? [];
+
+  return (
+    <Box>
+      <Card sx={{ width: "50%" }} variant="outlined">
+        <CardContent>
+          <Typography variant="h6">
+            {msp.name} ({msp.mspid})
+          </Typography>
+          <List dense disablePadding>
+            <ListItem>
+              <ListItemText
+                primary={mspOUString ? mspOUString : "-"}
+                secondary={"Organizational Units"}
+              />
+            </ListItem>
+            <ListItem>
+              <ListItemText
+                primary={msp.admins ? msp.admins : "-"}
+                secondary={"Admins"}
+              />
+            </ListItem>
+          </List>
+        </CardContent>
+      </Card>
+
+      <Typography variant="h6" marginY="1em">
+        Peers
+      </Typography>
+      <Box
+        display="grid"
+        gap="2rem"
+        gridTemplateColumns="repeat(auto-fit, minmax(300px, 400px))"
+      >
+        {peers.map((p) => (
+          <PeerCardButton key={p.id} peer={p} />
+        ))}
+        {peers.length === 0 && (
+          <Typography>No peers defined for this MSP</Typography>
+        )}
+      </Box>
+
+      <Typography variant="h6" marginY="1em">
+        Orderers
+      </Typography>
+      <Box
+        display="grid"
+        gap="2rem"
+        gridTemplateColumns="repeat(auto-fit, minmax(300px, 400px))"
+      >
+        {orderers.map((o) => (
+          <OrdererCardButton key={o.id} orderer={o} />
+        ))}
+        {orderers.length === 0 && (
+          <Typography>No orderers defined for this MSP</Typography>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+export default DiscoveryDetails;

--- a/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/pages/Discovery/OrdererCardButton.tsx
+++ b/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/pages/Discovery/OrdererCardButton.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+
+import OrdererDetailsBox from "./OrdererDetailsBox";
+import { DiscoveryOrderer } from "../../supabase-types";
+
+interface OrdererCardButtonProps {
+  orderer: DiscoveryOrderer;
+}
+
+export default function OrdererCardButton({ orderer }: OrdererCardButtonProps) {
+  const [openDialog, setOpenDialog] = React.useState(false);
+
+  return (
+    <>
+      <Button
+        style={{ textTransform: "none" }}
+        variant="outlined"
+        onClick={() => setOpenDialog(true)}
+      >
+        {orderer.name}
+      </Button>
+      <Dialog
+        fullWidth
+        maxWidth="sm"
+        onClose={() => setOpenDialog(false)}
+        open={openDialog}
+      >
+        <DialogTitle color="primary">Orderer Details</DialogTitle>
+        <DialogContent>
+          <OrdererDetailsBox orderer={orderer} />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/pages/Discovery/OrdererDetailsBox.tsx
+++ b/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/pages/Discovery/OrdererDetailsBox.tsx
@@ -1,0 +1,33 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import { styled } from "@mui/material/styles";
+import { DiscoveryOrderer } from "../../supabase-types";
+import StackedRowItems from "../../../../components/ui/StackedRowItems";
+
+const ListHeaderTypography = styled(Typography)(({ theme }) => ({
+  color: theme.palette.secondary.main,
+  fontWeight: "bold",
+}));
+
+export interface OrdererDetailsBoxProps {
+  orderer: DiscoveryOrderer;
+}
+
+export default function OrdererDetailsBox({ orderer }: OrdererDetailsBoxProps) {
+  return (
+    <Box>
+      <StackedRowItems>
+        <ListHeaderTypography>Name:</ListHeaderTypography>
+        <Typography>{orderer.name}</Typography>
+      </StackedRowItems>
+      <StackedRowItems>
+        <ListHeaderTypography>Host:</ListHeaderTypography>
+        <Typography>{orderer.host}</Typography>
+      </StackedRowItems>
+      <StackedRowItems>
+        <ListHeaderTypography>Port:</ListHeaderTypography>
+        <Typography>{orderer.port}</Typography>
+      </StackedRowItems>
+    </Box>
+  );
+}

--- a/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/pages/Discovery/PeerCardButton.tsx
+++ b/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/pages/Discovery/PeerCardButton.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+
+import PeerDetailsBox from "./PeerDetailsBox";
+import { DiscoveryPeer } from "../../supabase-types";
+
+interface PeerCardButtonProps {
+  peer: DiscoveryPeer;
+}
+
+export default function PeerCardButton({ peer }: PeerCardButtonProps) {
+  const [openDialog, setOpenDialog] = React.useState(false);
+
+  return (
+    <>
+      <Button
+        style={{ textTransform: "none" }}
+        variant="outlined"
+        onClick={() => setOpenDialog(true)}
+      >
+        {peer.name}
+      </Button>
+      <Dialog
+        fullWidth
+        maxWidth="sm"
+        onClose={() => setOpenDialog(false)}
+        open={openDialog}
+      >
+        <DialogTitle color="primary">Peer Details</DialogTitle>
+        <DialogContent>
+          <PeerDetailsBox peer={peer} />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/pages/Discovery/PeerDetailsBox.tsx
+++ b/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/pages/Discovery/PeerDetailsBox.tsx
@@ -1,0 +1,57 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import List from "@mui/material/List/List";
+import ListItem from "@mui/material/ListItem/ListItem";
+import ListItemText from "@mui/material/ListItemText/ListItemText";
+import { styled } from "@mui/material/styles";
+import { DiscoveryPeer, DiscoveryPeerChaincodes } from "../../supabase-types";
+import StackedRowItems from "../../../../components/ui/StackedRowItems";
+
+const ListHeaderTypography = styled(Typography)(({ theme }) => ({
+  color: theme.palette.secondary.main,
+  fontWeight: "bold",
+}));
+
+export interface PeerDetailsBoxProps {
+  peer: DiscoveryPeer;
+}
+
+export default function PeerDetailsBox({ peer }: PeerDetailsBoxProps) {
+  const parsedChaincodes: DiscoveryPeerChaincodes[] = JSON.parse(
+    peer.chaincodes,
+  );
+
+  return (
+    <Box>
+      <StackedRowItems>
+        <ListHeaderTypography>Name:</ListHeaderTypography>
+        <Typography>{peer.name}</Typography>
+      </StackedRowItems>
+      <StackedRowItems>
+        <ListHeaderTypography>Endpoint:</ListHeaderTypography>
+        <Typography>{peer.endpoint}</Typography>
+      </StackedRowItems>
+      <StackedRowItems>
+        <ListHeaderTypography>Ledger Height:</ListHeaderTypography>
+        <Typography>{peer.ledger_height}</Typography>
+      </StackedRowItems>
+
+      <ListHeaderTypography sx={{ marginTop: "2em", color: "primary.main" }}>
+        Chaincodes
+      </ListHeaderTypography>
+      <List dense disablePadding>
+        {parsedChaincodes.map((cc) => {
+          return (
+            <ListItem key={cc.name}>
+              <ListItemText
+                primaryTypographyProps={{ fontSize: "1em" }}
+                primary={cc.name}
+                secondary={`Version ${cc.version}`}
+              />
+            </ListItem>
+          );
+        })}
+      </List>
+    </Box>
+  );
+}

--- a/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/supabase-types.ts
+++ b/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/supabase-types.ts
@@ -55,3 +55,33 @@ export interface FabricCertificate {
   valid_from: string;
   valid_to: string;
 }
+
+export interface DiscoveryMSP {
+  id: string;
+  mspid: string;
+  name: string;
+  organizational_unit_identifiers: string;
+  admins: string;
+}
+
+export interface DiscoveryPeer {
+  id: string;
+  endpoint: string;
+  name: string;
+  chaincodes: string;
+  ledger_height: number;
+  discovery_msp_id: string;
+}
+
+export interface DiscoveryPeerChaincodes {
+  name: string;
+  version: string;
+}
+
+export interface DiscoveryOrderer {
+  id: string;
+  host: string;
+  name: string;
+  port: number;
+  discovery_msp_id: string;
+}

--- a/packages/cacti-ledger-browser/src/main/typescript/pages/home/AddApplicationPopupCard.tsx
+++ b/packages/cacti-ledger-browser/src/main/typescript/pages/home/AddApplicationPopupCard.tsx
@@ -63,7 +63,7 @@ export default function AddApplicationPopupCard() {
         sx={{
           display: "flex",
           flexDirection: "column",
-          width: 400,
+          width: "400px",
           minHeight: 250,
           backgroundColor: theme.palette.grey[100],
         }}

--- a/packages/cacti-ledger-browser/src/main/typescript/pages/home/AppCard.tsx
+++ b/packages/cacti-ledger-browser/src/main/typescript/pages/home/AppCard.tsx
@@ -122,7 +122,7 @@ export default function AppCard({ appConfig }: AppCardProps) {
       sx={{
         display: "flex",
         flexDirection: "column",
-        width: 400,
+        width: "400px",
       }}
     >
       <CardActionArea

--- a/packages/cacti-ledger-browser/src/main/typescript/pages/home/HomePage.tsx
+++ b/packages/cacti-ledger-browser/src/main/typescript/pages/home/HomePage.tsx
@@ -16,10 +16,10 @@ export default function HomePage({ appConfig }: HomePageProps) {
         Applications
       </Typography>
       <Box
-        display="flex"
-        flexWrap="wrap"
-        justifyContent="space-between"
-        gap={5}
+        display="grid"
+        gridTemplateColumns="repeat(auto-fit, 400px)"
+        justifyContent="center"
+        gap="2rem"
         padding={5}
       >
         <AddApplicationPopupCard />


### PR DESCRIPTION
feat(ledger-browser): show fabric network structure
  - Add `Discovery` tab to Fabric App for showing discovered
    fabric network components by MSP.
  - Update REAMDE.
  - Fix responsiveness of main App selection screen.
  
Depends on #3837

Closes #3554

Signed-off-by: Michal Bajer <michal.bajer@fujitsu.com>

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.