### PR TITLE
fix(ci): fix skip ci workflow in pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
         run: echo "${{ steps.lint-git-repo.outputs.lint-git-repo-response }}"
 
   check-ci-skip:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7


### PR DESCRIPTION
This PR fixes an error in the `check-ci-skip` job that occurred when the workflow was triggered by a push event (or any non-´pull_request´ event).
Previously, the job attempted to pass `${{ github.event.pull_request.url }}` to `ci-skip-for-maintainers.js` even when pull_request data was unavailable. This resulted in an invalid URL being constructed (undefined/commits) and caused the job to fail.

<img width="729" height="134" alt="Captura de ecrã 2025-08-11, às 14 22 23" src="https://github.com/user-attachments/assets/11ca572f-3d94-4b17-a1d1-4654d5c5592f" />

<img width="1291" height="839" alt="Captura de ecrã 2025-08-11, às 14 22 34" src="https://github.com/user-attachments/assets/ef3e53ef-47e1-4348-9ea1-06ac6d6aed5e" />



- Added an if: `github.event_name == 'pull_request'` condition to check-ci-skip so it only runs for PR events.

- Prevents the skip-ci script from being called with missing parameters.

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.