### PR TITLE
chore: added release script, fix npm registry URL

### DIFF
--- a/.github/workflows/all-nodejs-packages-publish.yaml
+++ b/.github/workflows/all-nodejs-packages-publish.yaml
@@ -89,7 +89,7 @@ jobs:
           always-auth: true
           node-version: ${{ env.NODEJS_VERSION }}
           registry-url: "https://npm.pkg.github.com/"
-          scope: "@hyperledger"
+          scope: "@{{ github.repository_owner }}"
 
       - run: cat /home/runner/work/_temp/.npmrc
 

--- a/RELEASE_MANAGEMENT.md
+++ b/RELEASE_MANAGEMENT.md
@@ -23,6 +23,26 @@ Hence the first step is to update (find and replace all) the document (no need t
 
 ### Do a find and replace all for the version: 1.1.3
 
+#### Single script
+
+* Make sure your clone has latest changes from `main` branch. (Make sure to not have any local changes.)
+```sh
+git pull origin main
+```
+
+* Run the release script with the version:
+```sh
+./tools/release.sh 1.1.3
+```
+This will update the versions, and create a release commit
+
+* Push the commit to github.
+```
+git push origin release-1.1.3
+```
+
+#### Manually
+
 ```sh
 git fetch --all
 git switch main
@@ -42,13 +62,14 @@ yarn build:dev
 
 - The `./tools/weaver-update-version.sh` automation script seems slightly buggy at the moment so you'll have to manually update `./weaver/core/relay/Cargo.toml` yourself. See this comment for an example: https://github.com/hyperledger-cacti/cacti/pull/3427#discussion_r1686850372
 
+### Points to Note:
 - Double check that all of the package dependencies were updated from the previous
 version to the new one because lerna usually fails to do that for `devDependency` parts
 of the package.json files so you have to do this manually with search and replace through
 the entire repository...
 
-The trick is to search for the previous release version within package.json 
-files or just search for "@hyperledger/cact*-*" within the package.json files. 
+* The trick is to search for the previous release version within package.json 
+files or just search for "@hyperledger/cact*-*" or "@hyperledger-cacti/cact*-*" within the package.json files. 
 
 With VSCode you can do a project wide search & replace where:
   1. Make sure that regex based replacing is enabled on the VSCode search UI (top right corner of the search panel)

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+if [ -z $1 ]; then
+    echo "Required: version as first argument as A.B.C, Exiting..."
+    exit 1
+fi
+
+VERSION=$1
+
+if [[ $VERSION =~ ^v ]]; then
+    VERSION="${VERSION#v}"
+fi
+
+echo "Release version: v$VERSION"
+
+function release() {
+    git checkout -b release-v$VERSION
+    if [ $? -ne 0 ]; then return 1; fi
+    yarn run configure
+    if [ $? -ne 0 ]; then return 1; fi
+    yarn lerna version $VERSION --ignore-scripts --conventional-commits --exact --git-remote upstream --message="chore(release): publish %s" --no-push --no-git-tag-version --no-ignore-changes
+    if [ $? -ne 0 ]; then return 1; fi
+    yarn tools:bump-openapi-spec-dep-versions --target-version=$VERSION
+    if [ $? -ne 0 ]; then return 1; fi
+    yarn codegen
+    if [ $? -ne 0 ]; then return 1; fi
+    yarn build:dev
+    if [ $? -ne 0 ]; then return 1; fi
+    ./tools/weaver-update-version.sh $VERSION .
+    if [ $? -ne 0 ]; then return 1; fi
+    ./tools/go-gen-checksum.sh $VERSION .
+    if [ $? -ne 0 ]; then return 1; fi
+    git add . && git commit -s -m "chore(release): publish v$VERSION"
+    return 0
+}
+
+release || (echo "Resetting all changes and switching to main" && git reset --hard HEAD && git checkout main && git branch -D release-v$VERSION)

--- a/tools/weaver-update-version.sh
+++ b/tools/weaver-update-version.sh
@@ -65,6 +65,7 @@ done
 ## Update Cargo.lock in relay
 pushd $ROOT_DIR/weaver/core/relay > /dev/null
 make build-local
+make protos
 popd > /dev/null
 
 # Dependencies


### PR DESCRIPTION
* Update the npm registry URL in publish CI to use `github.repository_owner` in place of hardcoded name to make it future proof.
* Fix a bug in `tools/weaver-update-version.sh` that used break Cargo.toml in relay.
* Added a release script to automate release process.

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.