### PR TITLE
ci: fix jar download

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -363,6 +363,31 @@ jobs:
         run: yarn cache clean && rm -rf node_modules && yarn install
 
       - run: ./tools/ci.sh
+
+      - name: Cache OpenAPI Generator JAR
+        id: cache-openapi-generator-jar
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules/@openapitools/openapi-generator-cli/versions/6.6.0.jar
+          key: openapi-generator-cli-${{ runner.os }}-6.6.0
+          restore-keys: |
+            openapi-generator-cli-${{ runner.os }}-
+      - name: Warmup
+        if: steps.cache-openapi-generator-jar.outputs.cache-hit != 'true'
+        run: yarn codegen:warmup-mkdir && yarn tools:download-file-to-disk --url=https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.6.0/openapi-generator-cli-6.6.0.jar --output-file-path=./node_modules/@openapitools/openapi-generator-cli/versions/6.6.0.jar
+
+      - name: Link OpenAPI Generator JAR into subpackages
+        run: |
+          for dir in packages/*/node_modules/@openapitools/openapi-generator-cli; do
+            if [ -d "$dir" ]; then
+              echo "Ensuring $dir/versions exists"
+              mkdir -p "$dir/versions"
+              echo "Linking cached jar into $dir/versions"
+              cp "node_modules/@openapitools/openapi-generator-cli/versions/6.6.0.jar" \
+                "$dir/versions/6.6.0.jar"
+            fi
+          done
       - run: git status --porcelain
       - run: git status --porcelain | wc -l
 


### PR DESCRIPTION
We are downloading the open api generator JAR
many times from the different jobs in the CI,
possibly triggering a rate limiter, and resulting
in failed jobs.

This substitutes: https://github.com/hyperledger-cacti/cacti/pull/4069

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.