### PR TITLE
fix(satp-hermes): fix inconsistencies for demo to work

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/examples/config/README.md
+++ b/packages/cactus-plugin-satp-hermes/src/examples/config/README.md
@@ -67,7 +67,7 @@ SATP configurations use the `bridgeConfig` section and include additional gatewa
 
 **Features**:
 - Gateway ID: mockID-1
-- Connected to HardhatTestNetwork1
+- Connected to EthereumLedgerTestNetwork1
 - Counter-party gateway configuration (Gateway 2)
 - Full cryptographic key pair configuration
 - Bridge configuration with claim format type 1
@@ -81,7 +81,7 @@ SATP configurations use the `bridgeConfig` section and include additional gatewa
 
 **Features**:
 - Gateway ID: mockID-2
-- Connected to HardhatTestNetwork2  
+- Connected to EthereumLedgerTestNetwork2  
 - Counter-party gateway configuration (Gateway 1)
 - Different cryptographic key pair from Gateway 1
 - Bridge configuration for the second network

--- a/packages/cactus-plugin-satp-hermes/src/examples/config/satp-gateway1-config.json
+++ b/packages/cactus-plugin-satp-hermes/src/examples/config/satp-gateway1-config.json
@@ -11,7 +11,7 @@
     ],
     "connectedDLTs": [
       {
-        "id": "HardhatTestNetwork1",
+        "id": "EthereumLedgerTestNetwork1",
         "ledgerType": "ETHEREUM"
       }
     ],
@@ -20,7 +20,10 @@
     "gatewayClientPort": 3011,
     "gatewayServerPort": 3010,
     "gatewayOapiPort": 4010,
-    "pubKey": "036256069f81bcaae52a64965b8add79521ee54cb2ad3d85de5250d78cf0fc171c"
+    "identificationCredential": {
+      "signingAlgorithm": "SECP256K1",
+      "pubKey": "036256069f81bcaae52a64965b8add79521ee54cb2ad3d85de5250d78cf0fc171c"
+    }
   },
   "logLevel": "TRACE",
   "counterPartyGateways": [
@@ -36,7 +39,7 @@
       ],
       "connectedDLTs": [
         {
-          "id": "HardhatTestNetwork2",
+          "id": "EthereumLedgerTestNetwork2",
           "ledgerType": "ETHEREUM"
         }
       ],
@@ -56,7 +59,7 @@
     "bridgeConfig": [
       {
         "networkIdentification": {
-          "id": "HardhatTestNetwork1",
+          "id": "EthereumLedgerTestNetwork1",
           "ledgerType": "ETHEREUM"
         },
         "signingCredential": {

--- a/packages/cactus-plugin-satp-hermes/src/examples/config/satp-gateway2-config.json
+++ b/packages/cactus-plugin-satp-hermes/src/examples/config/satp-gateway2-config.json
@@ -11,7 +11,7 @@
     ],
     "connectedDLTs": [
       {
-        "id": "HardhatTestNetwork2",
+        "id": "EthereumLedgerTestNetwork2",
         "ledgerType": "ETHEREUM"
       }
     ],
@@ -20,7 +20,7 @@
     "gatewayClientPort": 3011,
     "gatewayServerPort": 3010,
     "gatewayOapiPort": 4010,
-    "identificationCredentials": {
+    "identificationCredential": {
       "signingAlgorithm": "SECP256K1",
       "pubKey": "024c0cf54f92d23dbb3d409a8047aa2a44abcb911767d3516b19fd94c2358dec65"
     }
@@ -40,7 +40,7 @@
       ],
       "connectedDLTs": [
         {
-          "id": "HardhatTestNetwork1",
+          "id": "EthereumLedgerTestNetwork1",
           "ledgerType": "ETHEREUM"
         }
       ],
@@ -49,7 +49,10 @@
       "gatewayClientPort": 3011,
       "gatewayServerPort": 3010,
       "gatewayOapiPort": 4010,
-      "pubKey": "036256069f81bcaae52a64965b8add79521ee54cb2ad3d85de5250d78cf0fc171c"
+      "identificationCredential": {
+        "signingAlgorithm": "SECP256K1",
+        "pubKey": "036256069f81bcaae52a64965b8add79521ee54cb2ad3d85de5250d78cf0fc171c"
+      }
     }
   ],
   "environment": "development",

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/services/token-price-check/price-manager.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/services/token-price-check/price-manager.ts
@@ -74,6 +74,14 @@ export class PriceManager {
       FabricLedgerTestNetwork: 0.5, // 1 token = 0.5 USD
     };
 
+    if (networkId.includes("EthereumLedgerTestNetwork")) {
+      networkId = "EthereumLedgerTestNetwork";
+    } else if (networkId.includes("BesuLedgerTestNetwork")) {
+      networkId = "BesuLedgerTestNetwork";
+    } else if (networkId.includes("FabricLedgerTestNetwork")) {
+      networkId = "FabricLedgerTestNetwork";
+    }
+
     const rate = exchangeRates[networkId];
     if (rate === undefined) {
       this.logger.error(`Price not found for networkId: ${networkId}`);

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/services/validation/config-validating-functions/bridges-config-validating-functions/validate-besu-config.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/services/validation/config-validating-functions/bridges-config-validating-functions/validate-besu-config.ts
@@ -43,8 +43,8 @@ function isWeb3SigningCredentialCactusKeychainRef(
   return (
     typeof obj === "object" &&
     obj !== null &&
-    "transactionSignerEthAccount" in obj &&
-    typeof objRecord.transactionSignerEthAccount === "string" &&
+    "ethAccount" in obj &&
+    typeof objRecord.ethAccount === "string" &&
     "keychainEntryKey" in obj &&
     typeof objRecord.keychainEntryKey === "string" &&
     "keychainId" in obj &&
@@ -62,8 +62,8 @@ function isWeb3SigningCredentialPrivateKeyHex(
   return (
     typeof obj === "object" &&
     obj !== null &&
-    "transactionSignerEthAccount" in obj &&
-    typeof objRecord.transactionSignerEthAccount === "string" &&
+    "ethAccount" in obj &&
+    typeof objRecord.ethAccount === "string" &&
     "secret" in obj &&
     typeof objRecord.secret === "string" &&
     "type" in obj &&
@@ -92,6 +92,11 @@ function isWeb3SigningCredential(
   if (!obj || typeof obj !== "object") {
     log.error("isWeb3SigningCredential: obj is not an object or is null");
     return false;
+  }
+  const objRecord = obj as Record<string, unknown>;
+  if ("transactionSignerEthAccount" in objRecord) {
+    (obj as any).ethAccount = (obj as any).transactionSignerEthAccount;
+    delete (obj as any).transactionSignerEthAccount;
   }
   return (
     isWeb3SigningCredentialCactusKeychainRef(obj) ||

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/services/validation/config-validating-functions/bridges-config-validating-functions/validate-ethereum-config.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/services/validation/config-validating-functions/bridges-config-validating-functions/validate-ethereum-config.ts
@@ -41,8 +41,8 @@ function isWeb3SigningCredentialCactiKeychainRef(
   return (
     typeof obj === "object" &&
     obj !== null &&
-    "transactionSignerEthAccount" in obj &&
-    typeof objRecord.transactionSignerEthAccount === "string" &&
+    "ethAccount" in obj &&
+    typeof objRecord.ethAccount === "string" &&
     "keychainEntryKey" in obj &&
     typeof objRecord.keychainEntryKey === "string" &&
     (!("keychainId" in obj) || typeof objRecord.keychainId === "string") &&
@@ -59,8 +59,8 @@ function isWeb3SigningCredentialGethKeychainPassword(
   return (
     typeof obj === "object" &&
     obj !== null &&
-    "transactionSignerEthAccount" in obj &&
-    typeof objRecord.transactionSignerEthAccount === "string" &&
+    "ethAccount" in obj &&
+    typeof objRecord.ethAccount === "string" &&
     "secret" in obj &&
     typeof objRecord.secret === "string" &&
     "type" in obj &&
@@ -76,8 +76,8 @@ function isWeb3SigningCredentialPrivateKeyHex(
   return (
     typeof obj === "object" &&
     obj !== null &&
-    "transactionSignerEthAccount" in obj &&
-    typeof objRecord.transactionSignerEthAccount === "string" &&
+    "ethAccount" in obj &&
+    typeof objRecord.ethAccount === "string" &&
     "secret" in obj &&
     typeof objRecord.secret === "string" &&
     "type" in obj &&
@@ -106,6 +106,11 @@ function isWeb3SigningCredential(
   if (!obj || typeof obj !== "object") {
     log.error("isWeb3SigningCredential: obj is not an object or is null");
     return false;
+  }
+  const objRecord = obj as Record<string, unknown>;
+  if ("transactionSignerEthAccount" in objRecord) {
+    (obj as any).ethAccount = (obj as any).transactionSignerEthAccount;
+    delete (obj as any).transactionSignerEthAccount;
   }
   return (
     isWeb3SigningCredentialCactiKeychainRef(obj) ||


### PR DESCRIPTION
- Fixed inconsistency in ethereum based leafs, where transactionSignerEthAccount from a bridge config signing credential was not used in the wrapper contract deployment
- Fixed price manager to support numbered network ids, as used in test setups 

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.