### PR TITLE
fix(satp-hermes): return missing promise in rollback strategies

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/crash-management/rollback/stage0-rollback-strategy.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/crash-management/rollback/stage0-rollback-strategy.ts
@@ -98,7 +98,7 @@ export class Stage0RollbackStrategy implements RollbackStrategy {
   ): Promise<void> {
     const fnTag = "Stage0RollbackStrategy#handleClientSideRollback";
     const { span, context: ctx } = this.monitorService.startSpan(fnTag);
-    context.with(ctx, async () => {
+    return context.with(ctx, async () => {
       try {
         try {
           const networkId = {

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/crash-management/rollback/stage1-rollback-strategy.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/crash-management/rollback/stage1-rollback-strategy.ts
@@ -83,7 +83,7 @@ export class Stage1RollbackStrategy implements RollbackStrategy {
   ): Promise<void> {
     const fnTag = "Stage1RollbackStrategy#handleClientSideRollback";
     const { span, context: ctx } = this.monitorService.startSpan(fnTag);
-    context.with(ctx, () => {
+    return context.with(ctx, () => {
       try {
         try {
           rollbackState.rollbackLogEntries.push(
@@ -125,7 +125,7 @@ export class Stage1RollbackStrategy implements RollbackStrategy {
   ): Promise<void> {
     const fnTag = "Stage1RollbackStrategy#handleServerSideRollback";
     const { span, context: ctx } = this.monitorService.startSpan(fnTag);
-    context.with(ctx, () => {
+    return context.with(ctx, () => {
       try {
         try {
           rollbackState.rollbackLogEntries.push(

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/crash-management/rollback/stage2-rollback-strategy.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/crash-management/rollback/stage2-rollback-strategy.ts
@@ -97,7 +97,7 @@ export class Stage2RollbackStrategy implements RollbackStrategy {
   ): Promise<void> {
     const fnTag = "Stage2RollbackStrategy#handleClientSideRollback";
     const { span, context: ctx } = this.monitorService.startSpan(fnTag);
-    context.with(ctx, async () => {
+    return context.with(ctx, async () => {
       try {
         try {
           const networkId = {
@@ -166,7 +166,7 @@ export class Stage2RollbackStrategy implements RollbackStrategy {
   ): Promise<void> {
     const fnTag = "Stage2RollbackStrategy#handleServerSideRollback";
     const { span, context: ctx } = this.monitorService.startSpan(fnTag);
-    context.with(ctx, () => {
+    return context.with(ctx, () => {
       try {
         try {
           const network = serverSessionData.recipientGatewayNetworkId;

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/crash-management/rollback/stage3-rollback-strategy.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/crash-management/rollback/stage3-rollback-strategy.ts
@@ -97,7 +97,7 @@ export class Stage3RollbackStrategy implements RollbackStrategy {
   ): Promise<void> {
     const fnTag = "Stage3RollbackStrategy#handleClientSideRollback";
     const { span, context: ctx } = this.monitorService.startSpan(fnTag);
-    context.with(ctx, async () => {
+    return context.with(ctx, async () => {
       try {
         try {
           const networkId = {
@@ -172,7 +172,7 @@ export class Stage3RollbackStrategy implements RollbackStrategy {
   ): Promise<void> {
     const fnTag = "Stage3RollbackStrategy#handleServerSideRollback";
     const { span, context: ctx } = this.monitorService.startSpan(fnTag);
-    context.with(ctx, async () => {
+    return context.with(ctx, async () => {
       try {
         try {
           const networkId = {


### PR DESCRIPTION

I found a critical async bug across all four SATP rollback strategy files ,  every `context.with()` call was missing a `return` statement, silently discarding the promise and letting rollback methods resolve immediately without doing any actual work.

**The Problem**

The `execute()` method awaits `handleClientSideRollback()`, but since the inner promise was dropped, it resolved instantly ,  with an empty `rollbackLogEntries` array. The crash manager saw no failures and marked the rollback `"COMPLETED"` before a single ledger operation had run.

```ts
// Before -  promise is discarded
context.with(ctx, async () => { await bridge.mintAsset(asset); });

// After - promise is properly awaited
return context.with(ctx, async () => { await bridge.mintAsset(asset); });
```

**Why It Matters**

This broke the entire crash recovery path. A Stage 3 failure should mint assets back on the source chain and burn them on the destination, but neither happened. In practice, this could mean permanently lost or duplicated assets, with bridge errors silently swallowed as unhandled rejections.

**The Fix**

One word , return` , added at 7 call sites across 4 files. No logic changes, no refactoring. Rollbacks now complete fully before status is evaluated, failed rollbacks surface correctly, and cross-ledger atomicity during crash recovery actually holds.