### PR TITLE
ci: remove push-based ci trigger and add workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,10 +4,9 @@ on:
     branches:
       - main
       - dev
-  push:
-    branches:
-      - main
-      - dev
+
+  workflow_dispatch:
+    
   schedule:
     # Run at 8:00 AM UTC on weekends (Monday and Thursday)
     - cron: "0 8 * * 1,4" 


### PR DESCRIPTION
CI was running on every push, duplicating the same checks already triggered by the PR. In most cases, those jobs were skipped because the push did not include code changes.

Enabled manual CI runs to allow the workflow to be triggered when needed across other branches.