### PR TITLE
fix(satp-hermes): add nix support

### DIFF
--- a/.github/workflows/satp-hermes-workflow.yaml
+++ b/.github/workflows/satp-hermes-workflow.yaml
@@ -76,6 +76,9 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
       - uses: ./.github/actions/docker-pull/
         with:
           image: kubaya/cacti-satp-hermes-gateway:5f190f37f-2025-08-19

--- a/packages/cactus-plugin-satp-hermes/README.md
+++ b/packages/cactus-plugin-satp-hermes/README.md
@@ -62,6 +62,46 @@ curl -L https://foundry.paradigm.xyz | bash
 foundryup
 ```
 
+### Alternative: Use Nix
+
+If you prefer a reproducible development environment, use Nix instead of installing toolchains globally.
+
+1. Install [nix](https://nixos.org/download/).
+2. Enable flakes (one-time setup):
+  ```sh
+  mkdir -p ~/.config/nix
+  echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+  ```
+3. Enter the SATP Hermes Nix shell from this package directory:
+  ```sh
+  nix develop
+  ```
+  This opens a subshell with Node, Yarn, Go, Rust, Foundry, and other required tools pinned by the flake.
+
+4. Verify you are inside the Nix environment:
+  ```sh
+  echo "$IN_NIX_SHELL"
+  which node yarn go forge
+  ```
+  The binaries should resolve to paths under `/nix/store/...`.
+
+5. Install workspace dependencies from the monorepo root:
+  ```sh
+  cd ../..
+  yarn run configure
+  ```
+
+Common commands:
+```sh
+yarn run test
+yarn run build
+yarn run lint
+```
+
+To leave the Nix shell:
+```sh
+exit
+```
 
 Know how to use the following plugins of the project:
 

--- a/packages/cactus-plugin-satp-hermes/flake.lock
+++ b/packages/cactus-plugin-satp-hermes/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1774667365,
+        "narHash": "sha256-+JamhonkPyti+oqfl1ySAyF2L02adhCEcdZOzpSukq8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "98caaa8cd1fbcc45913d1bb2b7fbabcf3e8d967a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/packages/cactus-plugin-satp-hermes/flake.nix
+++ b/packages/cactus-plugin-satp-hermes/flake.nix
@@ -1,0 +1,113 @@
+{
+  description = "SATP Hermes development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+        nodeVersion = "22";
+        # Fallback when go_1_20 is unavailable in nixpkgs snapshot to default go package (which may be a newer version)
+        goToolchain = if pkgs ? go_1_20 then pkgs.go_1_20 else pkgs.go;
+        rustVersion = "stable";
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            nodejs
+            corepack
+            yarn
+
+            goToolchain
+
+            (rust-bin.stable.latest.default.override {
+              targets = [ "wasm32-unknown-unknown" ];
+              extensions = [ "rust-src" "rustfmt" "clippy" ];
+            })
+
+            foundry
+
+            pkg-config
+            gnumake
+            git
+            curl
+            wget
+
+            protobuf
+            grpc
+
+            docker
+
+            python3
+            python3Packages.pip
+
+            openjdk17  
+            
+            python3
+            gcc
+            glibc
+
+            shellcheck
+            nodePackages.eslint
+          ];
+
+          shellHook = ''
+            # Set up environment variables
+            export NODEJS_VERSION="v22.18.0"
+            export GO111MODULE=on
+            export CARGO_TERM_COLOR=always
+
+            # Print environment info
+            echo "=== SATP Hermes Development Environment ==="
+            echo "Node.js version: $(node --version)"
+            echo "yarn version: $(yarn --version)"
+            echo "Go version: $(go version)"
+            echo "Rust version: $(rustc --version)"
+            echo "Cargo version: $(cargo --version)"
+            echo "Forge version: $(forge --version 2>/dev/null || echo 'Not installed yet')"
+            echo ""
+            echo "Getting started:"
+            echo "  - Install dependencies (in root of the project): yarn run configure"
+            echo "  - Build the project: yarn build"
+            echo "  - Run tests: yarn test"
+            echo ""
+          '';
+        };
+
+        # Alternative shells for specific tasks
+        devShells.node-only = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            nodejs
+            corepack
+            yarn
+            git
+          ];
+        };
+
+        devShells.rust-only = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            (rust-bin.stable.latest.default.override {
+              targets = [ "wasm32-unknown-unknown" ];
+            })
+            foundry
+            pkg-config
+          ];
+        };
+
+        devShells.go-only = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            goToolchain
+            git
+          ];
+        };
+      }
+    );
+}

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/unit/nix-setup.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/unit/nix-setup.test.ts
@@ -1,0 +1,53 @@
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+
+const packageRoot = path.resolve(__dirname, "../../../../");
+const nixBaseCommand =
+  "nix --extra-experimental-features nix-command --extra-experimental-features flakes";
+
+function hasNixInPath(): boolean {
+  try {
+    execSync("command -v nix", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("SATP Hermes Nix installation and setup", () => {
+  it("has a SATP Hermes flake definition", () => {
+    const satpFlakeFile = path.join(packageRoot, "flake.nix");
+    expect(fs.existsSync(satpFlakeFile)).toBe(true);
+  });
+
+  it("validates flake commands when Nix is available", () => {
+    if (!hasNixInPath()) {
+      throw new Error("Nix must be available but it was not found.");
+    }
+
+    expect(() =>
+      execSync(`${nixBaseCommand} flake show`, {
+        cwd: packageRoot,
+        stdio: "pipe",
+      }),
+    ).not.toThrow();
+  });
+
+  it("enters nix develop and exposes required toolchain", () => {
+    if (!hasNixInPath()) {
+      throw new Error("Nix must be available but it was not found.");
+    }
+
+    const verifyDevelopShell =
+      `${nixBaseCommand} develop --command bash -lc ` +
+      `'test -n "$IN_NIX_SHELL" && command -v node yarn go forge >/dev/null'`;
+
+    expect(() =>
+      execSync(verifyDevelopShell, {
+        cwd: packageRoot,
+        stdio: "pipe",
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for 

Fixes #4035 

added `flake.nix` file that defines a Nix flake for setting up all required toolchains and updated the `README.md` file with instructions for using Nix as an alternative to global toolchain installation.

Setting up `satp-hermes` currently requires installing and keeping multiple toolchains in sync (and making sure versions match what the project expects). That can be slow and error-prone, especially across different developer machines and CI environments.

Providing a Nix flake helps because it:

- **Reduces onboarding time**: a single `nix develop` can replace a long list of manual installs.
- **Makes the dev environment reproducible**: contributors get the same tools/versions, reducing “works on my machine” issues.
- **Avoids polluting the global system**: toolchains live in the Nix environment rather than being installed system-wide.
- **Improves consistency across platforms**: Nix provides a common workflow for Linux/macOS/WSL2 users.

Additionally, different packages may require different Node.js / Go / Rust toolchain versions. Installing those globally can lead to version conflicts and brittle setup instructions. Having a Nix flake for each package helps by providing an isolated, reproducible dev environment with the exact toolchain versions that package needs.