### PR TITLE
fix(api-server): use Promise.allSettled in shutdown

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
@@ -222,7 +222,6 @@ export class ApiServer {
         this.shutdown()
           .catch((ex: unknown) => {
             this.log.warn("Failed async-exit-hook for cmd-api-server", ex);
-            throw ex;
           })
           .finally(() => {
             this.log.info("Concluded async-exit-hook for cmd-api-server ...");
@@ -507,12 +506,13 @@ export class ApiServer {
 
     const registry = await this.getOrInitPluginRegistry();
 
-    const webServicesShutdown = registry
+    const plugins = registry
       .getPlugins()
-      .filter((pluginInstance) => isIPluginWebService(pluginInstance))
-      .map((pluginInstance: ICactusPlugin) => {
-        return (pluginInstance as IPluginWebService).shutdown();
-      });
+      .filter((pluginInstance) => isIPluginWebService(pluginInstance));
+
+    const webServicesShutdown = plugins.map((pluginInstance: ICactusPlugin) => {
+      return (pluginInstance as IPluginWebService).shutdown();
+    });
 
     if (this.wsApi) {
       this.log.info(`Disconnecting SocketIO connections...`);
@@ -521,7 +521,13 @@ export class ApiServer {
     }
 
     this.log.info(`Stopping ${webServicesShutdown.length} WS plugin(s)...`);
-    await Promise.all(webServicesShutdown);
+    const results = await Promise.allSettled(webServicesShutdown);
+    results.forEach((result, idx) => {
+      if (result.status === "rejected") {
+        const pluginId = plugins[idx].getInstanceId();
+        this.log.warn(`Plugin "${pluginId}" shutdown failed:`, result.reason);
+      }
+    });
     this.log.info(`Stopped ${webServicesShutdown.length} WS plugin(s) OK`);
 
     if (this.httpServerApi?.listening) {


### PR DESCRIPTION
Fixes #4160

## Summary

- Replace `Promise.all` with `Promise.allSettled` in `ApiServer.shutdown()` so that a single plugin failure no longer skips HTTP/gRPC/CRPC server cleanup
- Remove re-throw in exit hook `.catch()` that caused an unhandled promise rejection on Node.js 15+

## Description

In `ApiServer.shutdown()` (`packages/cactus-cmd-api-server/src/main/typescript/api-server.ts`),  
`Promise.all` was used to shut down all registered `IPluginWebService` plugins.

If any single plugin fails during shutdown, `Promise.all` rejects immediately,  
which prevents the remaining shutdown logic from executing. As a result:

- HTTP server may not close
- CRPC (Fastify) server may not close
- gRPC server may not drain or close

Additionally, the exit hook re-threw errors in a `.catch()` block without a downstream handler,  
leading to unhandled promise rejections (Node.js 15+ behavior).

## Fix

- Replaced `Promise.all` with `Promise.allSettled` to ensure all plugin shutdowns are attempted
- Logged individual plugin shutdown failures instead of failing fast
- Removed the re-throw in the exit hook `.catch()` block to prevent unhandled promise rejections

## Steps to Reproduce

1. Deploy Cacti API server with a plugin that can fail during shutdown (e.g., SATP Hermes with a database dependency)
2. Kill the database before sending SIGTERM to the API server
3. Observe that HTTP/gRPC servers remain listening after shutdown attempt (before fix)

## Test Plan

- [x] Verify existing unit/integration tests still pass
- [x] Deploy with a plugin that throws during shutdown and confirm HTTP/gRPC servers close cleanly