### PR TITLE
fix(satp-hermes): add missing await to async DB writes in Stage 3 asset operations

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage3-client-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage3-client-service.ts
@@ -779,7 +779,7 @@ export class Stage3ClientService extends SATPService {
 
         const sessionData = session.getClientSessionData();
         this.Log.info(`init-${stepTag}`);
-        this.dbLogger.persistLogEntry({
+        await this.dbLogger.persistLogEntry({
           sessionId: sessionData.id,
           type: "burn-asset",
           operation: "init",
@@ -789,7 +789,7 @@ export class Stage3ClientService extends SATPService {
         this.Log.debug(`${fnTag}, Burning Asset...`);
         try {
           this.Log.info(`exec-${stepTag}`);
-          this.dbLogger.persistLogEntry({
+          await this.dbLogger.persistLogEntry({
             sessionId: sessionData.id,
             type: "burn-asset",
             operation: "exec",
@@ -832,7 +832,7 @@ export class Stage3ClientService extends SATPService {
           sessionData.burnAssertionClaim.signature = bufArray2HexStr(
             sign(this.Signer, sessionData.burnAssertionClaim.receipt),
           );
-          this.dbLogger.storeProof({
+          await this.dbLogger.storeProof({
             sessionId: sessionData.id,
             type: "burn-asset",
             operation: "done",
@@ -841,7 +841,7 @@ export class Stage3ClientService extends SATPService {
           });
           this.Log.info(`${fnTag}, done-${fnTag}`);
         } catch (error) {
-          this.dbLogger.persistLogEntry({
+          await this.dbLogger.persistLogEntry({
             sessionId: sessionData.id,
             type: "burn-asset",
             operation: "fail",

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/server/stage3-server-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/server/stage3-server-service.ts
@@ -815,7 +815,7 @@ export class Stage3ServerService extends SATPService {
         session.verify(fnTag, SessionType.SERVER);
 
         const sessionData = session.getServerSessionData();
-        this.dbLogger.persistLogEntry({
+        await this.dbLogger.persistLogEntry({
           sessionId: sessionData.id,
           type: "mint-asset",
           operation: "init",
@@ -824,7 +824,7 @@ export class Stage3ServerService extends SATPService {
         });
         try {
           this.Log.info(`exec-${stepTag}`);
-          this.dbLogger.persistLogEntry({
+          await this.dbLogger.persistLogEntry({
             sessionId: sessionData.id,
             type: "mint-asset",
             operation: "exec",
@@ -867,7 +867,7 @@ export class Stage3ServerService extends SATPService {
           sessionData.mintAssertionClaim.signature = bufArray2HexStr(
             sign(this.Signer, sessionData.mintAssertionClaim.receipt),
           );
-          this.dbLogger.storeProof({
+          await this.dbLogger.storeProof({
             sessionId: sessionData.id,
             type: "mint-asset",
             operation: "done",
@@ -877,7 +877,7 @@ export class Stage3ServerService extends SATPService {
           this.Log.info(`${fnTag}, done-${fnTag}`);
         } catch (error) {
           this.logger.debug(`Crash in ${fnTag}`, error);
-          this.dbLogger.persistLogEntry({
+          await this.dbLogger.persistLogEntry({
             sessionId: sessionData.id,
             type: "mint-asset",
             operation: "fail",
@@ -908,7 +908,7 @@ export class Stage3ServerService extends SATPService {
 
         session.verify(fnTag, SessionType.SERVER);
         const sessionData = session.getServerSessionData();
-        this.dbLogger.persistLogEntry({
+        await this.dbLogger.persistLogEntry({
           sessionId: sessionData.id,
           type: "assign-asset",
           operation: "init",
@@ -918,7 +918,7 @@ export class Stage3ServerService extends SATPService {
         try {
           this.Log.info(`${fnTag}, Assigning Asset...`);
           this.Log.info(`exec-${stepTag}`);
-          this.dbLogger.persistLogEntry({
+          await this.dbLogger.persistLogEntry({
             sessionId: sessionData.id,
             type: "assign-asset",
             operation: "exec",
@@ -962,7 +962,7 @@ export class Stage3ServerService extends SATPService {
           sessionData.assignmentAssertionClaim.signature = bufArray2HexStr(
             sign(this.Signer, sessionData.assignmentAssertionClaim.receipt),
           );
-          this.dbLogger.storeProof({
+          await this.dbLogger.storeProof({
             sessionId: sessionData.id,
             type: "assign-asset",
             operation: "done",
@@ -974,7 +974,7 @@ export class Stage3ServerService extends SATPService {
           this.Log.info(`${fnTag}, done-${fnTag}`);
         } catch (error) {
           this.logger.debug(`Crash in ${fnTag}`, error);
-          this.dbLogger.persistLogEntry({
+          await this.dbLogger.persistLogEntry({
             sessionId: sessionData.id,
             type: "assign-asset",
             operation: "fail",


### PR DESCRIPTION
## Summary

- Add missing `await` to 12 fire-and-forget `persistLogEntry()` and `storeProof()` calls in `mintAsset()`, `burnAsset()`, and `assignAsset()` methods
- Prevents unhandled promise rejections that crash the SATP gateway (exit code 255)
- Eliminates silent loss of blockchain transaction proofs needed for crash recovery

Fixes #4167

## Problem

In Stage 3 services, the asset operation methods (`mintAsset`, `burnAsset`, `assignAsset`) call `this.dbLogger.persistLogEntry()` and `this.dbLogger.storeProof()` without `await`. Both are `async` methods that write to local + remote databases.

This is inconsistent — every other method in the same files correctly awaits these calls.

Without `await`:
1. DB write errors become **unhandled promise rejections** → process crash
2. Proofs may not persist before the method returns → **silent data loss**
3. Crash recovery can't find proofs → re-executes operations → **duplicate blockchain transactions**

## Changes

| File | Method | Lines Fixed |
|------|--------|-------------|
| `stage3-server-service.ts` | `mintAsset()` | 818, 827, 870, 880 |
| `stage3-server-service.ts` | `assignAsset()` | 911, 921, 965, 977 |
| `stage3-client-service.ts` | `burnAsset()` | 782, 792, 835, 844 |

## Test plan

- [ ] Verify existing SATP integration tests still pass
- [ ] Verify Stage 3 asset operations correctly await DB writes
- [ ] Confirm no remaining unawaited `dbLogger` calls in affected files