### PR TITLE
docs(build): sync published build guide with repo instructions

### DIFF
--- a/docs/docs/cactus/build.md
+++ b/docs/docs/cactus/build.md
@@ -1,16 +1,16 @@
-Hyperledger Cactus Build Instructions
+Hyperledger Cacti Build Instructions
 =====================================
 
-This is the place to start if you want to give Cactus a spin on your local machine or if you are planning on contributing.
+This is the place to start if you want to give Cacti a spin on your local machine or if you are planning on contributing.
 
-> This is not a guide for `using` Cactus for your projects that have business logic but rather a guide for people who want to make changes to the code of Cactus. If you are just planning on using Cactus as an npm dependency for your project, then you might not need this guide at all.
+> This is not a guide for `using` Cacti for your projects that have business logic but rather a guide for people who want to make changes to the code of Cacti. If you are just planning on using Cacti as an npm dependency for your project, then you might not need this guide at all.
 
 The project uses Typescript for both back-end and front-end components.
 
 Developers guide
 ----------------
 
-This is a video guide to setup Hyperledger Cactus on your local machine.
+This is a video guide to setup Hyperledger Cacti on your local machine.
 
 ### Installing git
 
@@ -96,14 +96,14 @@ Getting Started
             
     *   Git
         
-    *   NodeJS v16.14.2, npm v8.5.0 (we recommend using the Node Version Manager (nvm) if available for your OS)
+    *   NodeJS v20.20.0, npm v10.8.2 (we recommend using the Node Version Manager (nvm) if available for your OS)
         
-        nvm install 16.14.2
-        nvm use 16.14.2
+        nvm install 20.20.0
+        nvm use 20.20.0
         
     *   Yarn
         
-        *   `npm run install-yarn` (from within the project directory)
+        *   `npm run enable-corepack` (from within the project directory)
             
     *   [Docker Engine](https://docs.docker.com/engine/install/ubuntu/). Make sure that Docker is working and running, for example, running `docker ps -aq`
         
@@ -123,6 +123,11 @@ Getting Started
 
         ```sh
         curl -L https://foundry.paradigm.xyz | bash
+        ```
+
+        Restart your terminal or run `source ~/.zshrc`, then:
+
+        ```sh
         foundryup
         ```
 


### PR DESCRIPTION
## Summary

- update stale Node/npm versions in the published build guide
- replace the outdated Yarn install step with the current Corepack flow
- align the Foundry setup instructions with the root build guide
- update top-level contributor-facing wording from `Cactus` to `Cacti`

## Why

The published docs page had drifted from the repo root `BUILD.md`, which can confuse new contributors during setup. This keeps the contributor-facing build instructions in sync with the current repo guidance.

## Test plan

- [x] compared `docs/docs/cactus/build.md` against `BUILD.md`
- [x] verified the diff is docs-only and narrow