### PR TITLE
fix(satp-hermes): await Stage 3 DB writes and restore body verifier

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage3-client-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage3-client-service.ts
@@ -779,7 +779,7 @@ export class Stage3ClientService extends SATPService {
 
         const sessionData = session.getClientSessionData();
         this.Log.info(`init-${stepTag}`);
-        this.dbLogger.persistLogEntry({
+        await this.dbLogger.persistLogEntry({
           sessionId: sessionData.id,
           type: "burn-asset",
           operation: "init",
@@ -789,7 +789,7 @@ export class Stage3ClientService extends SATPService {
         this.Log.debug(`${fnTag}, Burning Asset...`);
         try {
           this.Log.info(`exec-${stepTag}`);
-          this.dbLogger.persistLogEntry({
+          await this.dbLogger.persistLogEntry({
             sessionId: sessionData.id,
             type: "burn-asset",
             operation: "exec",
@@ -832,7 +832,7 @@ export class Stage3ClientService extends SATPService {
           sessionData.burnAssertionClaim.signature = bufArray2HexStr(
             sign(this.Signer, sessionData.burnAssertionClaim.receipt),
           );
-          this.dbLogger.storeProof({
+          await this.dbLogger.storeProof({
             sessionId: sessionData.id,
             type: "burn-asset",
             operation: "done",
@@ -841,7 +841,7 @@ export class Stage3ClientService extends SATPService {
           });
           this.Log.info(`${fnTag}, done-${fnTag}`);
         } catch (error) {
-          this.dbLogger.persistLogEntry({
+          await this.dbLogger.persistLogEntry({
             sessionId: sessionData.id,
             type: "burn-asset",
             operation: "fail",

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/server/stage3-server-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/server/stage3-server-service.ts
@@ -454,14 +454,12 @@ export class Stage3ServerService extends SATPService {
 
         const sessionData = session.getServerSessionData();
 
-        if (request.common == undefined) {
-          commonBodyVerifier(
-            fnTag,
-            request.common,
-            sessionData,
-            MessageType.COMMIT_PREPARE,
-          );
-        }
+        commonBodyVerifier(
+          fnTag,
+          request.common,
+          sessionData,
+          MessageType.COMMIT_PREPARE,
+        );
 
         signatureVerifier(fnTag, this.Signer, request, sessionData);
 
@@ -513,14 +511,12 @@ export class Stage3ServerService extends SATPService {
 
         const sessionData = session.getServerSessionData();
 
-        if (request.common == undefined) {
-          commonBodyVerifier(
-            fnTag,
-            request.common,
-            sessionData,
-            MessageType.COMMIT_FINAL,
-          );
-        }
+        commonBodyVerifier(
+          fnTag,
+          request.common,
+          sessionData,
+          MessageType.COMMIT_FINAL,
+        );
 
         signatureVerifier(fnTag, this.Signer, request, sessionData);
 
@@ -589,14 +585,12 @@ export class Stage3ServerService extends SATPService {
 
         const sessionData = session.getServerSessionData();
 
-        if (request.common == undefined) {
-          commonBodyVerifier(
-            fnTag,
-            request.common,
-            sessionData,
-            MessageType.COMMIT_TRANSFER_COMPLETE,
-          );
-        }
+        commonBodyVerifier(
+          fnTag,
+          request.common,
+          sessionData,
+          MessageType.COMMIT_TRANSFER_COMPLETE,
+        );
 
         signatureVerifier(fnTag, this.Signer, request, sessionData);
 
@@ -815,7 +809,7 @@ export class Stage3ServerService extends SATPService {
         session.verify(fnTag, SessionType.SERVER);
 
         const sessionData = session.getServerSessionData();
-        this.dbLogger.persistLogEntry({
+        await this.dbLogger.persistLogEntry({
           sessionId: sessionData.id,
           type: "mint-asset",
           operation: "init",
@@ -824,7 +818,7 @@ export class Stage3ServerService extends SATPService {
         });
         try {
           this.Log.info(`exec-${stepTag}`);
-          this.dbLogger.persistLogEntry({
+          await this.dbLogger.persistLogEntry({
             sessionId: sessionData.id,
             type: "mint-asset",
             operation: "exec",
@@ -867,7 +861,7 @@ export class Stage3ServerService extends SATPService {
           sessionData.mintAssertionClaim.signature = bufArray2HexStr(
             sign(this.Signer, sessionData.mintAssertionClaim.receipt),
           );
-          this.dbLogger.storeProof({
+          await this.dbLogger.storeProof({
             sessionId: sessionData.id,
             type: "mint-asset",
             operation: "done",
@@ -877,7 +871,7 @@ export class Stage3ServerService extends SATPService {
           this.Log.info(`${fnTag}, done-${fnTag}`);
         } catch (error) {
           this.logger.debug(`Crash in ${fnTag}`, error);
-          this.dbLogger.persistLogEntry({
+          await this.dbLogger.persistLogEntry({
             sessionId: sessionData.id,
             type: "mint-asset",
             operation: "fail",
@@ -908,7 +902,7 @@ export class Stage3ServerService extends SATPService {
 
         session.verify(fnTag, SessionType.SERVER);
         const sessionData = session.getServerSessionData();
-        this.dbLogger.persistLogEntry({
+        await this.dbLogger.persistLogEntry({
           sessionId: sessionData.id,
           type: "assign-asset",
           operation: "init",
@@ -918,7 +912,7 @@ export class Stage3ServerService extends SATPService {
         try {
           this.Log.info(`${fnTag}, Assigning Asset...`);
           this.Log.info(`exec-${stepTag}`);
-          this.dbLogger.persistLogEntry({
+          await this.dbLogger.persistLogEntry({
             sessionId: sessionData.id,
             type: "assign-asset",
             operation: "exec",
@@ -962,7 +956,7 @@ export class Stage3ServerService extends SATPService {
           sessionData.assignmentAssertionClaim.signature = bufArray2HexStr(
             sign(this.Signer, sessionData.assignmentAssertionClaim.receipt),
           );
-          this.dbLogger.storeProof({
+          await this.dbLogger.storeProof({
             sessionId: sessionData.id,
             type: "assign-asset",
             operation: "done",
@@ -974,7 +968,7 @@ export class Stage3ServerService extends SATPService {
           this.Log.info(`${fnTag}, done-${fnTag}`);
         } catch (error) {
           this.logger.debug(`Crash in ${fnTag}`, error);
-          this.dbLogger.persistLogEntry({
+          await this.dbLogger.persistLogEntry({
             sessionId: sessionData.id,
             type: "assign-asset",
             operation: "fail",


### PR DESCRIPTION
## Summary

- Removes inverted `if (request.common == undefined)` guard that was silently skipping all `commonBodyVerifier` protocol checks in Stage 3 server-side validation
- Aligns `stage3-server-service.ts` with every other stage service that calls `commonBodyVerifier` unconditionally

Fixes #4171

## Changes

Three functions in `stage3-server-service.ts` had `commonBodyVerifier` wrapped inside `if (request.common == undefined)`, causing validation to be skipped on every real request:

- `checkCommitPreparationRequest` (before `mintAsset`)
- `checkCommitFinalAssertionRequest` (before `assignAsset`)
- `checkTransferCompleteRequest` (before transfer completion)

Removed the wrapping condition so validation runs unconditionally, matching stage1-server, stage2-server, and all client services.

## Test plan

- [ ] Verify existing SATP integration tests pass
- [ ] Confirm Stage 3 requests with valid `common` body are now validated
- [ ] Confirm Stage 3 requests with missing `common` body still throw `SatpCommonBodyError`
- [ ] Confirm requests with wrong sequence number / session ID / pubkeys are rejected