### PR TITLE
docs(build): add ubuntu instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -120,8 +120,109 @@ _Unless explicitly stated otherwise, each bullet will apply to both Intel and AR
     ```
 
 ### Linux
-* Insert Linux instructions here
+# Getting Started: Ubuntu / Linux
 
+This guide provides a step-by-step walkthrough for setting up the Hyperledger Cacti development environment on Ubuntu (20.04+ recommended). These steps should also work for most Debian-based distributions.
+
+---
+
+## Prerequisites
+
+### 1. Git
+* Ensure your package index is updated and Git is installed for version control.
+```bash
+sudo apt update
+sudo apt install -y git
+```
+
+### 2. Node.js (v20.20.0) & npm
+
+* Cacti requires a specific Node version. We recommend using nvm (Node Version Manager) to avoid conflicts with system defaults.
+
+```
+curl -o- [https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh](https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh) | bash
+source ~/.bashrc
+
+nvm install 20.20.0
+nvm use 20.20.0
+```
+Verify:
+```
+node -v
+npm -v
+```
+### 3. Yarn (via Corepack)
+
+* Cacti uses Yarn for package management. Enable it using the built-in Corepack:
+
+```
+npm run enable-corepack
+```
+Verify:
+```
+yarn -v
+```
+### 4. Docker Engine
+
+* Docker is required to run the various blockchain ledgers supported by Cacti.
+```
+sudo apt install -y docker.io
+sudo systemctl start docker
+sudo systemctl enable docker
+```
+## Configure Permissions:
+* Add your user to the docker group so you can run commands without sudo:
+
+```
+sudo usermod -aG docker $USER
+newgrp docker
+```
+Verify:
+```
+docker --version
+```
+### 5. Docker Compose
+
+* Used for orchestrating multi-container ledger environments.
+```
+sudo apt install -y docker-compose
+```
+Verify:
+```
+docker-compose --version
+```
+### 6. OpenJDK (Java 8)
+
+* Required specifically for Corda ledger support.
+```
+sudo apt install -y openjdk-8-jdk
+```
+Verify:
+```
+java -version
+```
+### 7. Go
+
+* Required for Fabric and SATP components.
+```
+sudo apt install -y golang-go
+```
+Verify:
+```
+go version
+```
+### 8. Foundry
+
+* Required for SATP Hermes smart contract compilation.
+```
+curl -L [https://foundry.paradigm.xyz](https://foundry.paradigm.xyz) | bash
+source ~/.bashrc
+foundryup
+```
+Verify:
+```
+forge --version
+```
 ### Windows 
 * Insert Linux instructions here 
 


### PR DESCRIPTION
fixes #4173 
Adds a dedicated Ubuntu/Linux setup section to the build instructions to improve onboarding for contributors using non-macOS environments.
**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.