### PR TITLE
docs(docs): remove stale template text and repo links

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -135,7 +135,7 @@ We test most frequently on Ubuntu 20.04 LTS
 * Clone the repository
 
 ```sh
-git clone https://github.com/hyperledger/cactus.git
+git clone https://github.com/hyperledger-cacti/cacti.git
 ```
 
 
@@ -149,7 +149,7 @@ git config --system core.longpaths true
 * Change directories to the project root
 
 ```sh
-cd cactus
+cd cacti
 ```
 
 * Run this command to enable corepack (Corepack is included by default with all Node.js installs, but is currently opt-in.)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,17 @@
-# Welcome to the documentation template
+# Hyperledger Cacti Documentation
 
-This repository serves as a template for creating documentation for Hyperledger projects. The template utilizes MkDocs (documentation at [mkdocs.org](https://www.mkdocs.org)) and the theme Material for MkDocs (documentation at [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/)). Material adds a number of extra features to MkDocs, and Hyperledger repositories can take advantage of the theme's [Insiders](https://squidfunk.github.io/mkdocs-material/insiders/) capabilities.
+This directory contains the source for the Hyperledger Cacti documentation
+site. It uses MkDocs (documentation at [mkdocs.org](https://www.mkdocs.org)),
+the Material for MkDocs theme, and the Mike plugin for versioned deployments to
+GitHub Pages.
 
 [Material for MkDocs]: https://squidfunk.github.io/mkdocs-material/
 [Mike]: https://github.com/jimporter/mike
 
 ## Prerequisites
 
-To test the documents and update the published site, the following tools are needed:
+To preview the docs locally and update the published site, the following tools
+are needed:
 
 - A Bash shell
 - git
@@ -23,11 +27,11 @@ To test the documents and update the published site, the following tools are nee
 ### Python 3
 `Python 3` can be installed locally, as described in the [Python Getting Started guide](https://www.python.org/about/gettingstarted/).
 
-### Mkdocs
+### MkDocs
 
-The Mkdocs-related items can be installed locally, as described in the [Material
-for Mkdocs] installation instructions. The short, case-specific version of those
-instructions follow:
+The MkDocs-related items can be installed locally, as described in the
+[Material for MkDocs] installation instructions. The short, case-specific
+version for this repository is:
 
 ```bash
 pip install -r requirements.txt
@@ -35,7 +39,7 @@ pip install -r requirements.txt
 
 ### Verify Setup
 
-To verify your setup, check that you can run `mkdocs` by running the command `mkdocs --help` to see the help text.
+To verify your setup, run `mkdocs --help` and confirm the help text is shown.
 
 ## Useful MkDocs Commands
 

--- a/docs/docs/cactus/build.md
+++ b/docs/docs/cactus/build.md
@@ -131,7 +131,7 @@ Getting Started
 *   Clone the repository
     
 
-git clone https://github.com/hyperledger/cactus.git
+git clone https://github.com/hyperledger-cacti/cacti.git
 
 Windows specific gotcha: `File paths too long` error when cloning. To fix: Open PowerShell with administrative rights and then run the following:
 
@@ -140,7 +140,7 @@ git config \--system core.longpaths true
 *   Change directories to the project root
     
 
-cd cactus
+cd cacti
 
 *   Run this command to enable corepack (Corepack is included by default with all Node.js installs, but is currently opt-in.)
     

--- a/docs/docs/cactus/contributing.md
+++ b/docs/docs/cactus/contributing.md
@@ -9,14 +9,14 @@ There are many ways to contribute to Hyperledger Cactus, both as a user and as a
 
 As a user, this can include:
 
-*   [Making Feature/Enhancement Proposals](https://github.com/hyperledger/cactus/issues/new?assignees=&amp;labels=enhancement&amp;template=feature_request.md&amp;title=)
+*   [Making Feature/Enhancement Proposals](https://github.com/hyperledger-cacti/cacti/issues/new?assignees=&amp;labels=enhancement&amp;template=feature_request.md&amp;title=)
     
-*   [Reporting bugs](https://github.com/hyperledger/cactus/issues/new?assignees=&amp;labels=bug&amp;template=bug_report.md&amp;title=)
+*   [Reporting bugs](https://github.com/hyperledger-cacti/cacti/issues/new?assignees=&amp;labels=bug&amp;template=bug_report.md&amp;title=)
     
 
 As a developer:
 
-*   if you only have a little time, consider picking up a [“help-wanted”](https://github.com/hyperledger/cactus/labels/help%20wanted) or [“good-first-issue”](https://github.com/hyperledger/cactus/labels/good%20first%20issue) task
+*   if you only have a little time, consider picking up a [“help-wanted”](https://github.com/hyperledger-cacti/cacti/labels/help%20wanted) or [“good-first-issue”](https://github.com/hyperledger-cacti/cacti/labels/good%20first%20issue) task
     
 *   If you can commit to full-time development, then please contact us on our [Rocketchat channel](https://chat.hyperledger.org/channel/cactus) to work through logistics!
     
@@ -61,7 +61,7 @@ PR Checklist - Contributor/Developer
 
 **To avoid issues in the future, do not install dependencies globally. Ensure all dependencies are kept self-contained.**
 
-1.  Fork [hyperledger/cactus](https://github.com/hyperledger/cactus) via Github UI
+1.  Fork [hyperledger-cacti/cacti](https://github.com/hyperledger-cacti/cacti) via Github UI
     
     *   If you are using the Git client on the Windows operating system, you will need to enable long paths for git which you can do in PowerShell by executing the command below. To clarify, this may also apply if you are using any Git GUI application on Windows such as `Github Desktop` or others.
         
@@ -172,7 +172,7 @@ Create local branch
 2.  Setup your local fork to keep up-to-date (optional)
     
     \# Add 'upstream' repo to list of remotes
-    git remote add upstream https://github.com/hyperledger/cactus.git
+    git remote add upstream https://github.com/hyperledger-cacti/cacti.git
     
     \# Verify the new remote named 'upstream'
     git remote \-v


### PR DESCRIPTION
## Summary
- remove the leftover template intro from `docs/README.md`
- update old `hyperledger/cactus` links in the contributor guide
- fix the clone URL and `cd` path in both build guides

Part of #4034.

These are small cleanup fixes, but they matter because the current docs still send readers to old repo paths in a few places.