### PR TITLE
fix(satp-hermes): await async DB writes in Stage 0 and Stage 2

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage0-client-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage0-client-service.ts
@@ -623,7 +623,7 @@ export class Stage0ClientService extends SATPService {
         session.verify(fnTag, SessionType.CLIENT, false, false, true);
 
         const sessionData = session.getClientSessionData();
-        this.dbLogger.persistLogEntry({
+        await this.dbLogger.persistLogEntry({
           sessionId: sessionData.id,
           type: "wrap-token-client",
           operation: "init",
@@ -632,7 +632,7 @@ export class Stage0ClientService extends SATPService {
         });
         try {
           this.Log.info(`exec-${stepTag}`);
-          this.dbLogger.persistLogEntry({
+          await this.dbLogger.persistLogEntry({
             sessionId: sessionData.id,
             type: "wrap-token-client",
             operation: "exec",
@@ -673,7 +673,7 @@ export class Stage0ClientService extends SATPService {
             sign(this.Signer, sessionData.senderWrapAssertionClaim.receipt),
           );
 
-          this.dbLogger.storeProof({
+          await this.dbLogger.storeProof({
             sessionId: sessionData.id,
             type: "wrap-token-client",
             operation: "done",
@@ -685,7 +685,7 @@ export class Stage0ClientService extends SATPService {
           this.Log.info(`${fnTag}, done-${fnTag}`);
         } catch (error) {
           this.logger.debug(`Crash in ${fnTag}`, error);
-          this.dbLogger.persistLogEntry({
+          await this.dbLogger.persistLogEntry({
             sessionId: sessionData.id,
             type: "wrap-token-client",
             operation: "fail",

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage2-client-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage2-client-service.ts
@@ -293,7 +293,7 @@ export class Stage2ClientService extends SATPService {
 
         const sessionData = session.getClientSessionData();
         this.Log.info(`init-${stepTag}`);
-        this.dbLogger.storeProof({
+        await this.dbLogger.storeProof({
           sessionId: sessionData.id,
           type: "lock-asset",
           operation: "init",
@@ -302,7 +302,7 @@ export class Stage2ClientService extends SATPService {
         });
         try {
           this.Log.info(`exec-${stepTag}`);
-          this.dbLogger.storeProof({
+          await this.dbLogger.storeProof({
             sessionId: sessionData.id,
             type: "lock-asset",
             operation: "exec",
@@ -349,7 +349,7 @@ export class Stage2ClientService extends SATPService {
             sign(this.Signer, sessionData.lockAssertionClaim.receipt),
           );
 
-          this.dbLogger.storeProof({
+          await this.dbLogger.storeProof({
             sessionId: sessionData.id,
             type: "lock-asset",
             operation: "done",
@@ -358,7 +358,7 @@ export class Stage2ClientService extends SATPService {
           });
           this.Log.info(`${fnTag}, done-${fnTag}`);
         } catch (error) {
-          this.dbLogger.storeProof({
+          await this.dbLogger.storeProof({
             sessionId: sessionData.id,
             type: "lock-asset",
             operation: "fail",

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/server/stage0-server-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/server/stage0-server-service.ts
@@ -747,7 +747,7 @@ export class Stage0ServerService extends SATPService {
         }
 
         const sessionData = session.getServerSessionData();
-        this.dbLogger.persistLogEntry({
+        await this.dbLogger.persistLogEntry({
           sessionId: sessionData.id,
           type: "wrap-token-server",
           operation: "init",
@@ -756,7 +756,7 @@ export class Stage0ServerService extends SATPService {
         });
         try {
           this.Log.info(`exec-${stepTag}`);
-          this.dbLogger.persistLogEntry({
+          await this.dbLogger.persistLogEntry({
             sessionId: sessionData.id,
             type: "wrap-token-server",
             operation: "exec",
@@ -797,7 +797,7 @@ export class Stage0ServerService extends SATPService {
             sign(this.Signer, sessionData.receiverWrapAssertionClaim.receipt),
           );
 
-          this.dbLogger.storeProof({
+          await this.dbLogger.storeProof({
             sessionId: sessionData.id,
             type: "wrap-token-server",
             operation: "done",
@@ -810,7 +810,7 @@ export class Stage0ServerService extends SATPService {
         } catch (error) {
           this.Log.debug(`Crash in ${fnTag}`, error);
 
-          this.dbLogger.persistLogEntry({
+          await this.dbLogger.persistLogEntry({
             sessionId: sessionData.id,
             type: "wrap-token-server",
             operation: "fail",


### PR DESCRIPTION
## Summary

- Add missing `await` to 12 fire-and-forget `storeProof()` and `persistLogEntry()` calls in Stage 0 and Stage 2 asset operations
- Same bug pattern fixed for Stage 3 in #4168, but Stage 0 and Stage 2 were missed
- Prevents silent proof loss, unhandled promise rejections, and crash recovery failures during blockchain lock/wrap operations

Fixes #4177

## Affected Files

| File | Method | Fix |
|------|--------|-----|
| `stage2-client-service.ts` | `lockAsset()` | 4× `await` added to `storeProof()` |
| `stage0-client-service.ts` | `wrapAsset()` | 4× `await` added to `persistLogEntry()`/`storeProof()` |
| `stage0-server-service.ts` | `wrapAsset()` | 4× `await` added to `persistLogEntry()`/`storeProof()` |

## Test plan

- [ ] Verify Stage 2 `lockAsset` persists all proofs to DB before returning
- [ ] Verify Stage 0 `wrapAsset` (client + server) persists all logs/proofs before returning
- [ ] Confirm DB write failures in `storeProof`/`persistLogEntry` are now caught by existing try/catch blocks
- [ ] Run existing SATP integration tests

Signed-off-by: mn-ram <235066282+mn-ram@users.noreply.github.com>