### PR TITLE
fix(security): remove stale corda 4.6 test image default

### DIFF
--- a/packages/cactus-test-tooling/src/main/typescript/corda/corda-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/corda/corda-test-ledger.ts
@@ -39,8 +39,8 @@ export interface ICordaTestLedgerConstructorOptions {
  * Provides default options for Corda container
  */
 const DEFAULTS = Object.freeze({
-  imageVersion: "2021-03-01-7e07b5b",
-  imageName: "petermetz/cactus-corda-4-6-all-in-one-obligation",
+  imageVersion: "2022-03-31-28f0cbf--1956",
+  imageName: "ghcr.io/hyperledger/cactus-corda-4-8-all-in-one-obligation",
   rpcPortNotary: 10003,
   sshPort: 22,
   rpcPortA: 10008,


### PR DESCRIPTION
## Summary

Remove the only remaining default dependency on the old Corda 4.6 all-in-one image that was flagged in issue #2065.

## Changes

- update `CordaTestLedger` default image from the stale `petermetz/cactus-corda-4-6-all-in-one-obligation` image
- switch the default to the maintained Corda 4.8 obligation image that is already referenced elsewhere in this repo

## Notes

- this follows the current issue guidance to address the problem only if the old depending package still remains
- the repo no longer contains a Corda 4.6 all-in-one build definition, but `CordaTestLedger` still carried the old image as its default

## Verification

- confirmed this was the only remaining `cactus-corda-4-6` reference in the repository

Fixes #2065