### PR TITLE
docs(examples): add minimal cacti-starter onboarding template(Level 2)

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -120,8 +120,109 @@ _Unless explicitly stated otherwise, each bullet will apply to both Intel and AR
     ```
 
 ### Linux
-* Insert Linux instructions here
+# Getting Started: Ubuntu / Linux
 
+This guide provides a step-by-step walkthrough for setting up the Hyperledger Cacti development environment on Ubuntu (20.04+ recommended). These steps should also work for most Debian-based distributions.
+
+---
+
+## Prerequisites
+
+### 1. Git
+* Ensure your package index is updated and Git is installed for version control.
+```bash
+sudo apt update
+sudo apt install -y git
+```
+
+### 2. Node.js (v20.20.0) & npm
+
+* Cacti requires a specific Node version. We recommend using nvm (Node Version Manager) to avoid conflicts with system defaults.
+
+```
+curl -o- [https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh](https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh) | bash
+source ~/.bashrc
+
+nvm install 20.20.0
+nvm use 20.20.0
+```
+Verify:
+```
+node -v
+npm -v
+```
+### 3. Yarn (via Corepack)
+
+* Cacti uses Yarn for package management. Enable it using the built-in Corepack:
+
+```
+npm run enable-corepack
+```
+Verify:
+```
+yarn -v
+```
+### 4. Docker Engine
+
+* Docker is required to run the various blockchain ledgers supported by Cacti.
+```
+sudo apt install -y docker.io
+sudo systemctl start docker
+sudo systemctl enable docker
+```
+## Configure Permissions:
+* Add your user to the docker group so you can run commands without sudo:
+
+```
+sudo usermod -aG docker $USER
+newgrp docker
+```
+Verify:
+```
+docker --version
+```
+### 5. Docker Compose
+
+* Used for orchestrating multi-container ledger environments.
+```
+sudo apt install -y docker-compose
+```
+Verify:
+```
+docker-compose --version
+```
+### 6. OpenJDK (Java 8)
+
+* Required specifically for Corda ledger support.
+```
+sudo apt install -y openjdk-8-jdk
+```
+Verify:
+```
+java -version
+```
+### 7. Go
+
+* Required for Fabric and SATP components.
+```
+sudo apt install -y golang-go
+```
+Verify:
+```
+go version
+```
+### 8. Foundry
+
+* Required for SATP Hermes smart contract compilation.
+```
+curl -L [https://foundry.paradigm.xyz](https://foundry.paradigm.xyz) | bash
+source ~/.bashrc
+foundryup
+```
+Verify:
+```
+forge --version
+```
 ### Windows 
 * Insert Linux instructions here 
 

--- a/examples/cacti-starter/README.md
+++ b/examples/cacti-starter/README.md
@@ -1,0 +1,45 @@
+# Cacti Starter: Minimal Onboarding Template
+
+Welcome to the Hyperledger Cacti Starter! This template provides the simplest possible "Hello World" experience for new contributors. It demonstrates Level 2 architecture (API Server + Plugin) with minimal setup.
+
+## 🚀 Quick Start
+
+```bash
+cd examples/cacti-starter
+./bootstrap.sh
+./run.sh
+```
+
+- Swagger UI: [http://127.0.0.1:4000/api/v1/api-docs/](http://127.0.0.1:4000/api/v1/api-docs/)
+
+## 🧪 Test the Keychain Plugin
+
+In a new terminal:
+
+```bash
+./test.sh
+```
+
+## 🏗️ Architecture
+
+- **API Server**: Runs the Cacti REST API
+- **Plugin**: Only `@hyperledger/cactus-plugin-keychain-memory` is loaded
+- **No JWT, No TLS**: Authentication and encryption are disabled for simplicity
+
+```
++-------------------+
+|  API Server       |
+|-------------------|
+| Keychain Plugin   |
++-------------------+
+```
+
+## 📄 Purpose
+
+- Help new contributors get started in minutes
+- Provide a working, hackable Cacti setup
+- Avoid all unnecessary complexity
+
+---
+
+**Happy hacking!**

--- a/examples/cacti-starter/bootstrap.sh
+++ b/examples/cacti-starter/bootstrap.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+echo "[Cacti Starter] Enabling corepack..."
+npm run enable-corepack
+
+echo "[Cacti Starter] Installing dependencies..."
+yarn install
+
+echo "[Cacti Starter] Running yarn configure..."
+yarn configure
+
+echo "[Cacti Starter] Bootstrap complete!"

--- a/examples/cacti-starter/run.sh
+++ b/examples/cacti-starter/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/../.."
+CONFIG_PATH="$SCRIPT_DIR/.config.json"
+
+cd "$REPO_ROOT"
+
+echo "[Cacti Starter] Starting API server with custom config..."
+API_CONFIG_FILE="$CONFIG_PATH" npm run start:api-server

--- a/examples/cacti-starter/test.sh
+++ b/examples/cacti-starter/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+API_URL="http://127.0.0.1:4000/api/v1/plugins/@hyperledger/cactus-plugin-keychain-memory/set-keychain-entry-v1"
+
+PAYLOAD='{
+  "key": "hello",
+  "value": "world",
+  "keychainId": "starter-keychain"
+}'
+
+echo "[Cacti Starter] Testing keychain set-keychain-entry endpoint..."
+RESPONSE=$(curl -s -X POST "$API_URL" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD")
+
+echo "[Cacti Starter] Response:"
+echo "$RESPONSE"


### PR DESCRIPTION
Issue #4033 
Adds a minimal onboarding starter template under examples/cacti-starter/ to simplify the initial setup and usage of Hyperledger Cacti.

This provides a reproducible "Hello World" experience using the Level 2 architecture (API Server + Plugin).

**Changes**
Added a new starter template:
`examples/cacti-starter/README.md`
`examples/cacti-starter/bootstrap.sh`
`examples/cacti-starter/run.sh`
`examples/cacti-starter/test.sh`
Provides a minimal `.config.json` setup using a single plugin (keychain-memory)

Simplifies setup by:

Disabling JWT authentication
Disabling TLS for local development
Includes a simple API test to demonstrate functionality

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.