### PR TITLE
docs: update outdated pre-merger references in contributor documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 Code of Conduct Guidelines
 ==========================
 
-Please review the Hyperledger [Code of Conduct](https://wiki.hyperledger.org/community/hyperledger-project-code-of-conduct) before participating and abide by these community standards. 
+Please review the [LF Decentralized Trust Code of Conduct](https://lf-decentralized-trust.github.io/governance/governing-documents/code-of-conduct) before participating and abide by these community standards.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@
 Thank you for your interest to contribute to Hyperledger Cacti! :tada:
 
 
-First things first, please review the [Hyperledger Code of Conduct](https://wiki.hyperledger.org/display/HYP/Hyperledger+Code+of+Conduct) before participating.
+First things first, please review the [Hyperledger Code of Conduct](https://lf-decentralized-trust.github.io/governance/governing-documents/code-of-conduct) before participating.
 
 There are many ways to contribute to Hyperledger Cacti, both as a user and as a developer.
 
@@ -79,7 +79,7 @@ Further reading:
 ## PR Checklist - Contributor/Developer
 **To avoid issues in the future, do not install dependencies globally. Ensure all dependencies are kept self-contained.**
 
-1. Fork [hyperledger/cacti](https://github.com/hyperledger/cacti) via Github UI
+1. Fork [hyperledger-cacti/cacti](https://github.com/hyperledger-cacti/cacti) via Github UI
    - If you are using the Git client on the Windows operating system, you will need to enable long paths for git
      which you can do in PowerShell by executing the command below.
      To clarify, this may also apply if you are using any Git GUI application on Windows such as `Github Desktop` or others.
@@ -147,7 +147,7 @@ To protect the Hyperledger Cacti source code, GitHub pull requests are accepted 
 2. Setup your local fork to keep up-to-date (optional)
    ```
    # Add 'upstream' repo to list of remotes
-   git remote add upstream https://github.com/hyperledger/cacti.git
+   git remote add upstream https://github.com/hyperledger-cacti/cacti.git
 
    # Verify the new remote named 'upstream'
    git remote -v

--- a/docs/docs/cactus/build.md
+++ b/docs/docs/cactus/build.md
@@ -1,16 +1,16 @@
-Hyperledger Cactus Build Instructions
+Hyperledger Cacti Build Instructions
 =====================================
 
-This is the place to start if you want to give Cactus a spin on your local machine or if you are planning on contributing.
+This is the place to start if you want to give Cacti a spin on your local machine or if you are planning on contributing.
 
-> This is not a guide for `using` Cactus for your projects that have business logic but rather a guide for people who want to make changes to the code of Cactus. If you are just planning on using Cactus as an npm dependency for your project, then you might not need this guide at all.
+> This is not a guide for `using` Cacti for your projects that have business logic but rather a guide for people who want to make changes to the code of Cacti. If you are just planning on using Cacti as an npm dependency for your project, then you might not need this guide at all.
 
 The project uses Typescript for both back-end and front-end components.
 
 Developers guide
 ----------------
 
-This is a video guide to setup Hyperledger Cactus on your local machine.
+This is a video guide to setup Hyperledger Cacti on your local machine.
 
 ### Installing git
 
@@ -131,7 +131,7 @@ Getting Started
 *   Clone the repository
     
 
-git clone https://github.com/hyperledger/cactus.git
+git clone https://github.com/hyperledger-cacti/cacti.git
 
 Windows specific gotcha: `File paths too long` error when cloning. To fix: Open PowerShell with administrative rights and then run the following:
 
@@ -140,7 +140,7 @@ git config \--system core.longpaths true
 *   Change directories to the project root
     
 
-cd cactus
+cd cacti
 
 *   Run this command to enable corepack (Corepack is included by default with all Node.js installs, but is currently opt-in.)
     
@@ -160,7 +160,7 @@ For example you can _run a ledger single status endpoint test_ via the REST API 
 
 npx tap \--ts \--timeout\=600 packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-single-status-endpoint.test.ts
 
-_You can also start the API server_ and verify more complex scenarios with an arbitrary list of plugins loaded into Cactus. This is useful for when you intend to develop your plugin either as a Cactus maintained plugin or one on your own.
+_You can also start the API server_ and verify more complex scenarios with an arbitrary list of plugins loaded into Cactus. This is useful for when you intend to develop your plugin either as a Cacti maintained plugin or one on your own.
 
 npm run generate-api-server-config
 
@@ -196,13 +196,13 @@ Build Script Decision Tree
 
 The `npm run watch` script should cover 99% of the cases when it comes to working on Cactus code and having it recompile, but for that last 1% you’ll need to get your hands dirty with the rest of the build scripts. Usually this is only needed when you are adding new dependencies (npm packages) as part of something that you are implementing.
 
-There are a lot of different build scripts in Cactus in order to provide contributors fine(r) grained control over what parts of the framework they wish build.
+There are a lot of different build scripts in Cacti in order to provide contributors fine(r) grained control over what parts of the framework they wish build.
 
 > Q: Why the complexity of so many build scripts?
 > 
 > A: We could just keep it simple with a single build script that builds everything always, but that would be a nightmare to wait for after having changed a single line of code for example.
 
-To figure out which script could work for rebuilding Cactus, please follow the following decision tree (and keep in mind that we have `npm run watch` too)
+To figure out which script could work for rebuilding Cacti, please follow the following decision tree (and keep in mind that we have `npm run watch` too)
 
 ![Build Script Decision Tree](_images/build-script-decision-tree-2021-03-06.png)
 
@@ -222,11 +222,11 @@ By creating a PR for the edited `ci.yml` file, this will the CI to run their tes
 
 1.  Go to the PR and click the `checks` tab
     
-2.  Go to the `Actions` tab within the main Hyperledger Cactus Repository
+2.  Go to the `Actions` tab within the main Hyperledger Cacti Repository
     
 
 Click on the `CI Cactus workflow`. There should be a new job you’ve created be listed underneath the `build (ubuntu-22.04)` jobs. Click on the the new job (what’s you’ve named your build) and locate the SSH Session within the `Setup Upterm Session` dropdown. Copy the SSH command that start with `ssh` and ends in `.dev` (ex. ssh \*\*\*\*\*\*\*\*\*\*:\*\*\*\*\*\*\*\*\*\*\*@uptermd.upterm.dev). Open your OS and paste the SSH command script in order to begin an upterm session.
 
-[Previous](introduction.md "Welcome to Hyperledger Cactus documentation!") [Next](examples.md "Examples")
+[Previous](introduction.md "Welcome to Hyperledger Cacti documentation!") [Next](examples.md "Examples")
 
 * * *

--- a/docs/docs/cactus/code-of-conduct.md
+++ b/docs/docs/cactus/code-of-conduct.md
@@ -1,7 +1,7 @@
 Code of Conduct Guidelines
 ======================================================================================
 
-Please review the Hyperledger [Code of Conduct](https://wiki.hyperledger.org/community/hyperledger-project-code-of-conduct) before participating and abide by these community standards.
+Please review the [LF Decentralized Trust Code of Conduct](https://lf-decentralized-trust.github.io/governance/governing-documents/code-of-conduct) before participating and abide by these community standards.
 
 [Previous](governance.md "Governance") [Next](contributing.md "Contributing")
 

--- a/docs/docs/cactus/contributing.md
+++ b/docs/docs/cactus/contributing.md
@@ -1,22 +1,22 @@
 Contributing
 ==========================================================
 
-Thank you for your interest to contribute to Hyperledger Cactus! :tada:
+Thank you for your interest to contribute to Hyperledger Cacti! :tada:
 
-First things first, please review the [Hyperledger Code of Conduct](https://wiki.hyperledger.org/display/HYP/Hyperledger+Code+of+Conduct) before participating.
+First things first, please review the [Hyperledger Code of Conduct](https://lf-decentralized-trust.github.io/governance/governing-documents/code-of-conduct) before participating.
 
-There are many ways to contribute to Hyperledger Cactus, both as a user and as a developer.
+There are many ways to contribute to Hyperledger Cacti, both as a user and as a developer.
 
 As a user, this can include:
 
-*   [Making Feature/Enhancement Proposals](https://github.com/hyperledger/cactus/issues/new?assignees=&amp;labels=enhancement&amp;template=feature_request.md&amp;title=)
+*   [Making Feature/Enhancement Proposals](https://github.com/hyperledger-cacti/cacti/issues/new?assignees=&amp;labels=enhancement&amp;template=feature_request.md&amp;title=)
     
-*   [Reporting bugs](https://github.com/hyperledger/cactus/issues/new?assignees=&amp;labels=bug&amp;template=bug_report.md&amp;title=)
+*   [Reporting bugs](https://github.com/hyperledger-cacti/cacti/issues/new?assignees=&amp;labels=bug&amp;template=bug_report.md&amp;title=)
     
 
 As a developer:
 
-*   if you only have a little time, consider picking up a [“help-wanted”](https://github.com/hyperledger/cactus/labels/help%20wanted) or [“good-first-issue”](https://github.com/hyperledger/cactus/labels/good%20first%20issue) task
+*   if you only have a little time, consider picking up a ["help-wanted"](https://github.com/hyperledger-cacti/cacti/labels/help%20wanted) or ["good-first-issue"](https://github.com/hyperledger-cacti/cacti/labels/good%20first%20issue) task
     
 *   If you can commit to full-time development, then please contact us on our [Rocketchat channel](https://chat.hyperledger.org/channel/cactus) to work through logistics!
     
@@ -61,7 +61,7 @@ PR Checklist - Contributor/Developer
 
 **To avoid issues in the future, do not install dependencies globally. Ensure all dependencies are kept self-contained.**
 
-1.  Fork [hyperledger/cactus](https://github.com/hyperledger/cactus) via Github UI
+1.  Fork [hyperledger-cacti/cacti](https://github.com/hyperledger-cacti/cacti) via Github UI
     
     *   If you are using the Git client on the Windows operating system, you will need to enable long paths for git which you can do in PowerShell by executing the command below. To clarify, this may also apply if you are using any Git GUI application on Windows such as `Github Desktop` or others.
         
@@ -99,7 +99,7 @@ PR Checklist - Contributor/Developer
         
     2.  Be aware that we are using git commit hooks for the automation of certain mundane tasks such as applying the required code style and formatting so your code will be wrapped at 80 characters each line automatically. If you wish to see how your changes will be altered by the formatter you can run the `npm run prettier` command from a terminal or install an IDE extension for the `Prettier` tool that can do the same (VSCode has one that is known to work).
         
-8.  Ensure your branch is rebased onto the `upstream` main branch where `upstream` is fancy git talk for the main Cactus repo on Github (the one you created your fork from).
+8.  Ensure your branch is rebased onto the `upstream` main branch where `upstream` is fancy git talk for the main Cacti repo on Github (the one you created your fork from).
     
     1.  **Do not** duplicate your pull request after it has been reviewed. Duplication here means closing the existing PR and then opening a brand new one which does not contain the review history anymore. If you encounter issues with version control that you do not know how to solve the maintainers will be happy to assist to ensure that you do not need to open a new pull request from scratch.
         
@@ -160,7 +160,7 @@ Ensure all the following conditions are met (on top of you agreeing with the cha
     3.  If you are adamant that you do not want to merge a PR with multiple commits, that is completely understandable and fair game. The recommended approach there is to ask the contributor to break the pull request up to multiple pull requests by doing an interactive rebase on their branch and cherry picking/re-ordering things accordingly. This is a fairly advanced git use case so you might want to help them out with it (or ask Peter who is the one constantly nagging everyone about these git rules…)
         
 
-To protect the Hyperledger Cactus source code, GitHub pull requests are accepted from forked repositories only. There are also quality standards identified and documented here that will be enhanced over time.
+To protect the Hyperledger Cacti source code, GitHub pull requests are accepted from forked repositories only. There are also quality standards identified and documented here that will be enhanced over time.
 
 Create local branch
 ------------------------------------------------------------------------
@@ -172,7 +172,7 @@ Create local branch
 2.  Setup your local fork to keep up-to-date (optional)
     
     \# Add 'upstream' repo to list of remotes
-    git remote add upstream https://github.com/hyperledger/cactus.git
+    git remote add upstream https://github.com/hyperledger-cacti/cacti.git
     
     \# Verify the new remote named 'upstream'
     git remote \-v
@@ -209,13 +209,13 @@ Create local branch
 7.  Repeat step 3 to 6 when you need to prepare posting new pull request.
     
 
-NOTE: Once you submitted pull request to Cactus repository, step 6 is not necessary when you made further changes with `git commit --amend` since your amends will be sent automatically.
+NOTE: Once you submitted pull request to the Cacti repository, step 6 is not necessary when you made further changes with `git commit --amend` since your amends will be sent automatically.
 
 NOTE: You can refer original tutorial [‘GitHub Standard Fork & Pull Request Workflow’](https://gist.github.com/Chaser324/ce0505fbed06b947d962)
 
 ### Directory structure
 
-Whenever you begin to use your codes on Hyperledger Cactus, you should follow the directory strecture on Hyperledger Cactus. The current directory structure is described as the following:
+Whenever you begin to use your codes on Hyperledger Cacti, you should follow the directory structure on Hyperledger Cacti. The current directory structure is described as the following:
 
 > *   contrib/ : Contributions from each participants, which are not directly dependent on Cactus code.
 >     
@@ -353,7 +353,7 @@ Working with the Code
 
 There are additional details about this in the [BUILD.md](#./BUILD.md) file in the project root as well.
 
-We use Lerna for managing the [monorepo](https://blog.npmjs.org/post/186494959890/monorepos-and-npm) that is Cactus.
+We use Lerna for managing the [monorepo](https://blog.npmjs.org/post/186494959890/monorepos-and-npm) that is Cacti.
 
 > We heavily rely on Docker for testing the ledger plugins.
 
@@ -492,6 +492,6 @@ Further details:
 *   https://spin.atomicobject.com/2016/12/16/reproducible-builds-npm-yarn/
     
 
-[Previous](code-of-conduct.md "Code of Conduct Guidelines") [Next](whitepaper.md "Hyperledger Cactus White Paper")
+[Previous](code-of-conduct.md "Code of Conduct Guidelines") [Next](whitepaper.md "Hyperledger Cacti White Paper")
 
 * * *


### PR DESCRIPTION
## Description

Audits and updates outdated pre-merger references in contributor-facing documentation.

This is part of the **Cacti Cleanup Initiative** (goal #4: Improve documentation).

### Changes (5 files, 30 lines)

- **`CONTRIBUTING.md`** — Fixed fork URL (`hyperledger/cacti` → `hyperledger-cacti/cacti`), upstream remote URL, and Code of Conduct link
- **`docs/docs/cactus/contributing.md`** — Updated 17 outdated references: repo URLs, issue template links, fork/clone instructions, and project naming (Cactus → Cacti)
- **`docs/docs/cactus/build.md`** — Fixed clone URL, directory name, and 11 Cactus → Cacti naming references
- **`CODE_OF_CONDUCT.md`** & **`docs/docs/cactus/code-of-conduct.md`** — Updated Code of Conduct links from defunct `wiki.hyperledger.org` to current LF Decentralized Trust governance docs

### Audit Summary

Found **689 references** to the old `hyperledger/cactus` repository URL across markdown files. This PR addresses the **contributor-facing subset** — the files new contributors read first. Additional cleanup PRs can follow for package-level and Weaver docs.

### Not Changed (intentionally)
- `@hyperledger/cactus-*` npm package names (still valid published package names)
- `CHANGELOG.md` (historical record)
- Blog posts (historical context)

### Related
- Cacti Cleanup Initiative: https://github.com/orgs/hyperledger-cacti/projects/2
- Mentorship Issue: LF-Decentralized-Trust-Mentorships/mentorship-program#62
