### PR TITLE
docs: update Cactus naming to Cacti across documentation pages

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 Code of Conduct Guidelines
 ==========================
 
-Please review the Hyperledger [Code of Conduct](https://wiki.hyperledger.org/community/hyperledger-project-code-of-conduct) before participating and abide by these community standards. 
+Please review the [LF Decentralized Trust Code of Conduct](https://lf-decentralized-trust.github.io/governance/governing-documents/code-of-conduct) before participating and abide by these community standards.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@
 Thank you for your interest to contribute to Hyperledger Cacti! :tada:
 
 
-First things first, please review the [Hyperledger Code of Conduct](https://wiki.hyperledger.org/display/HYP/Hyperledger+Code+of+Conduct) before participating.
+First things first, please review the [Hyperledger Code of Conduct](https://lf-decentralized-trust.github.io/governance/governing-documents/code-of-conduct) before participating.
 
 There are many ways to contribute to Hyperledger Cacti, both as a user and as a developer.
 
@@ -79,7 +79,7 @@ Further reading:
 ## PR Checklist - Contributor/Developer
 **To avoid issues in the future, do not install dependencies globally. Ensure all dependencies are kept self-contained.**
 
-1. Fork [hyperledger/cacti](https://github.com/hyperledger/cacti) via Github UI
+1. Fork [hyperledger-cacti/cacti](https://github.com/hyperledger-cacti/cacti) via Github UI
    - If you are using the Git client on the Windows operating system, you will need to enable long paths for git
      which you can do in PowerShell by executing the command below.
      To clarify, this may also apply if you are using any Git GUI application on Windows such as `Github Desktop` or others.
@@ -147,7 +147,7 @@ To protect the Hyperledger Cacti source code, GitHub pull requests are accepted 
 2. Setup your local fork to keep up-to-date (optional)
    ```
    # Add 'upstream' repo to list of remotes
-   git remote add upstream https://github.com/hyperledger/cacti.git
+   git remote add upstream https://github.com/hyperledger-cacti/cacti.git
 
    # Verify the new remote named 'upstream'
    git remote -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@
 Thank you for your interest to contribute to Hyperledger Cacti! :tada:
 
 
-First things first, please review the [Hyperledger Code of Conduct](https://wiki.hyperledger.org/display/HYP/Hyperledger+Code+of+Conduct) before participating.
+First things first, please review the [LF Decentralized Trust Code of Conduct](https://lf-decentralized-trust.github.io/governance/governing-documents/code-of-conduct) before participating.
 If you use AI or LLM tooling in your contributions, please also review our [AI Guidelines](./AI_GUIDELINES.md).
 
 There are many ways to contribute to Hyperledger Cacti, both as a user and as a developer.
@@ -108,7 +108,7 @@ including concrete examples.
 ## PR Checklist - Contributor/Developer
 **To avoid issues in the future, do not install dependencies globally. Ensure all dependencies are kept self-contained.**
 
-1. Fork [hyperledger/cacti](https://github.com/hyperledger-cacti/cacti) via Github UI
+1. Fork [hyperledger-cacti/cacti](https://github.com/hyperledger-cacti/cacti) via Github UI
    - If you are using the Git client on the Windows operating system, you will need to enable long paths for git
      which you can do in PowerShell by executing the command below.
      To clarify, this may also apply if you are using any Git GUI application on Windows such as `Github Desktop` or others.
@@ -682,4 +682,3 @@ Bottom line: Do not use the the `^`, `~` and `*` syntax elements while declaring
 Further details:
 - https://reproducible-builds.org/
 - https://spin.atomicobject.com/2016/12/16/reproducible-builds-npm-yarn/
-

--- a/docs/docs/cactus/build.md
+++ b/docs/docs/cactus/build.md
@@ -1,16 +1,16 @@
-Hyperledger Cactus Build Instructions
+Hyperledger Cacti Build Instructions
 =====================================
 
-This is the place to start if you want to give Cactus a spin on your local machine or if you are planning on contributing.
+This is the place to start if you want to give Cacti a spin on your local machine or if you are planning on contributing.
 
-> This is not a guide for `using` Cactus for your projects that have business logic but rather a guide for people who want to make changes to the code of Cactus. If you are just planning on using Cactus as an npm dependency for your project, then you might not need this guide at all.
+> This is not a guide for `using` Cacti for your projects that have business logic but rather a guide for people who want to make changes to the code of Cacti. If you are just planning on using Cacti as an npm dependency for your project, then you might not need this guide at all.
 
 The project uses Typescript for both back-end and front-end components.
 
 Developers guide
 ----------------
 
-This is a video guide to setup Hyperledger Cactus on your local machine.
+This is a video guide to setup Hyperledger Cacti on your local machine.
 
 ### Installing git
 
@@ -131,7 +131,7 @@ Getting Started
 *   Clone the repository
     
 
-git clone https://github.com/hyperledger/cactus.git
+git clone https://github.com/hyperledger-cacti/cacti.git
 
 Windows specific gotcha: `File paths too long` error when cloning. To fix: Open PowerShell with administrative rights and then run the following:
 
@@ -140,7 +140,7 @@ git config \--system core.longpaths true
 *   Change directories to the project root
     
 
-cd cactus
+cd cacti
 
 *   Run this command to enable corepack (Corepack is included by default with all Node.js installs, but is currently opt-in.)
     
@@ -160,7 +160,7 @@ For example you can _run a ledger single status endpoint test_ via the REST API 
 
 npx tap \--ts \--timeout\=600 packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-single-status-endpoint.test.ts
 
-_You can also start the API server_ and verify more complex scenarios with an arbitrary list of plugins loaded into Cactus. This is useful for when you intend to develop your plugin either as a Cactus maintained plugin or one on your own.
+_You can also start the API server_ and verify more complex scenarios with an arbitrary list of plugins loaded into Cactus. This is useful for when you intend to develop your plugin either as a Cacti maintained plugin or one on your own.
 
 npm run generate-api-server-config
 
@@ -196,13 +196,13 @@ Build Script Decision Tree
 
 The `npm run watch` script should cover 99% of the cases when it comes to working on Cactus code and having it recompile, but for that last 1% you’ll need to get your hands dirty with the rest of the build scripts. Usually this is only needed when you are adding new dependencies (npm packages) as part of something that you are implementing.
 
-There are a lot of different build scripts in Cactus in order to provide contributors fine(r) grained control over what parts of the framework they wish build.
+There are a lot of different build scripts in Cacti in order to provide contributors fine(r) grained control over what parts of the framework they wish build.
 
 > Q: Why the complexity of so many build scripts?
 > 
 > A: We could just keep it simple with a single build script that builds everything always, but that would be a nightmare to wait for after having changed a single line of code for example.
 
-To figure out which script could work for rebuilding Cactus, please follow the following decision tree (and keep in mind that we have `npm run watch` too)
+To figure out which script could work for rebuilding Cacti, please follow the following decision tree (and keep in mind that we have `npm run watch` too)
 
 ![Build Script Decision Tree](_images/build-script-decision-tree-2021-03-06.png)
 
@@ -222,11 +222,11 @@ By creating a PR for the edited `ci.yml` file, this will the CI to run their tes
 
 1.  Go to the PR and click the `checks` tab
     
-2.  Go to the `Actions` tab within the main Hyperledger Cactus Repository
+2.  Go to the `Actions` tab within the main Hyperledger Cacti Repository
     
 
 Click on the `CI Cactus workflow`. There should be a new job you’ve created be listed underneath the `build (ubuntu-22.04)` jobs. Click on the the new job (what’s you’ve named your build) and locate the SSH Session within the `Setup Upterm Session` dropdown. Copy the SSH command that start with `ssh` and ends in `.dev` (ex. ssh \*\*\*\*\*\*\*\*\*\*:\*\*\*\*\*\*\*\*\*\*\*@uptermd.upterm.dev). Open your OS and paste the SSH command script in order to begin an upterm session.
 
-[Previous](introduction.md "Welcome to Hyperledger Cactus documentation!") [Next](examples.md "Examples")
+[Previous](introduction.md "Welcome to Hyperledger Cacti documentation!") [Next](examples.md "Examples")
 
 * * *

--- a/docs/docs/cactus/build.md
+++ b/docs/docs/cactus/build.md
@@ -232,6 +232,6 @@ By creating a PR for the edited `ci.yml` file, this will the CI to run their tes
 
 Click on the `CI Cactus workflow`. There should be a new job you’ve created be listed underneath the `build (ubuntu-22.04)` jobs. Click on the the new job (what’s you’ve named your build) and locate the SSH Session within the `Setup Upterm Session` dropdown. Copy the SSH command that start with `ssh` and ends in `.dev` (ex. ssh \*\*\*\*\*\*\*\*\*\*:\*\*\*\*\*\*\*\*\*\*\*@uptermd.upterm.dev). Open your OS and paste the SSH command script in order to begin an upterm session.
 
-[Previous](introduction.md "Welcome to Hyperledger Cactus documentation!") [Next](examples.md "Examples")
+[Previous](introduction.md "Welcome to Hyperledger Cacti documentation!") [Next](examples.md "Examples")
 
 * * *

--- a/docs/docs/cactus/code-of-conduct.md
+++ b/docs/docs/cactus/code-of-conduct.md
@@ -1,7 +1,7 @@
 Code of Conduct Guidelines
 ======================================================================================
 
-Please review the Hyperledger [Code of Conduct](https://wiki.hyperledger.org/community/hyperledger-project-code-of-conduct) before participating and abide by these community standards.
+Please review the [LF Decentralized Trust Code of Conduct](https://lf-decentralized-trust.github.io/governance/governing-documents/code-of-conduct) before participating and abide by these community standards.
 
 [Previous](governance.md "Governance") [Next](contributing.md "Contributing")
 

--- a/docs/docs/cactus/contributing.md
+++ b/docs/docs/cactus/contributing.md
@@ -1,22 +1,22 @@
 Contributing
 ==========================================================
 
-Thank you for your interest to contribute to Hyperledger Cactus! :tada:
+Thank you for your interest to contribute to Hyperledger Cacti! :tada:
 
-First things first, please review the [Hyperledger Code of Conduct](https://wiki.hyperledger.org/display/HYP/Hyperledger+Code+of+Conduct) before participating.
+First things first, please review the [Hyperledger Code of Conduct](https://lf-decentralized-trust.github.io/governance/governing-documents/code-of-conduct) before participating.
 
-There are many ways to contribute to Hyperledger Cactus, both as a user and as a developer.
+There are many ways to contribute to Hyperledger Cacti, both as a user and as a developer.
 
 As a user, this can include:
 
-*   [Making Feature/Enhancement Proposals](https://github.com/hyperledger/cactus/issues/new?assignees=&amp;labels=enhancement&amp;template=feature_request.md&amp;title=)
+*   [Making Feature/Enhancement Proposals](https://github.com/hyperledger-cacti/cacti/issues/new?assignees=&amp;labels=enhancement&amp;template=feature_request.md&amp;title=)
     
-*   [Reporting bugs](https://github.com/hyperledger/cactus/issues/new?assignees=&amp;labels=bug&amp;template=bug_report.md&amp;title=)
+*   [Reporting bugs](https://github.com/hyperledger-cacti/cacti/issues/new?assignees=&amp;labels=bug&amp;template=bug_report.md&amp;title=)
     
 
 As a developer:
 
-*   if you only have a little time, consider picking up a [“help-wanted”](https://github.com/hyperledger/cactus/labels/help%20wanted) or [“good-first-issue”](https://github.com/hyperledger/cactus/labels/good%20first%20issue) task
+*   if you only have a little time, consider picking up a ["help-wanted"](https://github.com/hyperledger-cacti/cacti/labels/help%20wanted) or ["good-first-issue"](https://github.com/hyperledger-cacti/cacti/labels/good%20first%20issue) task
     
 *   If you can commit to full-time development, then please contact us on our [Rocketchat channel](https://chat.hyperledger.org/channel/cactus) to work through logistics!
     
@@ -61,7 +61,7 @@ PR Checklist - Contributor/Developer
 
 **To avoid issues in the future, do not install dependencies globally. Ensure all dependencies are kept self-contained.**
 
-1.  Fork [hyperledger/cactus](https://github.com/hyperledger/cactus) via Github UI
+1.  Fork [hyperledger-cacti/cacti](https://github.com/hyperledger-cacti/cacti) via Github UI
     
     *   If you are using the Git client on the Windows operating system, you will need to enable long paths for git which you can do in PowerShell by executing the command below. To clarify, this may also apply if you are using any Git GUI application on Windows such as `Github Desktop` or others.
         
@@ -99,7 +99,7 @@ PR Checklist - Contributor/Developer
         
     2.  Be aware that we are using git commit hooks for the automation of certain mundane tasks such as applying the required code style and formatting so your code will be wrapped at 80 characters each line automatically. If you wish to see how your changes will be altered by the formatter you can run the `npm run prettier` command from a terminal or install an IDE extension for the `Prettier` tool that can do the same (VSCode has one that is known to work).
         
-8.  Ensure your branch is rebased onto the `upstream` main branch where `upstream` is fancy git talk for the main Cactus repo on Github (the one you created your fork from).
+8.  Ensure your branch is rebased onto the `upstream` main branch where `upstream` is fancy git talk for the main Cacti repo on Github (the one you created your fork from).
     
     1.  **Do not** duplicate your pull request after it has been reviewed. Duplication here means closing the existing PR and then opening a brand new one which does not contain the review history anymore. If you encounter issues with version control that you do not know how to solve the maintainers will be happy to assist to ensure that you do not need to open a new pull request from scratch.
         
@@ -160,7 +160,7 @@ Ensure all the following conditions are met (on top of you agreeing with the cha
     3.  If you are adamant that you do not want to merge a PR with multiple commits, that is completely understandable and fair game. The recommended approach there is to ask the contributor to break the pull request up to multiple pull requests by doing an interactive rebase on their branch and cherry picking/re-ordering things accordingly. This is a fairly advanced git use case so you might want to help them out with it (or ask Peter who is the one constantly nagging everyone about these git rules…)
         
 
-To protect the Hyperledger Cactus source code, GitHub pull requests are accepted from forked repositories only. There are also quality standards identified and documented here that will be enhanced over time.
+To protect the Hyperledger Cacti source code, GitHub pull requests are accepted from forked repositories only. There are also quality standards identified and documented here that will be enhanced over time.
 
 Create local branch
 ------------------------------------------------------------------------
@@ -172,7 +172,7 @@ Create local branch
 2.  Setup your local fork to keep up-to-date (optional)
     
     \# Add 'upstream' repo to list of remotes
-    git remote add upstream https://github.com/hyperledger/cactus.git
+    git remote add upstream https://github.com/hyperledger-cacti/cacti.git
     
     \# Verify the new remote named 'upstream'
     git remote \-v
@@ -209,13 +209,13 @@ Create local branch
 7.  Repeat step 3 to 6 when you need to prepare posting new pull request.
     
 
-NOTE: Once you submitted pull request to Cactus repository, step 6 is not necessary when you made further changes with `git commit --amend` since your amends will be sent automatically.
+NOTE: Once you submitted pull request to the Cacti repository, step 6 is not necessary when you made further changes with `git commit --amend` since your amends will be sent automatically.
 
 NOTE: You can refer original tutorial [‘GitHub Standard Fork & Pull Request Workflow’](https://gist.github.com/Chaser324/ce0505fbed06b947d962)
 
 ### Directory structure
 
-Whenever you begin to use your codes on Hyperledger Cactus, you should follow the directory strecture on Hyperledger Cactus. The current directory structure is described as the following:
+Whenever you begin to use your codes on Hyperledger Cacti, you should follow the directory structure on Hyperledger Cacti. The current directory structure is described as the following:
 
 > *   contrib/ : Contributions from each participants, which are not directly dependent on Cactus code.
 >     
@@ -353,7 +353,7 @@ Working with the Code
 
 There are additional details about this in the [BUILD.md](#./BUILD.md) file in the project root as well.
 
-We use Lerna for managing the [monorepo](https://blog.npmjs.org/post/186494959890/monorepos-and-npm) that is Cactus.
+We use Lerna for managing the [monorepo](https://blog.npmjs.org/post/186494959890/monorepos-and-npm) that is Cacti.
 
 > We heavily rely on Docker for testing the ledger plugins.
 
@@ -492,6 +492,6 @@ Further details:
 *   https://spin.atomicobject.com/2016/12/16/reproducible-builds-npm-yarn/
     
 
-[Previous](code-of-conduct.md "Code of Conduct Guidelines") [Next](whitepaper.md "Hyperledger Cactus White Paper")
+[Previous](code-of-conduct.md "Code of Conduct Guidelines") [Next](whitepaper.md "Hyperledger Cacti White Paper")
 
 * * *

--- a/docs/docs/cactus/contributing.md
+++ b/docs/docs/cactus/contributing.md
@@ -1,11 +1,11 @@
 Contributing
 ==========================================================
 
-Thank you for your interest to contribute to Hyperledger Cactus! :tada:
+Thank you for your interest to contribute to Hyperledger Cacti! :tada:
 
-First things first, please review the [Hyperledger Code of Conduct](https://wiki.hyperledger.org/display/HYP/Hyperledger+Code+of+Conduct) before participating.
+First things first, please review the [LF Decentralized Trust Code of Conduct](https://lf-decentralized-trust.github.io/governance/governing-documents/code-of-conduct) before participating.
 
-There are many ways to contribute to Hyperledger Cactus, both as a user and as a developer.
+There are many ways to contribute to Hyperledger Cacti, both as a user and as a developer.
 
 As a user, this can include:
 
@@ -99,7 +99,7 @@ PR Checklist - Contributor/Developer
         
     2.  Be aware that we are using git commit hooks for the automation of certain mundane tasks such as applying the required code style and formatting so your code will be wrapped at 80 characters each line automatically. If you wish to see how your changes will be altered by the formatter you can run the `npm run prettier` command from a terminal or install an IDE extension for the `Prettier` tool that can do the same (VSCode has one that is known to work).
         
-8.  Ensure your branch is rebased onto the `upstream` main branch where `upstream` is fancy git talk for the main Cactus repo on Github (the one you created your fork from).
+8.  Ensure your branch is rebased onto the `upstream` main branch where `upstream` is fancy git talk for the main Cacti repo on Github (the one you created your fork from).
     
     1.  **Do not** duplicate your pull request after it has been reviewed. Duplication here means closing the existing PR and then opening a brand new one which does not contain the review history anymore. If you encounter issues with version control that you do not know how to solve the maintainers will be happy to assist to ensure that you do not need to open a new pull request from scratch.
         
@@ -160,7 +160,7 @@ Ensure all the following conditions are met (on top of you agreeing with the cha
     3.  If you are adamant that you do not want to merge a PR with multiple commits, that is completely understandable and fair game. The recommended approach there is to ask the contributor to break the pull request up to multiple pull requests by doing an interactive rebase on their branch and cherry picking/re-ordering things accordingly. This is a fairly advanced git use case so you might want to help them out with it (or ask Peter who is the one constantly nagging everyone about these git rules…)
         
 
-To protect the Hyperledger Cactus source code, GitHub pull requests are accepted from forked repositories only. There are also quality standards identified and documented here that will be enhanced over time.
+To protect the Hyperledger Cacti source code, GitHub pull requests are accepted from forked repositories only. There are also quality standards identified and documented here that will be enhanced over time.
 
 Create local branch
 ------------------------------------------------------------------------
@@ -209,13 +209,13 @@ Create local branch
 7.  Repeat step 3 to 6 when you need to prepare posting new pull request.
     
 
-NOTE: Once you submitted pull request to Cactus repository, step 6 is not necessary when you made further changes with `git commit --amend` since your amends will be sent automatically.
+NOTE: Once you submitted pull request to the Cacti repository, step 6 is not necessary when you made further changes with `git commit --amend` since your amends will be sent automatically.
 
 NOTE: You can refer original tutorial [‘GitHub Standard Fork & Pull Request Workflow’](https://gist.github.com/Chaser324/ce0505fbed06b947d962)
 
 ### Directory structure
 
-Whenever you begin to use your codes on Hyperledger Cactus, you should follow the directory strecture on Hyperledger Cactus. The current directory structure is described as the following:
+Whenever you begin to use your codes on Hyperledger Cacti, you should follow the directory structure on Hyperledger Cacti. The current directory structure is described as the following:
 
 > *   contrib/ : Contributions from each participants, which are not directly dependent on Cactus code.
 >     
@@ -353,7 +353,7 @@ Working with the Code
 
 There are additional details about this in the [BUILD.md](#./BUILD.md) file in the project root as well.
 
-We use Lerna for managing the [monorepo](https://blog.npmjs.org/post/186494959890/monorepos-and-npm) that is Cactus.
+We use Lerna for managing the [monorepo](https://blog.npmjs.org/post/186494959890/monorepos-and-npm) that is Cacti.
 
 > We heavily rely on Docker for testing the ledger plugins.
 
@@ -492,6 +492,6 @@ Further details:
 *   https://spin.atomicobject.com/2016/12/16/reproducible-builds-npm-yarn/
     
 
-[Previous](code-of-conduct.md "Code of Conduct Guidelines") [Next](whitepaper.md "Hyperledger Cactus White Paper")
+[Previous](code-of-conduct.md "Code of Conduct Guidelines") [Next](whitepaper.md "Hyperledger Cacti White Paper")
 
 * * *

--- a/docs/docs/cactus/examples.md
+++ b/docs/docs/cactus/examples.md
@@ -1,10 +1,10 @@
 Examples
 ==================================================
 
-This section shows the sample applications that are provisioned by the Hyperledger Cactus.
+This section shows the sample applications that are provisioned by the Hyperledger Cacti.
 
 *   [Supply Chain App](examples/supply-chain-app.md)
 
-[Previous](build.md "Hyperledger Cactus Build Instructions") [Next](examples/supply-chain-app.md "Hyperledger Cactus Example - Supply Chain App")
+[Previous](build.md "Hyperledger Cacti Build Instructions") [Next](examples/supply-chain-app.md "Hyperledger Cacti Example - Supply Chain App")
 
 * * *

--- a/docs/docs/cactus/governance.md
+++ b/docs/docs/cactus/governance.md
@@ -1,7 +1,7 @@
 Governance
 ======================================================
 
-Hyperledger Cactus is managed under an open governance model as described in the Hyperledger charter. Cactus is led by a set of maintainers, who can be found in the MAINTAINERS.md file.
+Hyperledger Cacti is managed under an open governance model as described in the Hyperledger charter. Cacti is led by a set of maintainers, who can be found in the MAINTAINERS.md file.
 
 **Maintainers**
 
@@ -15,7 +15,7 @@ Maintainers may be removed by explicit resignation, for prolonged inactivity (3 
 
 **Releases**
 
-A majority of the maintainers may decide to create a release of Cactus. Any broader rules of Hyperledger pertaining to releases must be followed. Once the project is mature, there will be a stable LTS (long term support) release branch, as well as the main branch for upcoming new features.
+A majority of the maintainers may decide to create a release of Cacti. Any broader rules of Hyperledger pertaining to releases must be followed. Once the project is mature, there will be a stable LTS (long term support) release branch, as well as the main branch for upcoming new features.
 
 **Making Feature/Enhancement Proposals**
 
@@ -25,9 +25,9 @@ In particular, all contributors to the project should have enough time to voice 
 
 Significant changes can be marked as such via the predefined label with the same name. This is a tool that helps maintainers identify the most important issues/discussions to be had at any given time through the GitHub web interface.
 
-To easily access the list of significant changes, navigate to the label: https://github.com/hyperledger/cactus/labels/Significant\_Change
+To easily access the list of significant changes, navigate to the label: https://github.com/hyperledger-cacti/cacti/labels/Significant\_Change
 
-We also recommend reading our CONTRIBUTING.md file (https://github.com/hyperledger/cactus/blob/main/CONTRIBUTING.md) for more information about contributing.
+We also recommend reading our CONTRIBUTING.md file (https://github.com/hyperledger-cacti/cacti/blob/main/CONTRIBUTING.md) for more information about contributing.
 
 **Approving Pull Requests**
 
@@ -55,7 +55,7 @@ The technical roadmap is implicitly derived from the Github “milestones” fea
 
 **Communications**
 
-We use the Cactus email list for long-form communications and RocketChat for short, informal announcements and other communications. We encourage all communication, whenever possible, to be public and in the clear (i.e. rather than sending an email directly to a person or two, send it out to the whole list if it pertains to the project).
+We use the Cacti email list for long-form communications and Discord for short, informal announcements and other communications. We encourage all communication, whenever possible, to be public and in the clear (i.e. rather than sending an email directly to a person or two, send it out to the whole list if it pertains to the project).
 
 **Future Changes**
 
@@ -67,6 +67,6 @@ We require that changes to this document require a three-quarters approval of th
 
 This document is based on the Hyperledger Fabric governance document, with some substantial changes.
 
-[Previous](examples/supply-chain-app.md "Hyperledger Cactus Example - Supply Chain App") [Next](code-of-conduct.md "Code of Conduct Guidelines")
+[Previous](examples/supply-chain-app.md "Hyperledger Cacti Example - Supply Chain App") [Next](code-of-conduct.md "Code of Conduct Guidelines")
 
 * * *

--- a/docs/docs/cactus/introduction.md
+++ b/docs/docs/cactus/introduction.md
@@ -1,28 +1,28 @@
-Welcome to Hyperledger Cactus documentation!
+Welcome to Hyperledger Cacti documentation!
 =========================================================================================================================
 
-Hyperledger Cactus aims to provide Decentralized, Secure and Adaptable Integration between Blockchain Networks. Hyperledger Cactus is currently undergoing a major refactoring effort to enable the desired to-be architecture which will enable plug-in based collaborative development to increase the breadth of use cases & Ledgers supported.
+Hyperledger Cacti aims to provide Decentralized, Secure and Adaptable Integration between Blockchain Networks. Hyperledger Cacti is currently undergoing a major refactoring effort to enable the desired to-be architecture which will enable plug-in based collaborative development to increase the breadth of use cases & Ledgers supported.
 
-**What is Cactus?**
+**What is Cacti?**
 
 A pluggable, enterprise-grade framework to transact on multiple distributed ledgers without introducing yet another competing blockchain.
 
-> *   Cactus allows developers to abstract the application layer from the DLT addressing protocol fragmentation, lowering coupling and reducing implementation risks​
+> *   Cacti allows developers to abstract the application layer from the DLT addressing protocol fragmentation, lowering coupling and reducing implementation risks​
 >     
 > *   Cactus allows different DLT networks to interact with each other, through atomic transactions and state commits, this eliminates information silos and increases network’s value​
 >     
 
-**Why use Cactus?**
+**Why use Cacti?**
 
 > *   Maximize flexibility and future-proofing through plug-in architecture. ​
 >     
-> *   Avoid needing explicit action from users to have a secure Cactus deployment. Policies such as vaults are built into the SDK​
+> *   Avoid needing explicit action from users to have a secure Cacti deployment. Policies such as vaults are built into the SDK​
 >     
 > *   Keys and other credentials are not stored in source, configuration files, or environment variables​
 >     
 > *   Preserving Ledger Features Horizontal Scalability.​
 >     
 
-[Next](build.md "Hyperledger Cactus Build Instructions")
+[Next](build.md "Hyperledger Cacti Build Instructions")
 
 * * *

--- a/docs/docs/cactus/packages.md
+++ b/docs/docs/cactus/packages.md
@@ -1,7 +1,7 @@
 Cactus Components
 ====================================================================
 
-This section contains the components to form Hyperledger Cactus.
+This section contains the components to form Hyperledger Cacti.
 
 *   [Api Client](packages/cactus-api-client.md)
 *   [CMD Api Server](packages/cactus-cmd-api-server.md)

--- a/docs/docs/cactus/regulatory-and-industry-initiatives-reading-list.md
+++ b/docs/docs/cactus/regulatory-and-industry-initiatives-reading-list.md
@@ -54,6 +54,6 @@ https://datatracker.ietf.org/doc/draft-hargreaves-odap/ https://datatracker.ietf
 
 There are some more standards in section 6.2 of https://deepai.org/publication/a-survey-on-blockchain-interoperability-past-present-and-future-trends
 
-[Previous](whitepaper.md "Hyperledger Cactus White Paper") [Next](packages.md "Cactus Components")
+[Previous](whitepaper.md "Hyperledger Cacti White Paper") [Next](packages.md "Cacti Components")
 
 * * *

--- a/docs/docs/cactus/support.md
+++ b/docs/docs/cactus/support.md
@@ -1,7 +1,7 @@
 Ledger Support for Connectors
 ============================================================================================
 
-This section contains the ledger supported versions for connectors in Hyperledger Cactus.
+This section contains the ledger supported versions for connectors in Hyperledger Cacti.
 
 *   [Besu](support/besu.md)
 *   [Corda](support/corda.md)

--- a/docs/docs/cactus/support/besu.md
+++ b/docs/docs/cactus/support/besu.md
@@ -5,7 +5,7 @@ Note
 
 The deployContract feature is for development and test case authoring only, not recommended to be used in production environments for managing smart contracts.
 
-Hyperledger Cactus v0.9.0
+Hyperledger Cacti v0.9.0
 
 Besu version
 
@@ -31,7 +31,7 @@ Besu 1.5.1 and Orion 1.6
 
 ✅ test
 
-Hyperledger Cactus v0.8.0
+Hyperledger Cacti v0.8.0
 
 Besu version
 
@@ -49,7 +49,7 @@ Besu 1.5.1 and Orion 1.6
 
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.8.0/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/deploy-contract-from-json.test.ts)
 
-Hyperledger Cactus v0.7.0
+Hyperledger Cacti v0.7.0
 
 Besu version
 
@@ -67,7 +67,7 @@ Besu 1.5.1 and Orion 1.6
 
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.7.0/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/deploy-contract-from-json.test.ts)
 
-Hyperledger Cactus v0.6.0
+Hyperledger Cacti v0.6.0
 
 Besu version
 
@@ -85,7 +85,7 @@ Besu 1.5.1 and Orion 1.6
 
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.6.0/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/deploy-contract-from-json.test.ts)
 
-Hyperledger Cactus v0.5.0
+Hyperledger Cacti v0.5.0
 
 Besu version
 
@@ -103,7 +103,7 @@ Besu 1.5.1 and Orion 1.6
 
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.5.0/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/deploy-contract-from-json.test.ts)
 
-Hyperledger Cactus v0.4.1
+Hyperledger Cacti v0.4.1
 
 Besu version
 

--- a/docs/docs/cactus/support/corda.md
+++ b/docs/docs/cactus/support/corda.md
@@ -5,7 +5,7 @@ Note
 
 The deployContract feature is for development and test case authoring only, not recommended to be used in production environments for managing smart contracts.
 
-Hyperledger Cactus v0.9.0
+Hyperledger Cacti v0.9.0
 
 Corda version
 

--- a/docs/docs/cactus/support/fabric.md
+++ b/docs/docs/cactus/support/fabric.md
@@ -5,7 +5,7 @@ Note
 
 The deployContract feature is for development and test case authoring only, not recommended to be used in production environments for managing smart contracts.
 
-Hyperledger Cactus v0.9.0
+Hyperledger Cacti v0.9.0
 
 Fabric version
 
@@ -31,7 +31,7 @@ Fabric 1.4.8
 
 ✅ test
 
-Hyperledger Cactus v0.8.0
+Hyperledger Cacti v0.8.0
 
 Fabric version
 
@@ -49,7 +49,7 @@ Fabric 2.2.0
 
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.8.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts)
 
-Hyperledger Cactus v0.7.0
+Hyperledger Cacti v0.7.0
 
 Fabric version
 
@@ -68,7 +68,7 @@ Fabric 2.2.0
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.7.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts)
 
 
-Hyperledger Cactus v0.6.0
+Hyperledger Cacti v0.6.0
 
 Fabric version
 
@@ -86,7 +86,7 @@ Fabric 2.2.0
 
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.6.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts)
 
-Hyperledger Cactus v0.5.0
+Hyperledger Cacti v0.5.0
 
 Fabric version
 
@@ -104,7 +104,7 @@ Fabric 2.2.0
 
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.5.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts)
 
-Hyperledger Cactus v0.4.1
+Hyperledger Cacti v0.4.1
 
 Fabric version
 

--- a/docs/docs/cactus/support/substrate.md
+++ b/docs/docs/cactus/support/substrate.md
@@ -7,7 +7,7 @@ Substrate chains include Polkadot, Kusama, Rococco, etc. The deployContract feat
 ```
 
 <details>
-  <summary>Hyperledger Cactus v1.0.0-rc3</summary>
+  <summary>Hyperledger Cacti v1.0.0-rc3</summary>
 
   | Substrate API version | deployContract* | invokeContract | runTransaction |
   | --- | :---: | :---: | :---: |

--- a/docs/docs/cactus/support/xdai.md
+++ b/docs/docs/cactus/support/xdai.md
@@ -5,7 +5,7 @@ Note
 
 The deployContract feature is for development and test case authoring only, not recommended to be used in production environments for managing smart contracts.
 
-Hyperledger Cactus v0.9.0
+Hyperledger Cacti v0.9.0
 
 xDai version
 
@@ -23,7 +23,7 @@ xDai 1.8.27
 
 ✅ test
 
-Hyperledger Cactus v0.8.0
+Hyperledger Cacti v0.8.0
 
 xDai version
 
@@ -41,7 +41,7 @@ xDai 1.8.27
 
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.8.0/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/deploy-contract-from-json-xdai.test.ts)
 
-Hyperledger Cactus v0.7.0
+Hyperledger Cacti v0.7.0
 
 xDai version
 
@@ -59,7 +59,7 @@ xDai 1.8.27
 
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.7.0/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/deploy-contract-from-json-xdai.test.ts)
 
-Hyperledger Cactus v0.6.0
+Hyperledger Cacti v0.6.0
 
 xDai version
 
@@ -77,7 +77,7 @@ xDai 1.8.27
 
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.6.0/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/deploy-contract-from-json-xdai.test.ts)
 
-Hyperledger Cactus v0.5.0
+Hyperledger Cacti v0.5.0
 
 xDai version
 
@@ -95,7 +95,7 @@ xDai 1.8.27
 
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.5.0/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/deploy-contract-from-json-xdai.test.ts)
 
-Hyperledger Cactus v0.4.1
+Hyperledger Cacti v0.4.1
 
 xDai version
 

--- a/docs/docs/cactus/whitepaper.md
+++ b/docs/docs/cactus/whitepaper.md
@@ -1,4 +1,4 @@
-Hyperledger Cactus White Paper
+Hyperledger Cacti White Paper
 ======================================================================================
 
 The white paper is presently undergoing a revision. Please visit the [repository](https://github.com/hyperledger-cacti/cacti/blob/main/whitepaper/whitepaper.md) for updates.


### PR DESCRIPTION
## Description

Follow-up to #4197. Continues the documentation audit by updating remaining 
"Hyperledger Cactus" references to "Hyperledger Cacti" across documentation pages.

Part of the **Cacti Cleanup Initiative** (goal #4: Improve documentation).

### Changes (12 files, 39 lines)

- **introduction.md** — Updated project name, "What is Cacti?", "Why use Cacti?" sections
- **governance.md** — Updated naming, fixed repo URLs, updated RocketChat → Discord
- **examples.md** — Updated naming in nav links
- **packages.md** — Updated component section title
- **support.md** + **support/*.md** — Updated version references across all 5 ledger support pages (besu, corda, fabric, xdai, substrate)
- **whitepaper.md** — Updated title
- **regulatory-and-industry-initiatives-reading-list.md** — Updated nav links

### Related
- Previous PR: #4197
- Cacti Cleanup Initiative: https://github.com/orgs/hyperledger-cacti/projects/2
- Mentorship Issue: LF-Decentralized-Trust-Mentorships/mentorship-program#62
