### PR TITLE
fix(connector-sawtooth): pass through all txs when no family_name filter

### DIFF
--- a/packages/cactus-plugin-ledger-connector-sawtooth/src/main/typescript/web-services/watch-blocks-v1-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-sawtooth/src/main/typescript/web-services/watch-blocks-v1-endpoint.ts
@@ -83,6 +83,7 @@ export class WatchBlocksV1Endpoint {
         if (txFilterBy && txFilterBy.family_name) {
           return tx.header.family_name === txFilterBy.family_name;
         }
+        return true;
       })
       .map((tx) => {
         return {


### PR DESCRIPTION
## Summary

Fixes #4204.

`WatchBlocksV1Endpoint.sendCactiTransactions()` in the Sawtooth connector had a `filter()` predicate with no default return. When the optional `txFilterBy.family_name` was not configured — i.e. the default usage of `WatchBlocksV1ListenerType.CactiTransactions` — the arrow function fell off the end and returned `undefined`, which `Array.prototype.filter` treats as falsy. Every transaction was silently dropped, the guarded `socket.emit(WatchBlocksV1.Next, …)` was never reached, and clients received nothing forever with no error and no log.

This PR restores the missing default-true branch so that when no filter is configured all transactions pass through.

## Change

`packages/cactus-plugin-ledger-connector-sawtooth/src/main/typescript/web-services/watch-blocks-v1-endpoint.ts`

```ts
.filter((tx) => {
  if (txFilterBy && txFilterBy.family_name) {
    return tx.header.family_name === txFilterBy.family_name;
  }
  return true;
})
```

One-line fix, no behavior change for the filtered path.

## Test plan

- [ ] Subscribe with `{ type: "CactiTransactions" }` (no `txFilterBy`) and confirm `WatchBlocksV1.Next` events arrive with `cactiTransactionsEvents` populated.
- [ ] Subscribe with `{ type: "CactiTransactions", txFilterBy: { family_name: "intkey" } }` and confirm only matching-family transactions are emitted.
- [ ] Subscribe with `{ type: "Full" }` and confirm full-block path is unaffected.