### PR TITLE
fix(plugin-keychain-vault): return boolean from has() to stop leaking secret value

### DIFF
--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/plugin-keychain-vault.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/plugin-keychain-vault.ts
@@ -247,8 +247,8 @@ export class PluginKeychainVault implements IPluginWebService, IPluginKeychain {
   async has(key: string): Promise<boolean> {
     const path = this.pathFor(key);
     try {
-      const res = await this.backend.read(path);
-      return res;
+      await this.backend.read(path);
+      return true;
     } catch (ex) {
       // We have to make sure that the exception is either an expected
       // or an unexpected one where the expected exception is what we


### PR DESCRIPTION
## Summary

Fixes #4206.

`PluginKeychainVault.has()` was declared as `Promise<boolean>` but actually returned the entire `node-vault` `read()` response object (which contains the secret value under `data.data.value`). The HTTP `has-keychain-entry` endpoint then put that object straight into the `isPresent` field of its JSON response, so any caller of the presence-check endpoint received the plaintext secret of the queried key — without ever calling `get-keychain-entry`.

This PR makes `has()` discard the response and return a real boolean. Presence is now determined purely by whether `read()` resolved or rejected with `404`. No secret material escapes the `has()` boundary.

## Change

`packages/cactus-plugin-keychain-vault/src/main/typescript/plugin-keychain-vault.ts`

```ts
async has(key: string): Promise<boolean> {
  const path = this.pathFor(key);
  try {
    await this.backend.read(path);
    return true;
  } catch (ex) {
    if (ex?.response?.statusCode === HttpStatus.NOT_FOUND) {
      return false;
    }
    this.log.error(`Presence check of "${key}" crashed:`, ex);
    throw ex;
  }
}
```

Two-line behavioural change. The `404 → false` and rethrow branches are unchanged.

## Why this matters

- **Confidentiality / information disclosure** in a security-critical plugin. The keychain is the trust anchor for credential material used by the connectors above it (Fabric/Besu/Ethereum signing keys, SATP-Hermes oracle keys, etc.).
- **RBAC bypass.** Deployments that hardened `get-keychain-entry` and left `has-keychain-entry` more broadly accessible were silently exposing every secret to every caller of the presence endpoint.
- **Audit gap.** SIEM rules counting secret reads via `get-keychain-entry` under-reported by design — every `has-keychain-entry` call was a covert read of the same data.
- **OpenAPI contract violation.** `HasKeychainEntryResponseV1.isPresent` is typed `boolean` in the generated clients. JS clients doing `if (resp.isPresent)` happened to work because objects are truthy, but `=== true` checks, schema validators, and strongly-typed clients (Java/Go/Rust) were all broken.
- **Default code path.** This fired on every successful `has()` call against an existing key — not an edge case.

## Test plan

- [ ] Store a secret via `set-keychain-entry`, then call `has-keychain-entry` for the same key. Confirm the response body is `{ \"isPresent\": true, \"checkedAt\": \"…\", \"key\": \"…\" }` and that **no** Vault response object / secret value appears anywhere in the body.
- [ ] Call `has-keychain-entry` for a key that does not exist. Confirm `{ \"isPresent\": false, … }`.
- [ ] Trigger an unrelated Vault failure (e.g. wrong token) and confirm the endpoint surfaces the error rather than masking it.
- [ ] Run the existing keychain-vault test suite and confirm it still passes (and ideally extend it with a `has()` regression test that asserts the return type is a primitive boolean).