### PR TITLE
docs: update pull request template

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -25,9 +25,9 @@ In particular, all contributors to the project should have enough time to voice 
 Significant changes can be marked as such via the predefined label with the same name. This is a tool that helps maintainers identify the most important issues/discussions to be had at any given time through the GitHub web interface.
 
 To easily access the list of significant changes, navigate to the label:
-https://github.com/hyperledger/cactus/labels/Significant_Change
+https://github.com/hyperledger-cacti/cacti/labels/Significant_Change
 
-We also recommend reading our CONTRIBUTING.md file (https://github.com/hyperledger/cactus/blob/main/CONTRIBUTING.md) for more information about contributing.
+We also recommend reading our CONTRIBUTING.md file (https://github.com/hyperledger-cacti/cacti/blob/main/CONTRIBUTING.md) for more information about contributing.
 
 **Approving Pull Requests**
 
@@ -58,7 +58,7 @@ One point to mention about meetings is that new feature/enhancement proposals as
 The Cactus maintainers are required to maintain a roadmap.  There is a technical roadmap, with all of the issues as they directly relate to code, and a more public-friendly roadmap that anyone can digest.  The required features to be implemented will be maintained as issues at the official github repository of Cactus with tag string ‘for current release’ or ‘for future release’. The task which is not volunteered to work, will be dispatched to specific contributors following consensus among the majority of maintainers.
 
 The technical roadmap is implicitly derived from the Github “milestones” feature. To access the list of milestones for Cactus use this link:
-https://github.com/hyperledger/cactus/milestones
+https://github.com/hyperledger-cacti/cacti/milestones
 
 **Communications**
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,54 @@
-**Pull Request Requirements**
+## Summary
+- 
+
+## Commit Title (Conventional Commits)
+Use this format: `type(scope): description`
+
+- [ ] `type` is one of: `feat`, `fix`, `docs`, `ci`, `build`, `refactor`, `test`, `chore`, `perf`
+- [ ] `scope` is clear and specific
+
+Example: `docs(pr-template): clarify testing and docs impact`
+
+## Testing
+Explain how to run/reproduce this change and include the exact commands:
+
+Commands run:
+- 
+
+- [ ] Tests added/updated
+- [ ] Tests pass
+- [ ] If tests were not run, explanation provided
+
+## Docs Impact
+- [ ] Docs added/updated (list files/links)
+- [ ] N/A (explain why)
+
+Details:
+
+## Breaking Changes
+- [ ] Yes
+- [ ] No
+
+If yes, include:
+- [ ] Migration guide provided (steps and/or link)
+
+Details (only if yes):
+
+## AI Usage Disclosure
+- [ ] No AI tools used
+- [ ] AI-assisted (list tools and how they were used)
+- [ ] AI-generated content/code was reviewed and validated by the author
+
+Details:
+
+## Pull Request Requirements
 - [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
 - [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
-- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 
+- [ ] Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
-**Character Limit**
-- [ ] Pull Request Title and Commit Subject must not exceed 80 characters (including spaces and special characters).
-- [ ] Commit Message per line must not exceed 102 characters (including spaces and special characters).
+## Character Limit
+- [ ] PR Title ≤ 72 chars
+- [ ] Commit message line ≤ 80 chars
 
-**A Must Read for Beginners**
+## A Must Read for Beginners
 For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ As a fusion of two earlier systems (Cactus and Weaver) that have similar philoso
 
 The current Cacti code base contains the legacy Cactus and Weaver source code in aggregated form with their original folder structures intact. But the packages built from the two sections of code are unified and released under a common `cacti` namespace, and the CI/CD pipelines for testing and releases are also integrated under a common set of GitHub Actions. A _deeper_ merge and integration of source code is part of our roadmap, and will be carried out over a longer time period, but the current setup of code and release packages makes it easy for new users to navigate Cacti and for legacy users to carry out seamless upgrades.
 
-(Reference for legacy users: Cactus source code lies here (i.e., the root folder), excluding the `weaver` folder. Weaver source code lies within the [weaver](./weaver/) folder.
+Reference for legacy users: Cactus source code lives at the repository root, excluding the `weaver` folder. Weaver source code lives in [`./weaver/`](./weaver/).
 
 ## Documentation
 
@@ -72,7 +72,7 @@ as starting points.
 ## Contributing
 We welcome contributions to Hyperledger Cacti in many forms, and there’s always plenty to do!
 
-Please review [contributing](/CONTRIBUTING.md) guidelines to get started.
+Please review the [contributing guidelines](./CONTRIBUTING.md) to get started.
 
 ## License
-This distribution is published under the Apache License Version 2.0 found in the [LICENSE](/LICENSE) file.
+This distribution is published under the Apache License Version 2.0 found in the [LICENSE](./LICENSE) file.


### PR DESCRIPTION
## Summary
- add a structured PR template (Summary, Type, Testing, Docs, Breaking)
- keep the existing hygiene checks and headings as-is for the two original bullets
- clean up README and GOVERNANCE links to use the current repo URLs

## Why
Issue #4076 asks for a PR template update as part of cleanup work tracked in #4037. The old template focused on git hygiene but did not capture summary, testing, docs impact, or breaking changes. The README and GOVERNANCE updates remove legacy links.

## Testing
- not applicable (docs-only change)
