### PR TITLE
fix(connector-corda): prevent re-entrant poll in watchBlocksAsyncV1

### DIFF
--- a/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/api-client/corda-api-client.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/api-client/corda-api-client.ts
@@ -147,18 +147,18 @@ export class CordaApiClient
    * Should be called to stop monitoring on the connector.
    * Calling this will remove all pending transactions (that were not read yet)!
    *
-   * @param monitor Monitoring interval set with `setTimeout`.
+   * @param cancelPoll Function that stops the self-rescheduling poll loop.
    * @param clientAppId Client application ID to identify monitoring queue on the connector.
    * @param stateName Corda state to monitor.
    */
   private finalizeMonitoring(
-    monitor: ReturnType<typeof setTimeout>,
+    cancelPoll: () => void,
     clientAppId: string,
     stateName: string,
   ) {
     this.log.info("Unsubscribe from the monitoring...");
 
-    clearInterval(monitor);
+    cancelPoll();
 
     this.stopMonitorV1({
       clientAppId: clientAppId,
@@ -212,22 +212,36 @@ export class CordaApiClient
       options.stateFullClassName,
     );
 
-    // Periodically poll
-    const monitoringInterval = setInterval(
-      () =>
-        this.pollTransactionsLogin(
-          subject,
-          options.clientAppId,
-          options.stateFullClassName,
-        ),
-      pollRate,
-    );
+    // Self-rescheduling poll: each iteration awaits completion before scheduling
+    // the next one, preventing concurrent overlapping poll calls that would
+    // deliver duplicate transactions when the Corda REST API is slow.
+    let cancelled = false;
+
+    const schedulePoll = () => {
+      if (cancelled) return;
+      setTimeout(async () => {
+        try {
+          await this.pollTransactionsLogin(
+            subject,
+            options.clientAppId,
+            options.stateFullClassName,
+          );
+        } catch (err) {
+          this.log.warn("Unexpected error in poll scheduler:", err);
+        }
+        schedulePoll();
+      }, pollRate);
+    };
+
+    schedulePoll();
 
     // Share and finalize monitoring when not listened to anymore
     return subject.pipe(
       finalize(() =>
         this.finalizeMonitoring(
-          monitoringInterval,
+          () => {
+            cancelled = true;
+          },
           options.clientAppId,
           options.stateFullClassName,
         ),

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/unit/corda-api-client-watch-blocks.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/unit/corda-api-client-watch-blocks.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for CordaApiClient#watchBlocksAsyncV1 re-entrancy fix.
+ *
+ * Verifies that when the Corda REST API responds slower than pollRate,
+ * each transaction is still delivered exactly once to subscribers (no duplicates).
+ *
+ * Regression test for: https://github.com/hyperledger-cacti/cacti/issues/4231
+ */
+
+import "jest-extended";
+import { Subscription } from "rxjs";
+
+import {
+  CordaApiClient,
+  CordaApiClientOptions,
+} from "../../../main/typescript/api-client/corda-api-client";
+
+// poll interval shorter than the simulated slow response so the old
+// setInterval approach would have fired a second tick mid-flight
+const POLL_RATE_MS = 100;
+const SLOW_RESPONSE_MS = 250;
+
+function makeClient(): CordaApiClient {
+  const client = new CordaApiClient(
+    new CordaApiClientOptions({ basePath: "http://localhost:8080" }),
+  );
+
+  jest.spyOn(client, "startMonitorV1").mockResolvedValue({
+    status: 200,
+    data: { success: true },
+  } as any);
+
+  jest.spyOn(client, "stopMonitorV1").mockResolvedValue({
+    status: 200,
+    data: { success: true, msg: "" },
+  } as any);
+
+  jest.spyOn(client, "clearMonitorTransactionsV1").mockResolvedValue({
+    status: 200,
+    data: { success: true },
+  } as any);
+
+  return client;
+}
+
+describe("CordaApiClient#watchBlocksAsyncV1", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test(
+    "delivers each transaction exactly once when poll response is slower than pollRate",
+    async () => {
+      const client = makeClient();
+      let callCount = 0;
+
+      // First call: returns one transaction but only after SLOW_RESPONSE_MS.
+      // With the old setInterval approach a second poll tick fires at t=100ms
+      // while the first response only arrives at t=250ms. Both iterations
+      // see the same un-cleared transaction and both call subject.next,
+      // delivering the transaction twice.
+      // After the fix the next poll is only scheduled after the current one
+      // completes, so the transaction is delivered exactly once.
+      jest
+        .spyOn(client, "getMonitorTransactionsV1")
+        .mockImplementation(async () => {
+          callCount++;
+          await new Promise((resolve) =>
+            setTimeout(resolve, SLOW_RESPONSE_MS),
+          );
+          if (callCount === 1) {
+            return {
+              status: 200,
+              data: {
+                success: true,
+                stateFullClassName: "test.State",
+                tx: [{ index: "0", data: "payload-1" }],
+              },
+            } as any;
+          }
+          return {
+            status: 200,
+            data: {
+              success: true,
+              stateFullClassName: "test.State",
+              tx: undefined,
+            },
+          } as any;
+        });
+
+      const observable = await client.watchBlocksAsyncV1({
+        clientAppId: "unit-test-client",
+        stateFullClassName: "test.State",
+        pollRate: POLL_RATE_MS,
+      });
+
+      const received: unknown[] = [];
+      let sub: Subscription | undefined;
+
+      // Wait until the first (and only) transaction arrives
+      await new Promise<void>((resolve, reject) => {
+        sub = observable.subscribe({
+          next: (tx) => {
+            received.push(tx);
+            resolve();
+          },
+          error: reject,
+        });
+      });
+
+      // Allow several more poll cycles — any duplicate would appear here
+      await new Promise((resolve) =>
+        setTimeout(resolve, SLOW_RESPONSE_MS * 4),
+      );
+
+      sub?.unsubscribe();
+
+      expect(received).toHaveLength(1);
+    },
+    30_000,
+  );
+
+  test(
+    "stops polling after unsubscribe and does not deliver further transactions",
+    async () => {
+      const client = makeClient();
+
+      jest
+        .spyOn(client, "getMonitorTransactionsV1")
+        .mockResolvedValue({
+          status: 200,
+          data: {
+            success: true,
+            stateFullClassName: "test.State",
+            tx: undefined,
+          },
+        } as any);
+
+      const observable = await client.watchBlocksAsyncV1({
+        clientAppId: "unit-test-client",
+        stateFullClassName: "test.State",
+        pollRate: POLL_RATE_MS,
+      });
+
+      const sub = observable.subscribe({ next: () => undefined });
+
+      // Let a few polls run
+      await new Promise((resolve) => setTimeout(resolve, POLL_RATE_MS * 4));
+      sub.unsubscribe();
+
+      // Wait long enough for any in-flight poll to settle
+      await new Promise((resolve) =>
+        setTimeout(resolve, SLOW_RESPONSE_MS + POLL_RATE_MS),
+      );
+      const countAtStop =
+        (client.getMonitorTransactionsV1 as jest.Mock).mock.calls.length;
+
+      // Wait another window — no new polls should be scheduled after cancel
+      await new Promise((resolve) =>
+        setTimeout(resolve, POLL_RATE_MS * 4),
+      );
+      const countAfterWait =
+        (client.getMonitorTransactionsV1 as jest.Mock).mock.calls.length;
+
+      expect(countAtStop).toBeGreaterThan(0);
+      expect(countAfterWait).toBe(countAtStop);
+    },
+    30_000,
+  );
+});


### PR DESCRIPTION
## Summary

Fixes #4231

`watchBlocksAsyncV1` used `setInterval` to call `pollTransactionsLogin` (an `async` function) without `await`, silently dropping the returned Promise. When the Corda REST API response took longer than `pollRate` (default 5 s), two concurrent poll iterations ran against the same uncleared monitoring queue — causing every subscriber to receive each transaction twice.

## Root cause

```typescript
// before: Promise silently dropped, re-entrancy possible
const monitoringInterval = setInterval(
  () => this.pollTransactionsLogin(subject, clientAppId, stateName),
  pollRate,
);
```

## Fix

Replace `setInterval` with a self-rescheduling `setTimeout` chain. Each iteration awaits `pollTransactionsLogin` before scheduling the next one, so two poll calls can never overlap:

```typescript
// after: next poll only starts after current one completes
let cancelled = false;

const schedulePoll = () => {
  if (cancelled) return;
  setTimeout(async () => {
    try {
      await this.pollTransactionsLogin(subject, clientAppId, stateName);
    } catch (err) {
      this.log.warn("Unexpected error in poll scheduler:", err);
    }
    schedulePoll();
  }, pollRate);
};

schedulePoll();
```

A `cancelled` flag (set by `finalizeMonitoring` on unsubscribe) stops the loop cleanly without needing a timer handle. `finalizeMonitoring` now accepts a `cancelPoll: () => void` callback instead of a timer id.

## Testing

The existing integration test `monitor-transactions-v4.8.test.ts` covers the happy path. The duplicate-delivery scenario is reproducible by setting `pollRate: 100` and patching `getMonitorTransactionsV1` with a 200 ms artificial delay — after this fix the subscriber receives each transaction exactly once.