### PR TITLE
test(satp-hermes): retry fabric endorsement failures

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/environments/fabric-test-environment.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/environments/fabric-test-environment.ts
@@ -57,6 +57,11 @@ export interface IFabricTestEnvironment {
   claimFormat?: ClaimFormat;
   network?: string;
 }
+
+const FABRIC_TRANSACTION_RETRY_ATTEMPTS = 3;
+const FABRIC_TRANSACTION_RETRY_DELAY_MS = 1000;
+const FABRIC_ENDORSEMENT_POLICY_FAILURE = "ENDORSEMENT_POLICY_FAILURE";
+
 export class FabricTestEnvironment {
   public static readonly FABRIC_ASSET_ID: string = "FabricExampleAsset";
   public static readonly FABRIC_REFERENCE_ID: string = ExampleOntology.id;
@@ -278,6 +283,52 @@ export class FabricTestEnvironment {
 
   public getNetworkType(): LedgerType {
     return this.network.ledgerType;
+  }
+
+  private async transactWithFabricRetry(
+    request: Parameters<PluginLedgerConnectorFabric["transact"]>[0],
+  ): Promise<RunTransactionResponse> {
+    let lastError: unknown;
+
+    for (
+      let attempt = 1;
+      attempt <= FABRIC_TRANSACTION_RETRY_ATTEMPTS;
+      attempt++
+    ) {
+      try {
+        return await this.connector.transact(request);
+      } catch (error) {
+        lastError = error;
+        const errorMessage = this.getErrorMessage(error);
+
+        if (
+          !errorMessage.includes(FABRIC_ENDORSEMENT_POLICY_FAILURE) ||
+          attempt === FABRIC_TRANSACTION_RETRY_ATTEMPTS
+        ) {
+          throw error;
+        }
+
+        this.log.warn(
+          `Fabric transaction ${request.methodName} failed with ${FABRIC_ENDORSEMENT_POLICY_FAILURE}; retrying attempt ${
+            attempt + 1
+          }/${FABRIC_TRANSACTION_RETRY_ATTEMPTS}`,
+        );
+        await this.sleep(FABRIC_TRANSACTION_RETRY_DELAY_MS);
+      }
+    }
+
+    throw lastError;
+  }
+
+  private getErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+    return String(error);
+  }
+
+  private async sleep(delayMs: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
   }
 
   // Creates and initializes a new FabricTestEnvironment instance
@@ -551,7 +602,7 @@ export class FabricTestEnvironment {
     amount: string,
     signingCredential: FabricSigningCredential,
   ): Promise<void> {
-    const responseBalance1 = await this.connector.transact({
+    const responseBalance1 = await this.transactWithFabricRetry({
       contractName: contractName,
       channelName: channelName,
       params: [account],
@@ -565,7 +616,7 @@ export class FabricTestEnvironment {
   }
 
   public async giveRoleToBridge(mspID: string): Promise<void> {
-    const setBridgeResponse = await this.connector.transact({
+    const setBridgeResponse = await this.transactWithFabricRetry({
       contractName: this.satpContractName,
       channelName: this.fabricChannelName,
       params: [mspID],
@@ -585,7 +636,7 @@ export class FabricTestEnvironment {
     bridgeAddress: string,
     amount: string,
   ): Promise<void> {
-    const response = await this.connector.transact({
+    const response = await this.transactWithFabricRetry({
       contractName: this.satpContractName,
       channelName: this.fabricChannelName,
       params: [bridgeAddress, amount],
@@ -763,7 +814,7 @@ export class FabricTestEnvironment {
     expect(queryCommitted).toBeTruthy();
     this.log.info("SATP Contract deployed");
 
-    const initializeResponse = await this.connector.transact({
+    const initializeResponse = await this.transactWithFabricRetry({
       contractName: this.satpContractName,
       channelName: this.fabricChannelName,
       params: [this.userIdentity.mspId, FabricTestEnvironment.FABRIC_ASSET_ID],
@@ -782,7 +833,7 @@ export class FabricTestEnvironment {
       throw new Error("Bridge MSPID is undefined");
     }
 
-    const responseClientId = await this.connector.transact({
+    const responseClientId = await this.transactWithFabricRetry({
       contractName: this.satpContractName,
       channelName: this.fabricChannelName,
       params: [],
@@ -935,7 +986,7 @@ export class FabricTestEnvironment {
     expect(queryCommitted).toBeTruthy();
     this.log.info("Oracle Business Logic Contract deployed");
 
-    const initializeResponse = await this.connector.transact({
+    const initializeResponse = await this.transactWithFabricRetry({
       contractName: "oracle-bl-contract",
       channelName: this.fabricChannelName,
       params: [],
@@ -960,7 +1011,7 @@ export class FabricTestEnvironment {
     methodName: string,
     params: string[],
   ): Promise<RunTransactionResponse> {
-    const readData = await this.connector.transact({
+    const readData = await this.transactWithFabricRetry({
       contractName: contractName,
       channelName: this.fabricChannelName,
       params: params,
@@ -978,7 +1029,7 @@ export class FabricTestEnvironment {
     methodName: string,
     params: string[],
   ): Promise<RunTransactionResponse> {
-    const readData = await this.connector.transact({
+    const readData = await this.transactWithFabricRetry({
       contractName: contractName,
       channelName: this.fabricChannelName,
       params: params,
@@ -992,7 +1043,7 @@ export class FabricTestEnvironment {
   }
 
   public async mintTokens(amount: string): Promise<void> {
-    const responseMint = await this.connector.transact({
+    const responseMint = await this.transactWithFabricRetry({
       contractName: this.satpContractName,
       channelName: this.fabricChannelName,
       params: [amount],


### PR DESCRIPTION
## Summary

- Add a narrow retry wrapper for SATP Hermes Fabric test transactions.
- Retry only transient `ENDORSEMENT_POLICY_FAILURE` responses, with three attempts and a short delay.
- Route the shared Fabric test-environment transaction helpers through the retry wrapper so flaky CI failures are handled in one place.

## Notes

The retry is intentionally limited to the Fabric endorsement-policy failure described in #3978. Other transaction errors still fail immediately.

Fixes #3978

## Validation

- Verified the edited helper routes direct `connector.transact()` calls through `transactWithFabricRetry()`.
- Could not run the SATP Hermes TypeScript/Jest tests locally because this checkout does not have `node_modules` installed.