### PR TITLE
tests: refactored jest test for negative test cases

### DIFF
--- a/packages/cactus-common/src/test/typescript/unit/js-object-signer.test.ts
+++ b/packages/cactus-common/src/test/typescript/unit/js-object-signer.test.ts
@@ -194,19 +194,16 @@ test("Test optional hash function", async () => {
   expect(sign1.toString).toEqual(sign2.toString);
 });
 
-test("Test missing required constructor field", async () => {
-  try {
+test("Test missing required constructor field", () => {
+  expect(() => {
     const pkey: unknown = undefined;
     const jsObjectSignerOptions: IJsObjectSignerOptions = {
       privateKey: pkey as Uint8Array,
     };
     new JsObjectSigner(jsObjectSignerOptions);
-  } catch (e: unknown) {
-    expect(e).toBeInstanceOf(Error);
-    expect(e).toContainEntry([
-      "message",
-
-      "JsObjectSigner#ctor options.privateKey falsy.",
-    ]);
-  }
+  }).toThrowError(
+    expect.objectContaining({
+      message: "JsObjectSigner#ctor options.privateKey falsy.",
+    }),
+  );
 });

--- a/packages/cactus-plugin-keychain-google-sm/src/test/typescript/integration/openapi/openapi-validation.test.ts
+++ b/packages/cactus-plugin-keychain-google-sm/src/test/typescript/integration/openapi/openapi-validation.test.ts
@@ -108,174 +108,134 @@ describe("PluginKeychainGoogleSm", () => {
   });
 
   it(` ${fSet} - ${cWithoutParams}`, async () => {
-    try {
-      await apiClient.setKeychainEntryV1({
-        value,
-      } as unknown as SetKeychainEntryRequestV1);
-    } catch (e) {
-      const fields = e.response.data.map((param: unknown) => {
-        if (!hasKey(param, "path")) {
-          throw new TypeError("Expected param.path to exist.");
-        }
-        if (typeof param.path !== "string") {
-          throw new TypeError("Expected param.path to be string");
-        }
-        return param.path.replace("/body/", "");
-      });
-
-      expect(fields.includes("key")).toBeTrue();
-    }
+    const setKeychainEntryCall = apiClient.setKeychainEntryV1({
+      value,
+    } as unknown as SetKeychainEntryRequestV1);
+    await expect(setKeychainEntryCall).rejects.toMatchObject({
+      response: {
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/"),
+          }),
+        ]),
+      },
+    });
   });
 
   it(` ${fGet} - ${cWithoutParams}`, async () => {
-    try {
-      await apiClient.getKeychainEntryV1(
-        {} as unknown as GetKeychainEntryRequestV1,
-      );
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: unknown) => {
-        if (!hasKey(param, "path")) {
-          throw new TypeError("Expected param.path to exist.");
-        }
-        if (typeof param.path !== "string") {
-          throw new TypeError("Expected param.path to be string");
-        }
-        return param.path.replace("/body/", "");
-      });
-
-      expect(fields.includes("key")).toBeTrue();
-    }
+    const getKeychainEntryCall = apiClient.getKeychainEntryV1(
+      {} as unknown as GetKeychainEntryRequestV1,
+    );
+    await expect(getKeychainEntryCall).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/"),
+          }),
+        ]),
+      },
+    });
   });
 
   it(` ${fHas} - ${cWithoutParams}`, async () => {
-    try {
-      await apiClient.hasKeychainEntryV1(
-        {} as unknown as HasKeychainEntryRequestV1,
-      );
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: unknown) => {
-        if (!hasKey(param, "path")) {
-          throw new TypeError("Expected param.path to exist.");
-        }
-        if (typeof param.path !== "string") {
-          throw new TypeError("Expected param.path to be string");
-        }
-        return param.path.replace("/body/", "");
-      });
-
-      expect(fields.includes("key")).toBeTrue();
-    }
+    const hasKeychainEntryCall = apiClient.hasKeychainEntryV1(
+      {} as unknown as HasKeychainEntryRequestV1,
+    );
+    await expect(hasKeychainEntryCall).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/"),
+          }),
+        ]),
+      },
+    });
   });
 
   it(` ${fDelete} - ${cWithoutParams}`, async () => {
-    try {
-      await apiClient.deleteKeychainEntryV1(
-        {} as unknown as DeleteKeychainEntryRequestV1,
-      );
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: unknown) => {
-        if (!hasKey(param, "path")) {
-          throw new TypeError("Expected param.path to exist.");
-        }
-        if (typeof param.path !== "string") {
-          throw new TypeError("Expected param.path to be string");
-        }
-        return param.path.replace("/body/", "");
-      });
-
-      expect(fields.includes("key")).toBeTrue();
-    }
+    const deleteKeychainEntryCall = apiClient.deleteKeychainEntryV1(
+      {} as unknown as DeleteKeychainEntryRequestV1,
+    );
+    await expect(deleteKeychainEntryCall).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/"),
+          }),
+        ]),
+      },
+    });
   });
 
   it(` ${fSet} - ${cInvalidParams}`, async () => {
-    try {
-      await apiClient.setKeychainEntryV1({
-        key,
-        value,
-        fake: 4,
-      } as any as SetKeychainEntryRequestV1);
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: unknown) => {
-        if (!hasKey(param, "path")) {
-          throw new TypeError("Expected param.path to exist.");
-        }
-        if (typeof param.path !== "string") {
-          throw new TypeError("Expected param.path to be string");
-        }
-        return param.path.replace("/body/", "");
-      });
-
-      expect(fields.includes("fake")).toBeTrue();
-    }
+    const setKeychainEntryCall = apiClient.setKeychainEntryV1({
+      key,
+      value,
+      fake: 4,
+    } as any as SetKeychainEntryRequestV1);
+    await expect(setKeychainEntryCall).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/"),
+          }),
+        ]),
+      },
+    });
   });
 
   it(` ${fGet} - ${cInvalidParams}`, async () => {
-    try {
-      await apiClient.getKeychainEntryV1({
-        key,
-        fake: 4,
-      } as unknown as GetKeychainEntryRequestV1);
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: unknown) => {
-        if (!hasKey(param, "path")) {
-          throw new TypeError("Expected param.path to exist.");
-        }
-        if (typeof param.path !== "string") {
-          throw new TypeError("Expected param.path to be string");
-        }
-        return param.path.replace("/body/", "");
-      });
-
-      expect(fields.includes("fake")).toBeTrue();
-    }
+    const getKeychainEntryCall = apiClient.getKeychainEntryV1({
+      key,
+      fake: 4,
+    } as unknown as GetKeychainEntryRequestV1);
+    await expect(getKeychainEntryCall).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/"),
+          }),
+        ]),
+      },
+    });
   });
 
   it(` ${fHas} - ${cInvalidParams}`, async () => {
-    try {
-      await apiClient.hasKeychainEntryV1({
-        key,
-        fake: 4,
-      } as unknown as HasKeychainEntryRequestV1);
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: unknown) => {
-        if (!hasKey(param, "path")) {
-          throw new TypeError("Expected param.path to exist.");
-        }
-        if (typeof param.path !== "string") {
-          throw new TypeError("Expected param.path to be string");
-        }
-        return param.path.replace("/body/", "");
-      });
-
-      expect(fields.includes("fake")).toBeTrue();
-    }
+    const hasKeychainEntryCall = apiClient.hasKeychainEntryV1({
+      key,
+      fake: 4,
+    } as unknown as HasKeychainEntryRequestV1);
+    await expect(hasKeychainEntryCall).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/"),
+          }),
+        ]),
+      },
+    });
   });
 
   it(` ${fDelete} - ${cInvalidParams}`, async () => {
-    try {
-      await apiClient.deleteKeychainEntryV1({
-        key,
-        fake: 4,
-      } as unknown as DeleteKeychainEntryRequestV1);
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: unknown) => {
-        if (!hasKey(param, "path")) {
-          throw new TypeError("Expected param.path to exist.");
-        }
-        if (typeof param.path !== "string") {
-          throw new TypeError("Expected param.path to be string");
-        }
-        return param.path.replace("/body/", "");
-      });
-
-      expect(fields.includes("fake")).toBeTrue();
-    }
+    const deleteKeychainEntryCall = apiClient.deleteKeychainEntryV1({
+      key,
+      fake: 4,
+    } as unknown as DeleteKeychainEntryRequestV1);
+    await expect(deleteKeychainEntryCall).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/"),
+          }),
+        ]),
+      },
+    });
   });
 });

--- a/packages/cactus-plugin-keychain-google-sm/src/test/typescript/integration/openapi/openapi-validation.test.ts
+++ b/packages/cactus-plugin-keychain-google-sm/src/test/typescript/integration/openapi/openapi-validation.test.ts
@@ -113,6 +113,7 @@ describe("PluginKeychainGoogleSm", () => {
     } as unknown as SetKeychainEntryRequestV1);
     await expect(setKeychainEntryCall).rejects.toMatchObject({
       response: {
+        status: 400,
         data: expect.arrayContaining([
           expect.objectContaining({
             path: expect.stringContaining("/body/"),

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-json-object-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-json-object-v1.test.ts
@@ -231,39 +231,35 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
   });
 
   test("deployContract without contractJSON should fail", async () => {
-    try {
-      await apiClient.deployContract({
-        contract: {} as ContractJsonDefinition,
-        web3SigningCredential: {
-          ethAccount: WHALE_ACCOUNT_ADDRESS,
-          secret: "",
-          type: Web3SigningCredentialType.GethKeychainPassword,
-        },
-      });
-      fail("Expected deployContract call to fail but it succeeded.");
-    } catch (error) {
-      console.log("deployContract failed as expected");
-    }
+    const deployContractCall = apiClient.deployContract({
+      contract: {} as ContractJsonDefinition,
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+    });
+    await expect(deployContractCall).rejects.toMatchObject({
+      message: expect.any(String),
+    });
   });
 
   test("deployContract with additional parameters should fail", async () => {
-    try {
-      await apiClient.deployContract({
-        contract: {
-          contractJSON: HelloWorldContractJson,
-        },
-        web3SigningCredential: {
-          ethAccount: WHALE_ACCOUNT_ADDRESS,
-          secret: "",
-          type: Web3SigningCredentialType.GethKeychainPassword,
-        },
-        gas: 1000000,
-        fake: 4,
-      } as DeployContractV1Request);
-      fail("Expected deployContract call to fail but it succeeded.");
-    } catch (error) {
-      console.log("deployContract failed as expected");
-    }
+    const deployContractCall = apiClient.deployContract({
+      contract: {
+        contractJSON: HelloWorldContractJson,
+      },
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+      gas: 1000000,
+      fake: 4,
+    } as DeployContractV1Request);
+    await expect(deployContractCall).rejects.toMatchObject({
+      message: expect.any(String),
+    });
   });
 
   //////////////////////////////////
@@ -289,25 +285,23 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
     expect(setNameOut).toBeTruthy();
     expect(setNameOut.data).toBeTruthy();
 
-    try {
-      await apiClient.invokeContractV1({
-        contract: {
-          contractJSON: HelloWorldContractJson,
-          contractAddress,
-        },
-        invocationType: EthContractInvocationType.Send,
-        methodName: "foo",
-        params: [newName],
-        web3SigningCredential: {
-          ethAccount: WHALE_ACCOUNT_ADDRESS,
-          secret: "",
-          type: Web3SigningCredentialType.GethKeychainPassword,
-        },
-      });
-      fail("Expected getContractInfoKeychain call to fail but it succeeded.");
-    } catch (error) {
-      expect(error).toBeTruthy();
-    }
+    const invokeContractCall = apiClient.invokeContractV1({
+      contract: {
+        contractJSON: HelloWorldContractJson,
+        contractAddress,
+      },
+      invocationType: EthContractInvocationType.Send,
+      methodName: "foo",
+      params: [newName],
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+    });
+    await expect(invokeContractCall).rejects.toMatchObject({
+      message: expect.any(String),
+    });
 
     const getNameOut = await apiClient.invokeContractV1({
       contract: {
@@ -370,28 +364,26 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
     expect(setNameOut).toBeTruthy();
     expect(setNameOut.data).toBeTruthy();
 
-    try {
-      await apiClient.invokeContractV1({
-        contract: {
-          contractJSON: HelloWorldContractJson,
-          contractAddress,
-        },
-        invocationType: EthContractInvocationType.Send,
-        methodName: "foo",
-        params: [newName],
-        gasConfig: {
-          maxPriorityFeePerGas: priorityFee,
-        },
-        web3SigningCredential: {
-          ethAccount: testEthAccount.address,
-          secret: testEthAccount.privateKey,
-          type: Web3SigningCredentialType.PrivateKeyHex,
-        },
-      });
-      fail("Expected getContractInfoKeychain call to fail but it succeeded.");
-    } catch (error) {
-      expect(error).toBeTruthy();
-    }
+    const invokeContractCall = apiClient.invokeContractV1({
+      contract: {
+        contractJSON: HelloWorldContractJson,
+        contractAddress,
+      },
+      invocationType: EthContractInvocationType.Send,
+      methodName: "foo",
+      params: [newName],
+      gasConfig: {
+        maxPriorityFeePerGas: priorityFee,
+      },
+      web3SigningCredential: {
+        ethAccount: testEthAccount.address,
+        secret: testEthAccount.privateKey,
+        type: Web3SigningCredentialType.PrivateKeyHex,
+      },
+    });
+    await expect(invokeContractCall).rejects.toMatchObject({
+      message: expect.any(String),
+    });
 
     const invokeGetNameOut = await apiClient.invokeContractV1({
       contract: {
@@ -414,25 +406,21 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
   });
 
   test("invokeContractV1 without methodName should fail", async () => {
-    try {
-      await apiClient.invokeContractV1({
-        contract: {
-          contractJSON: HelloWorldContractJson,
-          contractAddress,
-        },
-        invocationType: EthContractInvocationType.Send,
-        params: [`DrCactus${uuidV4()}`],
-        web3SigningCredential: {
-          ethAccount: WHALE_ACCOUNT_ADDRESS,
-          secret: "",
-          type: Web3SigningCredentialType.GethKeychainPassword,
-        },
-      } as InvokeContractV1Request);
-      fail(
-        "Expected deployContractSolBytecodeV1 call to fail but it succeeded.",
-      );
-    } catch (error) {
-      console.log("deployContractSolBytecodeV1 failed as expected");
-    }
+    const invokeContractCall = apiClient.invokeContractV1({
+      contract: {
+        contractJSON: HelloWorldContractJson,
+        contractAddress,
+      },
+      invocationType: EthContractInvocationType.Send,
+      params: [`DrCactus${uuidV4()}`],
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+    } as InvokeContractV1Request);
+    await expect(invokeContractCall).rejects.toMatchObject({
+      message: expect.any(String),
+    });
   });
 });

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-json-object-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-json-object-v1.test.ts
@@ -240,7 +240,14 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
       },
     });
     await expect(deployContractCall).rejects.toMatchObject({
-      message: expect.any(String),
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.stringContaining("Expected type object but got type undefined"),
+          }),
+        ]),
+      },
     });
   });
 
@@ -258,7 +265,14 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
       fake: 4,
     } as DeployContractV1Request);
     await expect(deployContractCall).rejects.toMatchObject({
-      message: expect.any(String),
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.stringContaining('Unknown property "fake"'),
+          }),
+        ]),
+      },
     });
   });
 
@@ -300,7 +314,14 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
       },
     });
     await expect(invokeContractCall).rejects.toMatchObject({
-      message: expect.any(String),
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.stringContaining("Method 'foo' not found in contract"),
+          }),
+        ]),
+      },
     });
 
     const getNameOut = await apiClient.invokeContractV1({
@@ -382,7 +403,14 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
       },
     });
     await expect(invokeContractCall).rejects.toMatchObject({
-      message: expect.any(String),
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.stringContaining("Method 'foo' not found in contract"),
+          }),
+        ]),
+      },
     });
 
     const invokeGetNameOut = await apiClient.invokeContractV1({
@@ -420,7 +448,14 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
       },
     } as InvokeContractV1Request);
     await expect(invokeContractCall).rejects.toMatchObject({
-      message: expect.any(String),
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.stringContaining("Expected type string but got type undefined"),
+          }),
+        ]),
+      },
     });
   });
 });

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-keychain-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-keychain-v1.test.ts
@@ -246,7 +246,14 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
       },
     });
     await expect(deployContractCall).rejects.toMatchObject({
-      message: expect.any(String),
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.stringContaining("Expected type string but got type undefined"),
+          }),
+        ]),
+      },
     });
   });
 
@@ -265,7 +272,14 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
       fake: 4,
     } as DeployContractV1Request);
     await expect(deployContractCall).rejects.toMatchObject({
-      message: expect.any(String),
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.stringContaining('Unknown property "fake"'),
+          }),
+        ]),
+      },
     });
   });
 
@@ -307,7 +321,14 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
       },
     });
     await expect(invokeContractCall).rejects.toMatchObject({
-      message: expect.any(String),
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.stringContaining("Method 'foo' not found in contract"),
+          }),
+        ]),
+      },
     });
 
     const getNameOut = await apiClient.invokeContractV1({
@@ -537,7 +558,14 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
       },
     } as InvokeContractV1Request);
     await expect(invokeContractCall).rejects.toMatchObject({
-      message: expect.any(String),
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.stringContaining("Expected type string but got type undefined"),
+          }),
+        ]),
+      },
     });
   });
 

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-keychain-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-keychain-v1.test.ts
@@ -235,42 +235,38 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
   });
 
   test("deployContract without contractName should fail", async () => {
-    try {
-      await apiClient.deployContract({
-        contract: {
-          keychainId: keychainPlugin.getKeychainId(),
-        } as ContractKeychainDefinition,
-        web3SigningCredential: {
-          ethAccount: WHALE_ACCOUNT_ADDRESS,
-          secret: "",
-          type: Web3SigningCredentialType.GethKeychainPassword,
-        },
-      });
-      fail("Expected deployContract call to fail but it succeeded.");
-    } catch (error) {
-      console.log("deployContract failed as expected");
-    }
+    const deployContractCall = apiClient.deployContract({
+      contract: {
+        keychainId: keychainPlugin.getKeychainId(),
+      } as ContractKeychainDefinition,
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+    });
+    await expect(deployContractCall).rejects.toMatchObject({
+      message: expect.any(String),
+    });
   });
 
   test("deployContract with additional parameters should fail", async () => {
-    try {
-      await apiClient.deployContract({
-        contract: {
-          contractName: HelloWorldContractJson.contractName,
-          keychainId: keychainPlugin.getKeychainId(),
-        },
-        web3SigningCredential: {
-          ethAccount: WHALE_ACCOUNT_ADDRESS,
-          secret: "",
-          type: Web3SigningCredentialType.GethKeychainPassword,
-        },
-        gas: 1000000,
-        fake: 4,
-      } as DeployContractV1Request);
-      fail("Expected deployContract call to fail but it succeeded.");
-    } catch (error) {
-      console.log("deployContract failed as expected");
-    }
+    const deployContractCall = apiClient.deployContract({
+      contract: {
+        contractName: HelloWorldContractJson.contractName,
+        keychainId: keychainPlugin.getKeychainId(),
+      },
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+      gas: 1000000,
+      fake: 4,
+    } as DeployContractV1Request);
+    await expect(deployContractCall).rejects.toMatchObject({
+      message: expect.any(String),
+    });
   });
 
   //////////////////////////////////
@@ -296,25 +292,23 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
     expect(setNameOut).toBeTruthy();
     expect(setNameOut.data).toBeTruthy();
 
-    try {
-      await apiClient.invokeContractV1({
-        contract: {
-          contractName: HelloWorldContractJson.contractName,
-          keychainId: keychainPlugin.getKeychainId(),
-        },
-        invocationType: EthContractInvocationType.Send,
-        methodName: "foo",
-        params: [newName],
-        web3SigningCredential: {
-          ethAccount: WHALE_ACCOUNT_ADDRESS,
-          secret: "",
-          type: Web3SigningCredentialType.GethKeychainPassword,
-        },
-      });
-      fail("Expected invokeContractV1 call to fail but it succeeded.");
-    } catch (error) {
-      expect(error).toBeTruthy();
-    }
+    const invokeContractCall = apiClient.invokeContractV1({
+      contract: {
+        contractName: HelloWorldContractJson.contractName,
+        keychainId: keychainPlugin.getKeychainId(),
+      },
+      invocationType: EthContractInvocationType.Send,
+      methodName: "foo",
+      params: [newName],
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+    });
+    await expect(invokeContractCall).rejects.toMatchObject({
+      message: expect.any(String),
+    });
 
     const getNameOut = await apiClient.invokeContractV1({
       contract: {
@@ -390,16 +384,14 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
   });
 
   test("runTransactionV1 without transaction config should fail", async () => {
-    try {
-      await apiClient.runTransactionV1({
-        web3SigningCredential: {
-          type: Web3SigningCredentialType.None,
-        },
-      } as RunTransactionRequest);
-      fail("Expected runTransactionV1 call to fail but it succeeded.");
-    } catch (error) {
-      console.log("runTransactionV1 failed as expected");
-    }
+    const runTransactionCall = apiClient.runTransactionV1({
+      web3SigningCredential: {
+        type: Web3SigningCredentialType.None,
+      },
+    } as RunTransactionRequest);
+    await expect(runTransactionCall).rejects.toMatchObject({
+      message: expect.any(String),
+    });
   });
 
   test("invoke Web3SigningCredentialType.PrivateKeyHex", async () => {
@@ -425,28 +417,26 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
     expect(setNameOut).toBeTruthy();
     expect(setNameOut.data).toBeTruthy();
 
-    try {
-      await apiClient.invokeContractV1({
-        contract: {
-          contractName: HelloWorldContractJson.contractName,
-          keychainId: keychainPlugin.getKeychainId(),
-        },
-        invocationType: EthContractInvocationType.Send,
-        methodName: "foo",
-        params: [newName],
-        gasConfig: {
-          maxPriorityFeePerGas: priorityFee,
-        },
-        web3SigningCredential: {
-          ethAccount: testEthAccount.address,
-          secret: testEthAccount.privateKey,
-          type: Web3SigningCredentialType.PrivateKeyHex,
-        },
-      });
-      fail("Expected invokeContractV1 call to fail but it succeeded.");
-    } catch (error) {
-      expect(error).toBeTruthy();
-    }
+    const invokeContractCall = apiClient.invokeContractV1({
+      contract: {
+        contractName: HelloWorldContractJson.contractName,
+        keychainId: keychainPlugin.getKeychainId(),
+      },
+      invocationType: EthContractInvocationType.Send,
+      methodName: "foo",
+      params: [newName],
+      gasConfig: {
+        maxPriorityFeePerGas: priorityFee,
+      },
+      web3SigningCredential: {
+        ethAccount: testEthAccount.address,
+        secret: testEthAccount.privateKey,
+        type: Web3SigningCredentialType.PrivateKeyHex,
+      },
+    });
+    await expect(invokeContractCall).rejects.toMatchObject({
+      message: expect.any(String),
+    });
 
     const invokeGetNameOut = await apiClient.invokeContractV1({
       contract: {
@@ -495,28 +485,26 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
     expect(setNameOut).toBeTruthy();
     expect(setNameOut.data).toBeTruthy();
 
-    try {
-      await apiClient.invokeContractV1({
-        contract: {
-          contractName: HelloWorldContractJson.contractName,
-          keychainId: keychainPlugin.getKeychainId(),
-        },
-        invocationType: EthContractInvocationType.Send,
-        methodName: "foo",
-        params: [newName],
-        gasConfig: {
-          maxPriorityFeePerGas: priorityFee,
-        },
-        web3SigningCredential: {
-          ethAccount: WHALE_ACCOUNT_ADDRESS,
-          secret: "",
-          type: Web3SigningCredentialType.GethKeychainPassword,
-        },
-      });
-      fail("Expected invokeContractV1 call to fail but it succeeded.");
-    } catch (error) {
-      expect(error).toBeTruthy();
-    }
+    const invokeContractCall = apiClient.invokeContractV1({
+      contract: {
+        contractName: HelloWorldContractJson.contractName,
+        keychainId: keychainPlugin.getKeychainId(),
+      },
+      invocationType: EthContractInvocationType.Send,
+      methodName: "foo",
+      params: [newName],
+      gasConfig: {
+        maxPriorityFeePerGas: priorityFee,
+      },
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+    });
+    await expect(invokeContractCall).rejects.toMatchObject({
+      message: expect.any(String),
+    });
 
     const invokeGetNameOut = await apiClient.invokeContractV1({
       contract: {
@@ -535,24 +523,22 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
   });
 
   test("invokeContractV1 without methodName should fail", async () => {
-    try {
-      await apiClient.invokeContractV1({
-        contract: {
-          contractName: HelloWorldContractJson.contractName,
-          keychainId: keychainPlugin.getKeychainId(),
-        },
-        invocationType: EthContractInvocationType.Send,
-        params: [`DrCactus${uuidV4()}`],
-        web3SigningCredential: {
-          ethAccount: WHALE_ACCOUNT_ADDRESS,
-          secret: "",
-          type: Web3SigningCredentialType.GethKeychainPassword,
-        },
-      } as InvokeContractV1Request);
-      fail("Expected invokeContractV1 call to fail but it succeeded.");
-    } catch (error) {
-      console.log("invokeContractV1 failed as expected");
-    }
+    const invokeContractCall = apiClient.invokeContractV1({
+      contract: {
+        contractName: HelloWorldContractJson.contractName,
+        keychainId: keychainPlugin.getKeychainId(),
+      },
+      invocationType: EthContractInvocationType.Send,
+      params: [`DrCactus${uuidV4()}`],
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+    } as InvokeContractV1Request);
+    await expect(invokeContractCall).rejects.toMatchObject({
+      message: expect.any(String),
+    });
   });
 
   // @todo - move to separate test suite

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-invoke-web3-method-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-invoke-web3-method-v1.test.ts
@@ -167,43 +167,25 @@ describe("invokeRawWeb3EthMethod Tests", () => {
   });
 
   test("invokeRawWeb3EthMethod with missing arg throws error (getBlock)", async () => {
-    try {
-      const connectorResponse = connector.invokeRawWeb3EthMethod({
-        methodName: "getBlock",
-      });
-
-      await connectorResponse;
-      fail("Calling getBlock with missing argument should throw an error");
-    } catch (err) {
-      expect(err).toBeTruthy();
-    }
+    const connectorResponse = connector.invokeRawWeb3EthMethod({
+      methodName: "getBlock",
+    });
+    await expect(connectorResponse).rejects.toThrow();
   });
 
   test("invokeRawWeb3EthMethod with invalid arg throws error (getBlock)", async () => {
-    try {
-      const connectorResponse = connector.invokeRawWeb3EthMethod({
-        methodName: "getBlock",
-        params: ["foo"],
-      });
-
-      await connectorResponse;
-      fail("Calling getBlock with argument should throw an error");
-    } catch (err) {
-      expect(err).toBeTruthy();
-    }
+    const connectorResponse = connector.invokeRawWeb3EthMethod({
+      methodName: "getBlock",
+      params: ["foo"],
+    });
+    await expect(connectorResponse).rejects.toThrow();
   });
 
   test("invokeRawWeb3EthMethod with non existing method throws error", async () => {
-    try {
-      const connectorResponse = connector.invokeRawWeb3EthMethod({
-        methodName: "foo",
-        params: ["foo"],
-      });
-
-      await connectorResponse;
-      fail("Calling non existing method should throw an error");
-    } catch (err) {
-      expect(err).toBeTruthy();
-    }
+    const connectorResponse = connector.invokeRawWeb3EthMethod({
+      methodName: "foo",
+      params: ["foo"],
+    });
+    await expect(connectorResponse).rejects.toThrow();
   });
 });

--- a/packages/cactus-plugin-ledger-connector-iroha2/src/test/typescript/integration/iroha2-generate-and-send-signed-transaction.test.ts
+++ b/packages/cactus-plugin-ledger-connector-iroha2/src/test/typescript/integration/iroha2-generate-and-send-signed-transaction.test.ts
@@ -309,23 +309,24 @@ describe("Generate and send signed transaction tests", () => {
     const domainName = addRandomSuffix("errorCheckDomain");
     expect(domainName).toBeTruthy();
 
-    // Generate transaction with wrong instruction
-    try {
-      await env.apiClient.generateTransactionV1({
-        request: {
-          instruction: {
-            name: "foo" as IrohaInstruction,
-            params: [domainName],
-          },
+    const generateTransactionCall = env.apiClient.generateTransactionV1({
+      request: {
+        instruction: {
+          name: "foo" as IrohaInstruction,
+          params: [domainName],
         },
-        baseConfig: env.defaultBaseConfig,
-      });
-      expect(false).toBe(true); // should always throw by now
-    } catch (err: any) {
-      expect(err.response.status).toBe(500);
-      expect(err.response.data.message).toEqual("Internal Server Error");
-      expect(err.response.data.error).toBeTruthy();
-    }
+      },
+      baseConfig: env.defaultBaseConfig,
+    });
+    await expect(generateTransactionCall).rejects.toMatchObject({
+      response: {
+        status: 500,
+        data: {
+          message: "Internal Server Error",
+          error: expect.any(String),
+        },
+      },
+    });
   });
 
   /**
@@ -333,20 +334,22 @@ describe("Generate and send signed transaction tests", () => {
    */
   test("generateTransactionV1 returns error for invalid query parameter number", async () => {
     // Query domain without it's ID
-    try {
-      await env.apiClient.generateTransactionV1({
-        request: {
-          query: IrohaQuery.FindDomainById,
-          params: [],
+    const generateTransactionCall = env.apiClient.generateTransactionV1({
+      request: {
+        query: IrohaQuery.FindDomainById,
+        params: [],
+      },
+      baseConfig: env.defaultBaseConfig,
+    });
+    await expect(generateTransactionCall).rejects.toMatchObject({
+      response: {
+        status: 500,
+        data: {
+          message: "Internal Server Error",
+          error: expect.any(String),
         },
-        baseConfig: env.defaultBaseConfig,
-      });
-      expect(false).toBe(true); // should always throw by now
-    } catch (err: any) {
-      expect(err.response.status).toBe(500);
-      expect(err.response.data.message).toEqual("Internal Server Error");
-      expect(err.response.data.error).toBeTruthy();
-    }
+      },
+    });
   });
 
   /**

--- a/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/deploy-contract-from-json-xdai.test.ts
+++ b/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/deploy-contract-from-json-xdai.test.ts
@@ -348,7 +348,7 @@ describe(testCase, () => {
       web3SigningCredential,
       nonce: 4,
     });
-    await expect(invokeContractCall).rejects.not.toThrow("Nonce too low");
+    await expect(invokeContractCall).rejects.toThrow("Nonce too low");
 
     const { callOutput: getNameOut } = await connector.invokeContract({
       contractName,

--- a/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/deploy-contract-from-json-xdai.test.ts
+++ b/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/deploy-contract-from-json-xdai.test.ts
@@ -238,8 +238,8 @@ describe(testCase, () => {
     });
     expect(setNameOut).toBeTruthy();
 
-    try {
-      await connector.invokeContract({
+    await expect(
+      connector.invokeContract({
         contractName,
         keychainId: keychainPlugin.getKeychainId(),
         invocationType: EthContractInvocationType.Send,
@@ -252,11 +252,8 @@ describe(testCase, () => {
           type: Web3SigningCredentialType.PrivateKeyHex,
         },
         nonce: 1,
-      });
-      fail("It should not reach here");
-    } catch (error) {
-      expect(error).not.toBe("Nonce too low");
-    }
+      }),
+    ).rejects.toThrow("Nonce too low");
     const { callOutput: getNameOut } = await connector.invokeContract({
       contractName,
       keychainId: keychainPlugin.getKeychainId(),
@@ -341,21 +338,17 @@ describe(testCase, () => {
     });
     expect(setNameOut).toBeTruthy();
 
-    try {
-      await connector.invokeContract({
-        contractName,
-        keychainId: keychainPlugin.getKeychainId(),
-        invocationType: EthContractInvocationType.Send,
-        methodName: "setName",
-        params: [newName],
-        gas: 1000000,
-        web3SigningCredential,
-        nonce: 4,
-      });
-      fail("It should not reach here");
-    } catch (error) {
-      expect(error).not.toBe("Nonce too low");
-    }
+    const invokeContractCall = connector.invokeContract({
+      contractName,
+      keychainId: keychainPlugin.getKeychainId(),
+      invocationType: EthContractInvocationType.Send,
+      methodName: "setName",
+      params: [newName],
+      gas: 1000000,
+      web3SigningCredential,
+      nonce: 4,
+    });
+    await expect(invokeContractCall).rejects.not.toThrow("Nonce too low");
 
     const { callOutput: getNameOut } = await connector.invokeContract({
       contractName,


### PR DESCRIPTION
## test: refactor jest negative test cases - phase 1

**Issue:** #3483

### Summary
Refactored negative test cases across 25 files to use Jest's `.rejects` matchers instead of `try/catch/fail()` patterns.

### Changes
- Replaced `try/catch/fail()` with `expect().rejects.toMatchObject()`
- Removed artificial `Promise` wrappers from synchronous tests
- Added missing `getBlock` parameter validation in Ethereum connector
- Normalized log levels (`TRACE` → `INFO`) in test files


### Checklist
- [x] Rebased onto `upstream/main` and squashed into single commit
- [x] Git sign-off included (`-s` flag)
- [x] Commit subject: 52 characters ✅
- [x] Follows Conventional Commits specification
- [x] All tests passing
