### PR TITLE
ci: update SATP runner labels

### DIFF
--- a/.github/workflows/satp-hermes-docs.yaml
+++ b/.github/workflows/satp-hermes-docs.yaml
@@ -45,7 +45,7 @@ jobs:
   # This job builds the TypeDoc documentation for the SATP Hermes Gateway
   
   build-docs:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.7

--- a/.github/workflows/satp-hermes-ghcr-gateway-sdk.yaml
+++ b/.github/workflows/satp-hermes-ghcr-gateway-sdk.yaml
@@ -97,7 +97,7 @@ jobs:
         (github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'satp-dev' || github.base_ref == 'satp-stg')) ||
         github.event_name == 'workflow_dispatch'
       )
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-22.04
     outputs:
       package_version: ${{ steps.set_tags.outputs.package_version }}
       tag_suffix: ${{ steps.set_tags.outputs.tag_suffix }}
@@ -152,7 +152,7 @@ jobs:
   build-satp-hermes-ghcr-image:
     needs: [set-ghcr-tags]
     if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/satp-dev' || github.ref == 'refs/heads/satp-stg')) || (github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'satp-dev' || github.base_ref == 'satp-stg')) || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4.1.7
       - name: Setup Node.js
@@ -201,7 +201,7 @@ jobs:
   publish-satp-hermes-ghcr-image:
     needs: [build-satp-hermes-ghcr-image, set-ghcr-tags]
     if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/satp-dev' || github.ref == 'refs/heads/satp-stg')) || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4.1.7
       - name: Setup Node.js


### PR DESCRIPTION
## Summary

- Replaces the remaining `ubuntu-latest-16-cores` runner labels with `ubuntu-22.04`.
- Removes dependency on LF-provided custom runner labels for SATP Hermes docs and GHCR workflows.

Fixes #4083.

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/satp-hermes-docs.yaml .github/workflows/satp-hermes-ghcr-gateway-sdk.yaml`
- `git diff --check`
