### PR TITLE
test(api-server): cover fabric import without peer binary

### DIFF
--- a/packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-ledger-connector-fabric-0-7-0.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-ledger-connector-fabric-0-7-0.test.ts
@@ -19,7 +19,7 @@ import { ApiServer } from "../../../../main/typescript/api-server";
 
 const logLevel: LogLevelDesc = "INFO";
 
-test("can install plugin-ledger-connector-fabric", async (t: Test) => {
+test("can install plugin-ledger-connector-fabric without peerBinary", async (t: Test) => {
   const pluginsPath = path.join(
     __dirname, // start at the current file's path
     "../../../../../../../", // walk back up to the project root
@@ -49,7 +49,6 @@ test("can install plugin-ledger-connector-fabric", async (t: Test) => {
         instanceId: randomUUID(),
         logLevel,
         connectionProfile: {},
-        peerBinary: "peer",
       },
     },
   ];


### PR DESCRIPTION
## Summary

- Updates the API-server dynamic import regression test for the Fabric connector to omit `peerBinary`.
- Covers the issue #1171 startup configuration shape where the connector receives an `instanceId` and `connectionProfile`, but no Fabric peer binary path.

Fixes #1171.

## Validation

- `git diff --check`

The focused test was not run locally because installing the workspace dependencies in this scratch checkout failed with `ENOSPC` while linking `node_modules`.
