### PR TITLE
docs: add whitepaper v2 source scaffold

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -11,6 +11,8 @@ on:
 
     paths:
       - 'docs/**'
+      - 'whitepaper/**'
+      - 'tools/build-whitepaper-v2-pdf.sh'
       - 'packages/cactus-plugin-satp-hermes/docs/**'
 
   # Allows you to run this workflow manually from the Actions tab
@@ -77,6 +79,9 @@ jobs:
 
       - name: Build markdown for openapi specs
         run: 'python3 docs/scripts/publish_openapi.py'
+
+      - name: Build whitepaper PDF artifact for mkdocs
+        run: ./tools/build-whitepaper-v2-pdf.sh
         
       - name: Build and publish
         run: git pull && mkdocs gh-deploy

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ target/
 node_modules/
 docs/main
 docs/docs/references/openapi
+docs/docs/cactus/assets/whitepaper/*.pdf
 logs/
 jspm_packages/
 generated-sources/

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,15 @@ The commands you will usually use with `mkdocs` are:
 * `mkdocs -h` - Print help message and exit.
 * `mkdocs gh-deploy` - Build and push documents to `gh-pages` branch, and publish to URL configured in `mkdocs.yml`.
 
+To build the whitepaper PDF artifact that is linked from the docs site, run:
+
+```bash
+yarn docs:whitepaper:pdf
+```
+
+This generates `whitepaper/v2/build/main.pdf` and copies it into the MkDocs
+source tree at `docs/docs/cactus/assets/whitepaper/hyperledger-cacti-whitepaper-v2.pdf`.
+
 ## Adding Content
 
 The basic process for adding content to the site is:

--- a/docs/docs/cactus/whitepaper.md
+++ b/docs/docs/cactus/whitepaper.md
@@ -3,6 +3,8 @@ Hyperledger Cactus White Paper
 
 The white paper is presently undergoing a revision. Please visit the [repository](https://github.com/hyperledger-cacti/cacti/blob/main/whitepaper/whitepaper.md) for updates.
 
+Version 2 source is available in [`whitepaper/v2`](https://github.com/hyperledger-cacti/cacti/tree/main/whitepaper/v2), including LaTeX sources and reproducible build targets.
+
 [Previous](contributing.md "Contributing") [Next](regulatory-and-industry-initiatives-reading-list.md "Regulatory and Industry Initiatives Reading List")
 
 * * *

--- a/docs/docs/cactus/whitepaper.md
+++ b/docs/docs/cactus/whitepaper.md
@@ -5,6 +5,9 @@ The white paper is presently undergoing a revision. Please visit the [repository
 
 Version 2 source is available in [`whitepaper/v2`](https://github.com/hyperledger-cacti/cacti/tree/main/whitepaper/v2), including LaTeX sources and reproducible build targets.
 
+The latest generated PDF artifact is published with the docs site here:
+[Hyperledger Cacti Whitepaper v2 PDF](assets/whitepaper/hyperledger-cacti-whitepaper-v2.pdf).
+
 [Previous](contributing.md "Contributing") [Next](regulatory-and-industry-initiatives-reading-list.md "Regulatory and Industry Initiatives Reading List")
 
 * * *

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "watch-tsc": "tsc --build --watch",
     "watch": "run-p -r watch-*",
     "docs:diagrams": "mkdir -p docs/assets && echo 'Generating Getting Started guide diagrams (PNG)...' && bash -c 'for f in docs/docs/guides/diagrams/*.mmd; do name=$(basename \"$f\" .mmd); echo \"  $name.png\"; mmdc -i \"$f\" -o \"docs/assets/$name.png\" -t default -b transparent -w 1920 -s 2; done' && echo 'All diagrams generated successfully'",
+    "docs:whitepaper:pdf": "./tools/build-whitepaper-v2-pdf.sh",
     "build": "npm-run-all build:dev build:prod",
     "build:prod": "npm-run-all build:prod:frontend",
     "build:prod:frontend": "lerna run build:prod:frontend",

--- a/tools/build-whitepaper-v2-pdf.sh
+++ b/tools/build-whitepaper-v2-pdf.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WHITEPAPER_DIR="$ROOT_DIR/whitepaper/v2"
+OUTPUT_DIR="${WHITEPAPER_OUTPUT_DIR:-$ROOT_DIR/docs/docs/cactus/assets/whitepaper}"
+OUTPUT_FILE="${WHITEPAPER_OUTPUT_FILE:-hyperledger-cacti-whitepaper-v2.pdf}"
+
+if [[ -n "${WHITEPAPER_BUILD_TARGET:-}" ]]; then
+  BUILD_TARGET="$WHITEPAPER_BUILD_TARGET"
+elif command -v latexmk >/dev/null 2>&1; then
+  BUILD_TARGET="pdf"
+else
+  BUILD_TARGET="container-pdf"
+fi
+
+echo "Building whitepaper v2 PDF with target: ${BUILD_TARGET}"
+make -C "$WHITEPAPER_DIR" "$BUILD_TARGET"
+
+mkdir -p "$OUTPUT_DIR"
+cp "$WHITEPAPER_DIR/build/main.pdf" "$OUTPUT_DIR/$OUTPUT_FILE"
+
+echo "Whitepaper PDF copied to: $OUTPUT_DIR/$OUTPUT_FILE"

--- a/whitepaper/v2/.gitignore
+++ b/whitepaper/v2/.gitignore
@@ -1,0 +1,13 @@
+build/
+*.aux
+*.bbl
+*.bcf
+*.blg
+*.fdb_latexmk
+*.fls
+*.log
+*.out
+*.pdf
+*.run.xml
+*.synctex.gz
+*.toc

--- a/whitepaper/v2/Makefile
+++ b/whitepaper/v2/Makefile
@@ -1,0 +1,31 @@
+TEXLIVE_IMAGE ?= texlive/texlive:TL2024-historic
+SOURCE_DATE_EPOCH ?= 1704067200
+LATEXMK ?= latexmk
+OUT_DIR ?= build
+MAIN ?= main
+
+.PHONY: all pdf clean container-pdf
+
+all: pdf
+
+pdf:
+	mkdir -p $(OUT_DIR)
+	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
+	FORCE_SOURCE_DATE=1 \
+	TZ=UTC \
+	LC_ALL=C \
+	$(LATEXMK) -pdf -interaction=nonstopmode -halt-on-error -outdir=$(OUT_DIR) $(MAIN).tex
+
+container-pdf:
+	docker run --rm \
+		-e SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
+		-e FORCE_SOURCE_DATE=1 \
+		-e TZ=UTC \
+		-e LC_ALL=C \
+		-v "$(PWD):/work" \
+		-w /work \
+		$(TEXLIVE_IMAGE) \
+		latexmk -pdf -interaction=nonstopmode -halt-on-error -outdir=$(OUT_DIR) $(MAIN).tex
+
+clean:
+	rm -rf $(OUT_DIR)

--- a/whitepaper/v2/README.md
+++ b/whitepaper/v2/README.md
@@ -1,0 +1,41 @@
+# Hyperledger Cacti Whitepaper v2 Source
+
+This directory contains the source scaffold for the second version of the
+Hyperledger Cacti whitepaper.
+
+The goal is to keep the whitepaper source reviewable, reproducible, and close
+to the project documentation while the content is iterated by maintainers and
+contributors.
+
+## Build
+
+Build with a local TeX Live installation:
+
+```sh
+make pdf
+```
+
+Build in a container with a pinned TeX Live release image:
+
+```sh
+make container-pdf
+```
+
+Both targets set `SOURCE_DATE_EPOCH`, `FORCE_SOURCE_DATE`, `TZ`, and `LC_ALL`
+so the produced PDF is stable across machines when the same TeX Live image and
+source tree are used.
+
+The generated PDF is written to `build/main.pdf`.
+
+## Layout
+
+- `main.tex`: whitepaper entrypoint and outline.
+- `references.bib`: bibliography for papers, specifications, and theses that
+  inform Cacti technology.
+- `Makefile`: local and containerized build targets.
+
+## Editing Notes
+
+Use this scaffold to incrementally replace the current placeholder whitepaper.
+Prefer short, reviewable pull requests that add one section or bibliography
+group at a time.

--- a/whitepaper/v2/main.tex
+++ b/whitepaper/v2/main.tex
@@ -1,0 +1,85 @@
+\documentclass[11pt,letterpaper]{article}
+
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{geometry}
+\usepackage{hyperref}
+\usepackage{longtable}
+\usepackage{microtype}
+\usepackage{parskip}
+
+\geometry{margin=1in}
+
+\title{Hyperledger Cacti Whitepaper\\Version 2}
+\author{Hyperledger Cacti Contributors}
+\date{\today}
+
+\begin{document}
+
+\maketitle
+
+\begin{abstract}
+Hyperledger Cacti provides a framework for interoperability across distributed
+ledger technologies and related enterprise systems. This second whitepaper is a
+living source document for the architecture, trust assumptions, deployment
+models, and research foundations of the project.
+\end{abstract}
+
+\tableofcontents
+\newpage
+
+\section{Status}
+
+This document is the version 2 source scaffold. It intentionally starts as a
+concise outline so maintainers can evolve the whitepaper in reviewable changes.
+
+\section{Motivation}
+
+Enterprise interoperability requires systems that can coordinate actions,
+state, identities, and evidence across networks with different governance
+models. Cacti brings together connector, routing, validation, and application
+components so deployments can integrate ledgers without treating every
+interoperability problem as a one-off integration.
+
+\section{Scope}
+
+The whitepaper should describe:
+
+\begin{itemize}
+  \item Cacti's goals and non-goals.
+  \item Supported interoperability patterns.
+  \item Core architectural components and extension points.
+  \item Security and trust assumptions.
+  \item Operational and deployment models.
+  \item Related research, specifications, papers, and theses.
+\end{itemize}
+
+\section{Architecture Outline}
+
+\subsection{Connectors}
+
+Connectors expose ledger-specific capabilities through common APIs and plugin
+interfaces.
+
+\subsection{Validation and Verification}
+
+Validation components provide evidence handling, proof verification, and
+cross-network state checking where supported by the target networks.
+
+\subsection{Applications and Tooling}
+
+Cacti includes application-level packages, examples, and operational tooling
+that demonstrate how interoperability components are composed.
+
+\section{Research and Prior Art}
+
+The bibliography is intentionally kept in source form so papers, theses, and
+specifications can be reviewed alongside the text that cites them.
+
+\nocite{hyperledger-cacti-docs}
+\nocite{hyperledger-cacti-repo}
+
+\bibliographystyle{plain}
+\bibliography{references}
+
+\end{document}

--- a/whitepaper/v2/references.bib
+++ b/whitepaper/v2/references.bib
@@ -1,0 +1,15 @@
+@misc{hyperledger-cacti-repo,
+  author = {{Hyperledger Cacti Contributors}},
+  title = {{Hyperledger Cacti Source Repository}},
+  howpublished = {\url{https://github.com/hyperledger-cacti/cacti}},
+  year = {2026},
+  note = {Accessed for the version 2 whitepaper source scaffold}
+}
+
+@misc{hyperledger-cacti-docs,
+  author = {{Hyperledger Cacti Contributors}},
+  title = {{Hyperledger Cacti Documentation}},
+  howpublished = {\url{https://hyperledger-cacti.github.io/cacti/}},
+  year = {2026},
+  note = {Project documentation and contributor guidance}
+}

--- a/whitepaper/whitepaper.md
+++ b/whitepaper/whitepaper.md
@@ -23,6 +23,9 @@ Photo by Pontus Wellgraf on Unsplash
 > Please see the related item in the issue tracker for further details & to join the discussion/work:
 > https://github.com/hyperledger-cacti/cacti/issues/2691
 >
+> Version 2 source lives under [`whitepaper/v2`](./v2/README.md), including
+> LaTeX sources and reproducible build targets.
+>
 > To access the old version of the whitepaper, you can use
 > an older commit of the `main` branch, such as this one:
 > https://github.com/hyperledger-cacti/cacti/blob/7bb39576080592919bea0ac89646b32105e1748e/whitepaper/whitepaper.md


### PR DESCRIPTION
## Summary

- Adds a `whitepaper/v2` source scaffold with LaTeX, bibliography, README, and Makefile.
- Provides local and containerized PDF build targets with reproducibility-focused environment settings.
- Links the existing whitepaper placeholder and MkDocs whitepaper page to the new v2 source directory.

Fixes #3994.

## Validation

- `git diff --check`
- `make -n pdf`
- `make -n container-pdf`
- `make pdf`
