### PR TITLE
ci(dependent-issues): fix fork PR token permissions

### DIFF
--- a/.github/workflows/dependent-issues.yaml
+++ b/.github/workflows/dependent-issues.yaml
@@ -6,7 +6,9 @@ on:
       - opened
       - edited
       - reopened
-  pull_request:
+  # pull_request_target grants write scope on fork PRs. Safe here because
+  # this action only reads PR metadata and never checks out PR head code.
+  pull_request_target:
     types:
       - opened
       - edited
@@ -18,6 +20,12 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  statuses: write
 
 jobs:
   check:


### PR DESCRIPTION
Fork PRs get a read-only `GITHUB_TOKEN` since Feb 2023, so the `Dependent Issues` workflow fails on every external contributor PR with `Resource not accessible by integration`.

**Fix:** switch `pull_request` → `pull_request_target` (runs in base repo's token context so fork PRs get write scope) and add an explicit least-privilege `permissions:` block.

**Safety:** the action only reads PR metadata via the API — it never checks out PR head code, so the usual `pull_request_target` RCE risk does not apply.

### Checklist
- [x] Rebased on `upstream/main`, single commit
- [x] DCO sign-off
- [x] Conventional Commits, title ≤ 72 chars, body ≤ 80 chars/line
- [x] YAML validated locally