### PR TITLE
fix(keychain-vault): redact sensitive logs and sanitize 500 responses

### DIFF
--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/delete-keychain-entry-endpoint-v1.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/delete-keychain-entry-endpoint-v1.ts
@@ -92,7 +92,7 @@ export class DeleteKeychainEntryEndpointV1 implements IWebServiceEndpoint {
   public async handleRequest(req: Request, res: Response): Promise<void> {
     const tag = `${this.getVerbLowerCase().toUpperCase()} ${this.getPath()}`;
     try {
-      this.log.debug(`${tag} %o`, req.body);
+      this.log.debug(tag);
       await this.plugin.delete(req.body.key);
       const resBody: DeleteKeychainEntryResponseV1 = {
         key: req.body.key,
@@ -100,9 +100,9 @@ export class DeleteKeychainEntryEndpointV1 implements IWebServiceEndpoint {
       res.status(200);
       res.json(resBody);
     } catch (ex) {
-      this.log.debug(`${tag} Failed to serve request:`, ex);
+      this.log.error(`${tag} Failed to serve request:`, ex);
       res.status(500);
-      res.json({ error: ex.stack });
+      res.json({ error: "Internal Server Error" });
     }
   }
 }

--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/get-keychain-entry-endpoint-v1.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/get-keychain-entry-endpoint-v1.ts
@@ -92,7 +92,7 @@ export class GetKeychainEntryEndpointV1 implements IWebServiceEndpoint {
   public async handleRequest(req: Request, res: Response): Promise<void> {
     const tag = `${this.getVerbLowerCase().toUpperCase()} ${this.getPath()}`;
     try {
-      this.log.debug(`${tag} %o`, req.body);
+      this.log.debug(tag);
       const value = await this.plugin.get(req.body.key);
       const resBody: GetKeychainEntryResponseV1 = {
         key: req.body.key,
@@ -101,9 +101,9 @@ export class GetKeychainEntryEndpointV1 implements IWebServiceEndpoint {
       res.status(200);
       res.json(resBody);
     } catch (ex) {
-      this.log.debug(`${tag} Failed to serve request:`, ex);
+      this.log.error(`${tag} Failed to serve request:`, ex);
       res.status(500);
-      res.json({ error: ex.stack });
+      res.json({ error: "Internal Server Error" });
     }
   }
 }

--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/get-prometheus-exporter-metrics-endpoint-v1.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/get-prometheus-exporter-metrics-endpoint-v1.ts
@@ -95,8 +95,7 @@ export class GetPrometheusExporterMetricsEndpointV1
     } catch (ex) {
       this.log.error(`${fnTag} failed to serve request`, ex);
       res.status(500);
-      res.statusMessage = ex.message;
-      res.json({ error: ex.stack });
+      res.json({ error: "Internal Server Error" });
     }
   }
 }

--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/has-keychain-entry-endpoint-v1.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/has-keychain-entry-endpoint-v1.ts
@@ -92,7 +92,7 @@ export class HasKeychainEntryEndpointV1 implements IWebServiceEndpoint {
   public async handleRequest(req: Request, res: Response): Promise<void> {
     const tag = `${this.getVerbLowerCase().toUpperCase()} ${this.getPath()}`;
     try {
-      this.log.debug(`${tag} %o`, req.body);
+      this.log.debug(tag);
       const isPresent = await this.plugin.has(req.body.key);
       const resBody: HasKeychainEntryResponseV1 = {
         isPresent,
@@ -102,9 +102,9 @@ export class HasKeychainEntryEndpointV1 implements IWebServiceEndpoint {
       res.status(200);
       res.json(resBody);
     } catch (ex) {
-      this.log.debug(`${tag} Failed to serve request:`, ex);
+      this.log.error(`${tag} Failed to serve request:`, ex);
       res.status(500);
-      res.json({ error: ex.stack });
+      res.json({ error: "Internal Server Error" });
     }
   }
 }

--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/set-keychain-entry-endpoint-v1.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/set-keychain-entry-endpoint-v1.ts
@@ -90,15 +90,15 @@ export class SetKeychainEntryEndpointV1 implements IWebServiceEndpoint {
   public async handleRequest(req: Request, res: Response): Promise<void> {
     const tag = `${this.getVerbLowerCase().toUpperCase()} ${this.getPath()}`;
     try {
-      this.log.debug(`${tag} %o`, req.body);
+      this.log.debug(tag);
       const { key, value } = req.body;
       const resBody = await this.plugin.set(key, value);
       res.status(200);
       res.json(resBody);
     } catch (ex) {
-      this.log.debug(`${tag} Failed to serve request:`, ex);
+      this.log.error(`${tag} Failed to serve request:`, ex);
       res.status(500);
-      res.json({ error: ex.stack });
+      res.json({ error: "Internal Server Error" });
     }
   }
 }

--- a/packages/cactus-plugin-keychain-vault/src/test/typescript/unit/keychain-vault-endpoints.security.test.ts
+++ b/packages/cactus-plugin-keychain-vault/src/test/typescript/unit/keychain-vault-endpoints.security.test.ts
@@ -1,8 +1,6 @@
 import "jest-extended";
 import type { Request, Response } from "express";
 
-import { LoggerProvider } from "@hyperledger/cactus-common";
-
 import { PluginKeychainVault } from "../../../main/typescript/plugin-keychain-vault";
 import { DeleteKeychainEntryEndpointV1 } from "../../../main/typescript/web-services/delete-keychain-entry-endpoint-v1";
 import { GetKeychainEntryEndpointV1 } from "../../../main/typescript/web-services/get-keychain-entry-endpoint-v1";
@@ -35,15 +33,6 @@ describe("Keychain vault endpoint security regression", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest
-      .spyOn(LoggerProvider, "getOrCreate")
-      .mockReturnValue(
-        loggerMock as unknown as ReturnType<typeof LoggerProvider.getOrCreate>,
-      );
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
   });
 
   test("GetKeychainEntryEndpointV1 does not return stack details", async () => {
@@ -56,6 +45,7 @@ describe("Keychain vault endpoint security regression", () => {
       plugin,
       logLevel: "DEBUG",
     });
+    (endpoint as unknown as { log: typeof loggerMock }).log = loggerMock;
     const req = { body: { key: "k1" } } as Request;
     const res = createMockResponse();
 
@@ -76,6 +66,7 @@ describe("Keychain vault endpoint security regression", () => {
       plugin,
       logLevel: "DEBUG",
     });
+    (endpoint as unknown as { log: typeof loggerMock }).log = loggerMock;
     const req = { body: { key: "k2" } } as Request;
     const res = createMockResponse();
 
@@ -98,6 +89,7 @@ describe("Keychain vault endpoint security regression", () => {
       plugin,
       logLevel: "DEBUG",
     });
+    (endpoint as unknown as { log: typeof loggerMock }).log = loggerMock;
     const req = { body: { key: "k3" } } as Request;
     const res = createMockResponse();
 
@@ -120,6 +112,7 @@ describe("Keychain vault endpoint security regression", () => {
       plugin,
       logLevel: "DEBUG",
     });
+    (endpoint as unknown as { log: typeof loggerMock }).log = loggerMock;
     const req = {} as Request;
     const res = createMockResponse();
 

--- a/packages/cactus-plugin-keychain-vault/src/test/typescript/unit/keychain-vault-endpoints.security.test.ts
+++ b/packages/cactus-plugin-keychain-vault/src/test/typescript/unit/keychain-vault-endpoints.security.test.ts
@@ -1,0 +1,132 @@
+import "jest-extended";
+import type { Request, Response } from "express";
+
+import { LoggerProvider } from "@hyperledger/cactus-common";
+
+import { PluginKeychainVault } from "../../../main/typescript/plugin-keychain-vault";
+import { DeleteKeychainEntryEndpointV1 } from "../../../main/typescript/web-services/delete-keychain-entry-endpoint-v1";
+import { GetKeychainEntryEndpointV1 } from "../../../main/typescript/web-services/get-keychain-entry-endpoint-v1";
+import { GetPrometheusExporterMetricsEndpointV1 } from "../../../main/typescript/web-services/get-prometheus-exporter-metrics-endpoint-v1";
+import { HasKeychainEntryEndpointV1 } from "../../../main/typescript/web-services/has-keychain-entry-endpoint-v1";
+
+type MockResponse = {
+  status: jest.Mock;
+  json: jest.Mock;
+  send: jest.Mock;
+};
+
+function createMockResponse(): Response & MockResponse {
+  const res = {} as Response & MockResponse;
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.send = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe("Keychain vault endpoint security regression", () => {
+  const leakMarker = "S3CR3T-LEAK-MARKER";
+
+  const loggerMock = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest
+      .spyOn(LoggerProvider, "getOrCreate")
+      .mockReturnValue(
+        loggerMock as unknown as ReturnType<typeof LoggerProvider.getOrCreate>,
+      );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("GetKeychainEntryEndpointV1 does not return stack details", async () => {
+    const plugin = Object.create(
+      PluginKeychainVault.prototype,
+    ) as PluginKeychainVault & { get: jest.Mock };
+    plugin.get = jest.fn().mockRejectedValue(new Error(`fail ${leakMarker}`));
+
+    const endpoint = new GetKeychainEntryEndpointV1({
+      plugin,
+      logLevel: "DEBUG",
+    });
+    const req = { body: { key: "k1" } } as Request;
+    const res = createMockResponse();
+
+    await endpoint.handleRequest(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: "Internal Server Error" });
+    expect(JSON.stringify(res.json.mock.calls[0][0])).not.toContain(leakMarker);
+  });
+
+  test("HasKeychainEntryEndpointV1 does not return stack details", async () => {
+    const plugin = Object.create(
+      PluginKeychainVault.prototype,
+    ) as PluginKeychainVault & { has: jest.Mock };
+    plugin.has = jest.fn().mockRejectedValue(new Error(`fail ${leakMarker}`));
+
+    const endpoint = new HasKeychainEntryEndpointV1({
+      plugin,
+      logLevel: "DEBUG",
+    });
+    const req = { body: { key: "k2" } } as Request;
+    const res = createMockResponse();
+
+    await endpoint.handleRequest(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: "Internal Server Error" });
+    expect(JSON.stringify(res.json.mock.calls[0][0])).not.toContain(leakMarker);
+  });
+
+  test("DeleteKeychainEntryEndpointV1 does not return stack details", async () => {
+    const plugin = Object.create(
+      PluginKeychainVault.prototype,
+    ) as PluginKeychainVault & { delete: jest.Mock };
+    plugin.delete = jest
+      .fn()
+      .mockRejectedValue(new Error(`fail ${leakMarker}`));
+
+    const endpoint = new DeleteKeychainEntryEndpointV1({
+      plugin,
+      logLevel: "DEBUG",
+    });
+    const req = { body: { key: "k3" } } as Request;
+    const res = createMockResponse();
+
+    await endpoint.handleRequest(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: "Internal Server Error" });
+    expect(JSON.stringify(res.json.mock.calls[0][0])).not.toContain(leakMarker);
+  });
+
+  test("GetPrometheusExporterMetricsEndpointV1 does not return stack details", async () => {
+    const plugin = Object.create(
+      PluginKeychainVault.prototype,
+    ) as PluginKeychainVault & { getPrometheusExporterMetrics: jest.Mock };
+    plugin.getPrometheusExporterMetrics = jest
+      .fn()
+      .mockRejectedValue(new Error(`fail ${leakMarker}`));
+
+    const endpoint = new GetPrometheusExporterMetricsEndpointV1({
+      plugin,
+      logLevel: "DEBUG",
+    });
+    const req = {} as Request;
+    const res = createMockResponse();
+
+    await endpoint.handleRequest(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: "Internal Server Error" });
+    expect(JSON.stringify(res.json.mock.calls[0][0])).not.toContain(leakMarker);
+  });
+});

--- a/packages/cactus-plugin-keychain-vault/src/test/typescript/unit/set-keychain-entry-endpoint-v1.security.test.ts
+++ b/packages/cactus-plugin-keychain-vault/src/test/typescript/unit/set-keychain-entry-endpoint-v1.security.test.ts
@@ -1,8 +1,6 @@
 import "jest-extended";
 import type { Request, Response } from "express";
 
-import { LoggerProvider } from "@hyperledger/cactus-common";
-
 import { PluginKeychainVault } from "../../../main/typescript/plugin-keychain-vault";
 import { SetKeychainEntryEndpointV1 } from "../../../main/typescript/web-services/set-keychain-entry-endpoint-v1";
 
@@ -31,15 +29,6 @@ describe("SetKeychainEntryEndpointV1 security regression", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest
-      .spyOn(LoggerProvider, "getOrCreate")
-      .mockReturnValue(
-        loggerMock as unknown as ReturnType<typeof LoggerProvider.getOrCreate>,
-      );
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
   });
 
   test("does not leak secret in logs and does not return stack trace on error", async () => {
@@ -56,6 +45,7 @@ describe("SetKeychainEntryEndpointV1 security regression", () => {
       plugin,
       logLevel: "DEBUG",
     });
+    (endpoint as unknown as { log: typeof loggerMock }).log = loggerMock;
 
     const req = {
       body: { key, value: secretValue },

--- a/packages/cactus-plugin-keychain-vault/src/test/typescript/unit/set-keychain-entry-endpoint-v1.security.test.ts
+++ b/packages/cactus-plugin-keychain-vault/src/test/typescript/unit/set-keychain-entry-endpoint-v1.security.test.ts
@@ -1,0 +1,80 @@
+import "jest-extended";
+import type { Request, Response } from "express";
+
+import { LoggerProvider } from "@hyperledger/cactus-common";
+
+import { PluginKeychainVault } from "../../../main/typescript/plugin-keychain-vault";
+import { SetKeychainEntryEndpointV1 } from "../../../main/typescript/web-services/set-keychain-entry-endpoint-v1";
+
+type MockResponse = {
+  status: jest.Mock;
+  json: jest.Mock;
+};
+
+function createMockResponse(): Response & MockResponse {
+  const res = {} as Response & MockResponse;
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe("SetKeychainEntryEndpointV1 security regression", () => {
+  const key = "sample-key";
+  const secretValue = "super-secret-value";
+
+  const loggerMock = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest
+      .spyOn(LoggerProvider, "getOrCreate")
+      .mockReturnValue(
+        loggerMock as unknown as ReturnType<typeof LoggerProvider.getOrCreate>,
+      );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("does not leak secret in logs and does not return stack trace on error", async () => {
+    const plugin = Object.create(
+      PluginKeychainVault.prototype,
+    ) as PluginKeychainVault & {
+      set: jest.Mock;
+    };
+    plugin.set = jest
+      .fn()
+      .mockRejectedValue(new Error(`backend failure for ${secretValue}`));
+
+    const endpoint = new SetKeychainEntryEndpointV1({
+      plugin,
+      logLevel: "DEBUG",
+    });
+
+    const req = {
+      body: { key, value: secretValue },
+    } as Request;
+    const res = createMockResponse();
+
+    await endpoint.handleRequest(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: "Internal Server Error" });
+
+    const loggedCalls = JSON.stringify([
+      ...loggerMock.debug.mock.calls,
+      ...loggerMock.error.mock.calls,
+    ]);
+    expect(loggedCalls).not.toContain(secretValue);
+
+    const responseBody = JSON.stringify(res.json.mock.calls[0][0]);
+    expect(responseBody).not.toContain(secretValue);
+    expect(responseBody).not.toContain("stack");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #4279.

This patch closes two security gaps in the keychain-vault endpoints:

1. Request body logging no longer prints sensitive payloads.
2. 500 responses no longer return stack traces or exception messages to clients.

## Why this change

`set-keychain-entry` accepts plaintext secret values (`value`). Logging the full request body can leak those secrets into centralized logs. Returning `ex.stack` and `ex.message` to clients also exposes internal implementation details.

## What changed

- Replaced `this.log.debug(..., req.body)` with route-only debug logging in:
  - `set-keychain-entry-endpoint-v1.ts`
  - `get-keychain-entry-endpoint-v1.ts`
  - `has-keychain-entry-endpoint-v1.ts`
  - `delete-keychain-entry-endpoint-v1.ts`
- Replaced stack/message exposure on 500 responses with:
  - `res.json({ error: "Internal Server Error" })`
- Removed `res.statusMessage = ex.message` from prometheus metrics endpoint error path.

## Tests

Added security regression unit tests:

- `set-keychain-entry-endpoint-v1.security.test.ts`
  - verifies secret marker does not appear in logs or error response payload
- `keychain-vault-endpoints.security.test.ts`
  - verifies `get/has/delete/prometheus` handlers return sanitized 500 responses

## Verification

Ran targeted Jest tests:

`yarn test:jest:all -- packages/cactus-plugin-keychain-vault/src/test/typescript/unit/set-keychain-entry-endpoint-v1.security.test.ts packages/cactus-plugin-keychain-vault/src/test/typescript/unit/keychain-vault-endpoints.security.test.ts`

Result:
- `2` suites passed
- `5` tests passed

Note: Jest reported existing monorepo haste-map warnings about duplicate names in `src/` vs `dist/`, but the targeted tests passed.
