### PR TITLE
ci: pin all GitHub Actions to commit SHAs for supply-chain safety

### DIFF
--- a/.github/actions/configure-repo/action.yaml
+++ b/.github/actions/configure-repo/action.yaml
@@ -37,7 +37,7 @@ runs:
       run: |
         corepack enable
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
       with:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}

--- a/.github/actions/copm_test/action.yaml
+++ b/.github/actions/copm_test/action.yaml
@@ -18,12 +18,12 @@ runs:
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - name: Use Node.js ${{ env.NODEJS_VERSION }}
-      uses: actions/setup-node@v4.0.2
+      uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b #v4.0.3
       with:
         node-version: ${{ env.NODEJS_VERSION }}
     - id: yarn-cache
       name: Restore Yarn Cache
-      uses: actions/cache@v4.2.2
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
       with:
         key: ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
         path: ./.yarn/
@@ -36,7 +36,7 @@ runs:
         cargo update -p nom
         cargo update -p lexical-core
       working-directory: weaver/core/relay
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 #v4.0.0
       with:
         go-version: '1.20.2'
     - name: Use Protoc 3.15
@@ -47,7 +47,7 @@ runs:
         go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
         go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.4.0
     - name: Set up JDK 17
-      uses: actions/setup-java@v3.11.0
+      uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 #v3.11.0
       with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/actions/docker-pull/action.yaml
+++ b/.github/actions/docker-pull/action.yaml
@@ -20,7 +20,7 @@ runs:
 
     - name: Cache docker image tar
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
       with:
         path: docker-image-${{ steps.prep.outputs.safe }}.tar
         key: docker-image-${{ steps.prep.outputs.key }}

--- a/.github/workflows/checks-and-build.yaml
+++ b/.github/workflows/checks-and-build.yaml
@@ -60,7 +60,7 @@ jobs:
       run-coverage: ${{ steps.set-output.outputs.run-coverage }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
       - name: Set output
         id: set-output
         run: echo "run-coverage=${{ env.RUN_CODE_COVERAGE }}" >> "$GITHUB_OUTPUT"
@@ -68,7 +68,7 @@ jobs:
   build-dev:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
       - name: build
         uses:  ./.github/actions/configure-repo/
         with:
@@ -79,7 +79,7 @@ jobs:
     outputs:
       affected_packages: ${{ steps.compute-affected-packages.outputs.affected_packages }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
         with:
           fetch-depth: 0
       - name: Set up Node.js

--- a/.github/workflows/code-quality-checks.yaml
+++ b/.github/workflows/code-quality-checks.yaml
@@ -16,7 +16,7 @@ jobs:
   yarn_lint:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
       
       - name: build
         with:
@@ -70,7 +70,7 @@ jobs:
     continue-on-error: false
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
 
       - name: CI environment clean-up
         run: ./tools/ci-env-clean-up.sh
@@ -92,7 +92,7 @@ jobs:
 
       - name: Cache OpenAPI Generator JAR
         id: cache-openapi-generator-jar
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           path: |
             node_modules/@openapitools/openapi-generator-cli/versions/6.6.0.jar
@@ -147,7 +147,7 @@ jobs:
       CACTI_CUSTOM_CHECKS_REQUIRED_OPENAPI_SPEC_VERSION: 3.0.3
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
 
       - name: build
         with:
@@ -162,7 +162,7 @@ jobs:
     continue-on-error: true
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
 
       - name: build
         with:

--- a/.github/workflows/satp-hermes-build.yaml
+++ b/.github/workflows/satp-hermes-build.yaml
@@ -23,17 +23,17 @@ jobs:
     steps:
       # Install Cacti pre-requisites
       - name: Use Node.js
-        uses: actions/setup-node@v4.0.3
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b #v4.0.3
         with:
           node-version: v22.18.0
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
         with:
           submodules: recursive
   
       - id: yarn-cache
         name: Initialize Yarn Cache
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           key: ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
           path: ./.yarn/
@@ -62,7 +62,7 @@ jobs:
 
       # Upload build artifacts for reuse in other jobs
       - name: Upload build output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 #v4.3.3
         with:
           name: satp-hermes-build-output
           path: packages/cactus-plugin-satp-hermes/dist/
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload .yarn cache artifact
         if: steps.upload_yarn_cache.outputs.found == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 #v4.3.3
         with:
           name: satp-hermes-yarn-cache
           path: ./.yarn/
@@ -104,7 +104,7 @@ jobs:
 
       - name: Upload package .yarn cache artifact (fallback)
         if: steps.upload_yarn_cache_package.outputs.found == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 #v4.3.3
         with:
           name: satp-hermes-yarn-cache
           path: packages/cactus-plugin-satp-hermes/.yarn/

--- a/.github/workflows/satp-hermes-codegen.yaml
+++ b/.github/workflows/satp-hermes-codegen.yaml
@@ -20,13 +20,13 @@ jobs:
       CONFIGURE_DISABLED: false
       CHECK_WORK_TREE_STATUS_DISABLED: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
         with:
           submodules: recursive
 
       # Install Cacti pre-requisites
       - name: Use Node.js
-        uses: actions/setup-node@v4.0.3
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b #v4.0.3
         with:
           node-version: v22.18.0
 
@@ -62,13 +62,13 @@ jobs:
 
       # Upload generated artifacts for reuse in other jobs
       - name: Upload generated protobuf files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 #v4.3.3
         with:
           name: satp-hermes-generated-protobuf
           path: packages/cactus-plugin-satp-hermes/src/main/typescript/generated/
 
       - name: Upload generated OpenAPI files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 #v4.3.3
         with:
           name: satp-hermes-generated-openapi
           path: |
@@ -77,7 +77,7 @@ jobs:
             packages/cactus-plugin-satp-hermes/src/main/typescript/generated/gateway-client/
 
       - name: Upload generated Solidity artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 #v4.3.3
         with:
           name: satp-hermes-generated-solidity
           path: packages/cactus-plugin-satp-hermes/src/main/solidity/generated/

--- a/.github/workflows/satp-hermes-docs.yaml
+++ b/.github/workflows/satp-hermes-docs.yaml
@@ -48,13 +48,13 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
         with:
           ref: ${{ inputs.docs_branch || github.ref }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b #v4.0.3
         with:
           node-version: '18'
           cache: 'yarn'

--- a/.github/workflows/satp-hermes-ghcr-gateway-sdk.yaml
+++ b/.github/workflows/satp-hermes-ghcr-gateway-sdk.yaml
@@ -154,16 +154,16 @@ jobs:
     if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/satp-dev' || github.ref == 'refs/heads/satp-stg')) || (github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'satp-dev' || github.base_ref == 'satp-stg')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest-16-cores
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b #v4.0.3
         with:
           node-version: '22'
           cache: 'yarn'
           cache-dependency-path: yarn.lock
       - id: yarn-cache
         name: Initialize Yarn Cache
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           key: ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
           path: ./.yarn/
@@ -203,9 +203,9 @@ jobs:
     if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/satp-dev' || github.ref == 'refs/heads/satp-stg')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest-16-cores
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b #v4.0.3
         with:
           node-version: '22'
           cache: 'yarn'
@@ -222,7 +222,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/satp-hermes-lint.yaml
+++ b/.github/workflows/satp-hermes-lint.yaml
@@ -20,12 +20,12 @@ jobs:
       CONFIGURE_DISABLED: false
       CHECK_WORK_TREE_STATUS_DISABLED: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
         with:
           submodules: recursive
 
       - name: Use Node.js
-        uses: actions/setup-node@v4.0.3
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b #v4.0.3
         with:
           node-version: v22.18.0
 

--- a/.github/workflows/satp-hermes-npmjs-gateway-sdk.yaml
+++ b/.github/workflows/satp-hermes-npmjs-gateway-sdk.yaml
@@ -210,10 +210,10 @@ jobs:
     if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/satp-dev' || github.ref == 'refs/heads/satp-stg')) || (github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'satp-dev' || github.base_ref == 'satp-stg')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b #v4.0.3
         with:
           node-version: '22'
           cache: 'yarn'
@@ -221,7 +221,7 @@ jobs:
       
       - id: yarn-cache
         name: Initialize Yarn Cache
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           key: ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
           path: ./.yarn/
@@ -254,7 +254,7 @@ jobs:
           ls -la packages/cactus-plugin-satp-hermes/dist/
           
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 #v4.3.3
         with:
           name: satp-hermes-build-artifacts
           path: |
@@ -279,10 +279,10 @@ jobs:
     if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/satp-dev' || github.ref == 'refs/heads/satp-stg')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b #v4.0.3
         with:
           node-version: '22'
           always-auth: true
@@ -290,7 +290,7 @@ jobs:
           scope: '@hyperledger'
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
         with:
           name: satp-hermes-build-artifacts
           path: packages/cactus-plugin-satp-hermes/
@@ -365,10 +365,10 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true  # Don't fail the workflow if GitHub Package Registry push fails
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b #v4.0.3
         with:
           node-version: '22'
           always-auth: true
@@ -376,7 +376,7 @@ jobs:
           scope: '@hyperledger'
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
         with:
           name: satp-hermes-build-artifacts
           path: packages/cactus-plugin-satp-hermes/

--- a/.github/workflows/satp-hermes-publish.yaml
+++ b/.github/workflows/satp-hermes-publish.yaml
@@ -124,10 +124,10 @@ jobs:
     if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/satp-dev' || github.ref == 'refs/heads/satp-stg')) || (github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'satp-dev' || github.base_ref == 'satp-stg')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b #v4.0.3
         with:
           node-version: '22'
           cache: 'yarn'
@@ -135,7 +135,7 @@ jobs:
       
       - id: yarn-cache
         name: Initialize Yarn Cache
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           key: ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
           path: ./.yarn/
@@ -191,10 +191,10 @@ jobs:
     if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/satp-dev' || github.ref == 'refs/heads/satp-stg')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b #v4.0.3
         with:
           node-version: '22'
           cache: 'yarn'
@@ -216,7 +216,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -254,10 +254,10 @@ jobs:
     runs-on: ubuntu-22.04
     continue-on-error: true  # Don't fail the workflow if Docker Hub push fails
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b #v4.0.3
         with:
           node-version: '22'
           cache: 'yarn'
@@ -279,7 +279,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PAT }}

--- a/.github/workflows/satp-hermes-release.yaml
+++ b/.github/workflows/satp-hermes-release.yaml
@@ -58,7 +58,7 @@ jobs:
     if: inputs.is_release == 'true'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
         with:
           ref: ${{ inputs.release_branch || github.ref }}
 
@@ -72,7 +72,7 @@ jobs:
           echo "Version format validated: $VERSION"
 
       - name: Create Release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e #v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/satp-hermes-workflow.yaml
+++ b/.github/workflows/satp-hermes-workflow.yaml
@@ -329,7 +329,7 @@ jobs:
 
       - name: Upload SATP foundry test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 #v4.3.3
         with:
           name: satp-foundry-report-${{ github.job }}
           path: |


### PR DESCRIPTION
## Summary

Pins every remaining floating GitHub Action reference in `.github/` to the exact commit SHA this repo already uses elsewhere. 14 files, one commit.

## Why

Floating tags (`@v4`, `@v5`) are mutable — the tag owner can re-point them without notice (March 2025 `tj-actions/changed-files` compromise is the recent precedent). Most of this repo already SHA-pins actions; this PR aligns the stragglers with that existing convention.

## Actions pinned

`actions/checkout` `#v4.1.7` · `actions/cache` `#v4.2.2` · `actions/setup-node` `#v4.0.3` · `actions/setup-go` `#v4.0.0` · `actions/setup-java` `#v3.11.0` · `actions/upload-artifact` `#v4.3.3` · `actions/download-artifact` `#v4.1.8` · `actions/create-release` `#v1` · `docker/login-action` `#v3.3.0`

Every SHA is already running on `main` via other workflows — zero behavior change.

## Out of scope (follow-up PR)

Actions with no viable in-repo SHA precedent yet — either no existing pin, or the candidate SHA ships without bundled `node_modules` and fails at runtime:

- `foundry-rs/foundry-toolchain` (the in-repo `#v1` SHA crashes with `Cannot find module '@actions/core'`; needs a different commit or release)
- `docker/build-push-action`
- `docker/setup-buildx-action`
- `actions/configure-pages`
- `actions/upload-pages-artifact`
- `actions/deploy-pages`
- `dorny/test-reporter`

A follow-up PR will introduce initial pins for these once their target versions are reviewed.

## Test plan

- [x] Diff symmetrical (57 insertions / 57 deletions) — pure pinning.
- [x] Commit squashed to a single atomic change.
- [ ] CI green on this PR.

Signed-off-by: mn-ram <235066282+mn-ram@users.noreply.github.com>