### PR TITLE
fix(satp-hermes): add input validation to transact-handler-service

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/api1/transaction/transact-handler-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/api1/transaction/transact-handler-service.ts
@@ -1,6 +1,9 @@
 import { TransactRequest, TransactResponse } from "../../public-api";
 import { SATPManager } from "../../services/gateway/satp-manager";
-import { populateClientSessionData } from "../../core/session-utils";
+import {
+  populateClientSessionData,
+  validateTransactRequest,
+} from "../../core/session-utils";
 import {
   CredentialProfile,
   LockType,
@@ -27,8 +30,10 @@ export async function executeTransact(
 
   logger.info(`${fnTag}, executing transaction endpoint`);
 
-  //TODO check input for valid strings...
+  validateTransactRequest(req, fnTag);
+
   const ourGateway: GatewayIdentity = orchestrator.ourGateway;
+
   const senderGatewayOwnerId: string = ourGateway.id;
 
   //This data is set in satpManager GOL

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/session-utils.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/session-utils.ts
@@ -109,8 +109,83 @@ import { SATPInternalError } from "./errors/satp-errors";
 import { SATPSession } from "./satp-session";
 
 import { v4 as uuidv4 } from "uuid";
-import { TokenType } from "../public-api";
+import { TokenType, TransactRequest } from "../public-api";
 import { TokenType as ProtoTokenType } from "../generated/proto/cacti/satp/v02/common/message_pb";
+
+/**
+ * Validates the required fields of a TransactRequest.
+ *
+ * @description
+ * Checks that the essential nested fields needed by
+ * {@link populateClientSessionData} are present on the request,
+ * throwing a 400 SATPInternalError for the first missing field.
+ *
+ * @public
+ * @param {TransactRequest} req - The incoming transact request.
+ * @param {string} fnTag - Caller function tag for error context.
+ * @throws {SATPInternalError} If a required field is missing.
+ */
+export function validateTransactRequest(
+  req: TransactRequest,
+  fnTag: string,
+): void {
+  if (!req.sourceAsset) {
+    throw new SATPInternalError(
+      `${fnTag}, missing required field: sourceAsset`,
+      null,
+      400,
+    );
+  }
+  if (!req.receiverAsset) {
+    throw new SATPInternalError(
+      `${fnTag}, missing required field: receiverAsset`,
+      null,
+      400,
+    );
+  }
+  if (!req.sourceAsset.networkId) {
+    throw new SATPInternalError(
+      `${fnTag}, missing required field: sourceAsset.networkId`,
+      null,
+      400,
+    );
+  }
+  if (!req.receiverAsset.networkId) {
+    throw new SATPInternalError(
+      `${fnTag}, missing required field: receiverAsset.networkId`,
+      null,
+      400,
+    );
+  }
+  if (!req.sourceAsset.owner) {
+    throw new SATPInternalError(
+      `${fnTag}, missing required field: sourceAsset.owner`,
+      null,
+      400,
+    );
+  }
+  if (!req.receiverAsset.owner) {
+    throw new SATPInternalError(
+      `${fnTag}, missing required field: receiverAsset.owner`,
+      null,
+      400,
+    );
+  }
+  if (!req.sourceAsset.contractName) {
+    throw new SATPInternalError(
+      `${fnTag}, missing required field: sourceAsset.contractName`,
+      null,
+      400,
+    );
+  }
+  if (!req.receiverAsset.contractName) {
+    throw new SATPInternalError(
+      `${fnTag}, missing required field: receiverAsset.contractName`,
+      null,
+      400,
+    );
+  }
+}
 
 /**
  * Enumeration of timestamp types for SATP message processing.


### PR DESCRIPTION
**Pull Request Requirements**
- [x] Rebased onto `upstream/main` and squashed into single commit.
- [x] Signed off with `git commit -s`.
- [x] Follows the Conventional Commits specification.

**Character Limit**
- [x] Title and Commit Subject < 72 characters.
- [x] Commit Message per line < 80 characters.

---

Closes: relates to #4037 (Cacti cleanup)

#### What This Does
Adds input validation guard clauses to `executeTransact()` in
`transact-handler-service.ts`, replacing a `TODO` stub. Previously,
missing `sourceAsset` or `receiverAsset` fields caused cryptic
`Cannot read properties of undefined` errors deep in the session
population logic.

#### Changes
- **`api1/transaction/transact-handler-service.ts`**: Added guard
  clauses that validate `sourceAsset`, `receiverAsset`, and their
  required nested fields (`networkId`, `owner`, `contractName`).
- Throws `SATPInternalError` with HTTP 400 for missing fields.

#### Validation
- `yarn eslint` :- clean 
- Additive guard clauses only; existing valid calls unaffected
