### PR TITLE
fix(verifier): propagate startMonitor startup errors to callers

### DIFF
--- a/packages/cactus-verifier-client/src/main/typescript/verifier.ts
+++ b/packages/cactus-verifier-client/src/main/typescript/verifier.ts
@@ -124,6 +124,7 @@ export class Verifier<LedgerApiType extends ISocketApiClient<unknown>>
     } catch (err) {
       this.log.error(`##Error: startMonitor, ${err}`);
       this.runningMonitors.delete(appId);
+      throw err;
     }
   }
 

--- a/packages/cactus-verifier-client/src/test/typescript/unit/verifier.test.ts
+++ b/packages/cactus-verifier-client/src/test/typescript/unit/verifier.test.ts
@@ -99,7 +99,7 @@ describe("Monitoring Tests", () => {
     expect(sut.startMonitor("someId", {}, eventListenerMock)).toReject();
   });
 
-  test("In case of ApiClient exception runningMonitors is not updated", () => {
+  test("In case of ApiClient exception startMonitor rejects and runningMonitors is not updated", async () => {
     apiClientMock = new MockApiClient();
     apiClientMock.watchBlocksV1.mockImplementation(() => {
       throw Error("Some mock error in watchBlocks");
@@ -107,7 +107,7 @@ describe("Monitoring Tests", () => {
     sut = new Verifier("test-id", apiClientMock, sutLogLevel);
 
     expect(sut.runningMonitors.size).toEqual(0);
-    expect(sut.startMonitor("someId", {}, eventListenerMock)).toResolve();
+    await expect(sut.startMonitor("someId", {}, eventListenerMock)).toReject();
     expect(sut.runningMonitors.size).toEqual(0);
   });
 


### PR DESCRIPTION
`Verifier.startMonitor()` catches errors thrown by `watchBlocksV1()` or `watchBlocksAsyncV1()` during subscription setup, logs them, cleans up `runningMonitors`, but never rethrows. Because the method returns `Promise<void>`, the returned promise resolves successfully even when monitoring failed to start.

Callers that `await startMonitor()` receive no indication that monitoring is inactive. Applications can silently believe block monitoring is running when it is not, which is detectable only by inspecting logs.

## Root cause

```ts
} catch (err) {
  this.log.error(`##Error: startMonitor, ${err}`);
  this.runningMonitors.delete(appId);
  // error swallowed here - promise resolves
}
```

File: `packages/cactus-verifier-client/src/main/typescript/verifier.ts`, lines 124-127.

## Fix

Add `throw err;` after the cleanup so the error propagates to the caller:

```ts
} catch (err) {
  this.log.error(`##Error: startMonitor, ${err}`);
  this.runningMonitors.delete(appId);
  throw err;
}
```

The cleanup (deleting from `runningMonitors`) still happens before rethrowing, so the map stays consistent.

## Test

The existing test `In case of ApiClient exception runningMonitors is not updated` was asserting the broken behaviour (promise resolves on error). Updated it to:

- make the test `async` so the `await` actually waits for the promise
- assert `toReject()` instead of `toResolve()` to match the corrected behaviour
- rename to `In case of ApiClient exception startMonitor rejects and runningMonitors is not updated`

Fixes #4251