### PR TITLE
fix(satp-hermes): stop leaking stack traces from admin endpoints

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/api1/admin/add-counterparty-gateway-endpoint.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/api1/admin/add-counterparty-gateway-endpoint.ts
@@ -12,7 +12,10 @@ import {
   type IAsyncProvider,
 } from "@hyperledger-cacti/cactus-common";
 
-import { registerWebServiceEndpoint } from "@hyperledger-cacti/cactus-core";
+import {
+  handleRestEndpointException,
+  registerWebServiceEndpoint,
+} from "@hyperledger-cacti/cactus-core";
 
 import OAS from "../../../json/oapi-api1-bundled.json";
 import type { IRequestOptions } from "../../core/types";
@@ -83,7 +86,6 @@ export class AddCounterpartyGatewayEndpointV1 implements IWebServiceEndpoint {
   // TODO discover way to inherit OAS schema and have request types here
   // parameter checks should be enforced by the type system
   public async handleRequest(req: Request, res: Response): Promise<void> {
-    const fnTag = `${this.className}#handleRequest()`;
     const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
     const reqBody: AddCounterpartyRequest = req.body;
     try {
@@ -91,11 +93,8 @@ export class AddCounterpartyGatewayEndpointV1 implements IWebServiceEndpoint {
         await this.options.dispatcher.AddCounterpartyGateway(reqBody);
       res.status(200).json(status);
     } catch (ex) {
-      this.log.error(`${fnTag}: Crash while serving ${reqTag}`, ex);
-      res.status(500).json({
-        message: "Internal Server Error",
-        error: ex?.stack || ex?.message,
-      });
+      const errorMsg = `${reqTag} Failed to add counterparty gateway:`;
+      handleRestEndpointException({ errorMsg, log: this.log, error: ex, res });
     }
   }
 }

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/api1/admin/audit-endpoint.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/api1/admin/audit-endpoint.ts
@@ -44,7 +44,10 @@ import {
   type IAsyncProvider,
 } from "@hyperledger-cacti/cactus-common";
 
-import { registerWebServiceEndpoint } from "@hyperledger-cacti/cactus-core";
+import {
+  handleRestEndpointException,
+  registerWebServiceEndpoint,
+} from "@hyperledger-cacti/cactus-core";
 
 import OAS from "../../../json/oapi-api1-bundled.json";
 import type { IRequestOptions } from "../../core/types";
@@ -271,18 +274,9 @@ export class AuditEndpointV1 implements IWebServiceEndpoint {
       const result = await this.options.dispatcher.PerformAudit(auditRequest);
 
       res.status(200).json(result);
-    } catch (ex: any) {
-      this.log.error(`Crash while serving ${reqTag}`, ex);
-
-      const status = ex?.statusCode ?? 500;
-
-      res.status(status).json({
-        error: status === 400 ? "InvalidParameter" : "InternalError",
-        message:
-          status === 400
-            ? ex?.message ?? "Invalid parameter"
-            : "Internal Server Error",
-      });
+    } catch (ex) {
+      const errorMsg = `${reqTag} Failed to perform audit:`;
+      handleRestEndpointException({ errorMsg, log: this.log, error: ex, res });
     }
   }
 }

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/api1/admin/get-all-session-ids-endpoints.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/api1/admin/get-all-session-ids-endpoints.ts
@@ -12,7 +12,10 @@ import {
   type IAsyncProvider,
 } from "@hyperledger-cacti/cactus-common";
 
-import { registerWebServiceEndpoint } from "@hyperledger-cacti/cactus-core";
+import {
+  handleRestEndpointException,
+  registerWebServiceEndpoint,
+} from "@hyperledger-cacti/cactus-core";
 
 import OAS from "../../../json/oapi-api1-bundled.json";
 import type { IRequestOptions } from "../../core/types";
@@ -88,11 +91,8 @@ export class GetSessionIdsEndpointV1 implements IWebServiceEndpoint {
       const result = await this.options.dispatcher.GetSessionIds();
       res.status(200).json(result);
     } catch (ex) {
-      this.log.error(`Crash while serving ${reqTag}`, ex);
-      res.status(500).json({
-        message: "Internal Server Error",
-        error: ex?.stack || ex?.message,
-      });
+      const errorMsg = `${reqTag} Failed to get session ids:`;
+      handleRestEndpointException({ errorMsg, log: this.log, error: ex, res });
     }
   }
 }

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/api1/admin/status-endpoint.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/api1/admin/status-endpoint.ts
@@ -46,7 +46,10 @@ import {
   type IAsyncProvider,
 } from "@hyperledger-cacti/cactus-common";
 
-import { registerWebServiceEndpoint } from "@hyperledger-cacti/cactus-core";
+import {
+  handleRestEndpointException,
+  registerWebServiceEndpoint,
+} from "@hyperledger-cacti/cactus-core";
 
 import OAS from "../../../json/oapi-api1-bundled.json";
 import type { IRequestOptions } from "../../core/types";
@@ -160,11 +163,8 @@ export class GetStatusEndpointV1 implements IWebServiceEndpoint {
       const result = await this.options.dispatcher.GetStatus(statusRequest);
       res.status(200).json(result);
     } catch (ex) {
-      this.log.error(`Crash while serving ${reqTag}`, ex);
-      res.status(500).json({
-        message: "Internal Server Error",
-        error: ex instanceof Error ? ex.message : String(ex),
-      });
+      const errorMsg = `${reqTag} Failed to get status:`;
+      handleRestEndpointException({ errorMsg, log: this.log, error: ex, res });
     }
   }
 }


### PR DESCRIPTION
**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit.
- [x] Have git sign-off at the end of the commit message.
- [x] Follow the Conventional Commits specification.

**Character Limit**
- [x] Pull Request Title and Commit Subject ≤ 80 characters.
- [x] Commit Message per line ≤ 102 characters.

---

Closes: relates to #4037 (Cacti cleanup)

#### What This Does

Four admin endpoints :- `audit`, `status`, `add-counterparty-gateway`, and `get-all-session-ids` 
-> caught internal exceptions and serialized `ex?.stack` directly into the HTTP 500 response body
This leaked file paths, framework internals, and trace IDs to any caller that triggered a 500
Every other SATP-Hermes endpoint already routes through the canonical `handleRestEndpointException` helper from `@hyperledger/cactus-core`, which sanitizes the payload and only exposes details when `error.expose === true`

#### Root Cause

Identical anti-pattern in 4 files:

```ts
} catch (ex) {
  this.log.error(`Crash while serving ${reqTag}`, ex);
  res.status(500).json({
    message: "Internal Server Error",
    error: ex?.stack || ex?.message,
  });
}