### PR TITLE
docs(packages): backfill stub READMEs for keychain and common packages

### DIFF
--- a/packages/cactus-common/README.md
+++ b/packages/cactus-common/README.md
@@ -1,9 +1,63 @@
 # `@hyperledger/cactus-common`
 
-> TODO: description
+Universal utility library shared by both the front-end and back-end components of Cacti. Acts as a developer "swiss army knife" for the rest of the monorepo.
+
+## Summary
+
+`cactus-common` is a low-level dependency consumed by virtually every other Cacti package. It exposes small, focused helpers in the following areas:
+
+- **Logging** — `LoggerProvider`, `Logger`, log levels.
+- **Type guards & primitives** — `Strings`, `Bools`, `Objects`, `Checks`, `isRecord`, `hasKey`.
+- **Errors** — `CodedError`, `safeStringifyException`, `createRuntimeErrorWithCause` / `newRex`, `coerceUnknownToError`, `ErrorFromUnknownThrowable`, `ErrorFromSymbol`.
+- **Crypto** — `JsObjectSigner`, `Secp256k1Keys`, `KeyConverter`, `KeyFormat`.
+- **HTTP** — `HttpHeader`, HTTP status code errors, `ExpressHttpVerbMethodName`.
+- **gRPC** — `isGrpcStatusObjectWithCode`.
+- **Serde** — `bigIntToDecimalStringReplacer` and friends for safe `BigInt` JSON.
+- **JOSE / JWT** — `IJoseFittingJwtParams`, `isIJoseFittingJwtParams`.
+
+The full surface lives in [`src/main/typescript/public-api.ts`](./src/main/typescript/public-api.ts).
+
+## Installation
+
+```sh
+yarn add @hyperledger/cactus-common
+# or
+npm install @hyperledger/cactus-common
+```
 
 ## Usage
 
+```typescript
+import {
+  Checks,
+  LoggerProvider,
+  Strings,
+  newRex,
+} from "@hyperledger/cactus-common";
+
+const log = LoggerProvider.getOrCreate({ label: "my-component", level: "INFO" });
+
+function greet(name: string): string {
+  Checks.nonBlankString(name, "name");
+  return `Hello, ${Strings.dropNonPrintable(name)}!`;
+}
+
+try {
+  log.info(greet("alice"));
+} catch (cause) {
+  throw newRex("greet failed", cause);
+}
 ```
-// TODO: DEMONSTRATE API
+
+## Running tests
+
+From the repository root:
+
+```sh
+yarn lerna run test --scope=@hyperledger/cactus-common
 ```
+
+## References
+
+- Public API surface: [`src/main/typescript/public-api.ts`](./src/main/typescript/public-api.ts)
+- [Cacti core API](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-core-api)

--- a/packages/cactus-plugin-keychain-azure-kv/README.md
+++ b/packages/cactus-plugin-keychain-azure-kv/README.md
@@ -1,3 +1,80 @@
 # `@hyperledger/cactus-plugin-keychain-azure-kv`
 
-# TO-DO
+A Cacti keychain plugin that stores keychain entries in [Azure Key Vault](https://learn.microsoft.com/azure/key-vault/general/overview).
+
+## Summary
+
+Provides a keychain backend backed by Azure Key Vault so that secrets used by Cacti plugins (private keys, API tokens, certificates, etc.) can be persisted in a managed cloud secret store instead of in memory. The plugin implements the standard `IPluginKeychain` interface and exposes the usual `get`, `set`, `has`, and `delete` HTTP endpoints used by other Cacti components.
+
+## Installation
+
+```sh
+yarn add @hyperledger/cactus-plugin-keychain-azure-kv
+# or
+npm install @hyperledger/cactus-plugin-keychain-azure-kv
+```
+
+## Usage
+
+```typescript
+import {
+  PluginKeychainAzureKv,
+  AzureCredentialType,
+} from "@hyperledger/cactus-plugin-keychain-azure-kv";
+
+const keychain = new PluginKeychainAzureKv({
+  keychainId: "my-keychain",
+  instanceId: "instance-1",
+  azureEndpoint: "https://my-vault.vault.azure.net",
+  azureCredentialType: AzureCredentialType.InMemory,
+  azureInMemoryCredentials: {
+    azureTenantId: process.env.AZURE_TENANT_ID!,
+    azureClientId: process.env.AZURE_CLIENT_ID!,
+    azureUsername: process.env.AZURE_USERNAME!,
+    azurePassword: process.env.AZURE_PASSWORD!,
+  },
+});
+
+await keychain.set("my-secret", "s3cr3t");
+const value = await keychain.get("my-secret");
+```
+
+## Options
+
+`IPluginKeychainAzureKvOptions`:
+
+| Option | Required | Description |
+|---|---|---|
+| `keychainId` | yes | Logical id used to address this keychain instance. |
+| `instanceId` | yes | Unique id for the plugin instance within the host. |
+| `azureEndpoint` | yes | Vault URL (e.g. `https://<name>.vault.azure.net`). |
+| `azureCredentialType` | no | One of `InMemory`, `LocalFile`, `RefreshToken`, `AccessToken`. |
+| `azureInMemoryCredentials` | conditional | Required when `azureCredentialType === InMemory`. |
+| `refreshTokenCredentials` | conditional | Required when `azureCredentialType === RefreshToken`. |
+| `accessTokenCredentials` | conditional | Required when `azureCredentialType === AccessToken`. |
+| `backend` | no | Inject a pre-built `@azure/keyvault-secrets` `SecretClient` (mainly for tests). |
+| `logLevel` | no | Cacti `LogLevelDesc`. |
+
+## Web service endpoints
+
+Mounted under `/api/v1/plugins/@hyperledger/cactus-plugin-keychain-azure-kv/`:
+
+- `set-keychain-entry`
+- `get-keychain-entry`
+- `has-keychain-entry`
+- `delete-keychain-entry`
+
+## Running tests
+
+From the repository root:
+
+```sh
+yarn lerna run test --scope=@hyperledger/cactus-plugin-keychain-azure-kv
+```
+
+Integration tests require valid Azure Key Vault credentials in the environment.
+
+## References
+
+- [Azure Key Vault documentation](https://learn.microsoft.com/azure/key-vault/)
+- [Cacti core API](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-core-api)

--- a/packages/cactus-plugin-keychain-google-sm/README.md
+++ b/packages/cactus-plugin-keychain-google-sm/README.md
@@ -1,3 +1,66 @@
 # `@hyperledger/cactus-plugin-keychain-google-sm`
 
-# TO-DO
+A Cacti keychain plugin that stores keychain entries in [Google Cloud Secret Manager](https://cloud.google.com/security/products/secret-manager).
+
+## Summary
+
+Provides a keychain backend backed by Google Cloud Secret Manager so that secrets used by Cacti plugins (private keys, API tokens, certificates, etc.) can be persisted in a managed cloud secret store instead of in memory. The plugin implements the standard `IPluginKeychain` interface and exposes the usual `get`, `set`, `has`, and `delete` HTTP endpoints used by other Cacti components.
+
+## Installation
+
+```sh
+yarn add @hyperledger/cactus-plugin-keychain-google-sm
+# or
+npm install @hyperledger/cactus-plugin-keychain-google-sm
+```
+
+## Usage
+
+```typescript
+import { PluginKeychainGoogleSm } from "@hyperledger/cactus-plugin-keychain-google-sm";
+
+const keychain = new PluginKeychainGoogleSm({
+  keychainId: "my-keychain",
+  instanceId: "instance-1",
+});
+
+await keychain.set("my-secret", "s3cr3t");
+const value = await keychain.get("my-secret");
+```
+
+Authentication is handled by the underlying `@google-cloud/secret-manager` client, which honours the standard [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) chain (`GOOGLE_APPLICATION_CREDENTIALS`, workload identity, etc.).
+
+## Options
+
+`IPluginKeychainGoogleSmOptions`:
+
+| Option | Required | Description |
+|---|---|---|
+| `keychainId` | yes | Logical id used to address this keychain instance. |
+| `instanceId` | yes | Unique id for the plugin instance within the host. |
+| `backend` | no | Inject a pre-built `SecretManagerServiceClient` (mainly for tests). |
+| `logLevel` | no | Cacti `LogLevelDesc`. |
+
+## Web service endpoints
+
+Mounted under `/api/v1/plugins/@hyperledger/cactus-plugin-keychain-google-sm/`:
+
+- `set-keychain-entry`
+- `get-keychain-entry`
+- `has-keychain-entry`
+- `delete-keychain-entry`
+
+## Running tests
+
+From the repository root:
+
+```sh
+yarn lerna run test --scope=@hyperledger/cactus-plugin-keychain-google-sm
+```
+
+Integration tests require valid Google Cloud credentials in the environment and access to a project with Secret Manager enabled.
+
+## References
+
+- [Google Cloud Secret Manager documentation](https://cloud.google.com/secret-manager/docs)
+- [Cacti core API](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-core-api)

--- a/packages/cactus-plugin-keychain-google-sm/package.json
+++ b/packages/cactus-plugin-keychain-google-sm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hyperledger/cactus-plugin-keychain-google-sm",
   "version": "2.1.0",
-  "description": "A keychain implementation storing its entries in Azure key vault.",
+  "description": "A keychain implementation storing its entries in Google Cloud Secret Manager.",
   "keywords": [
     "Hyperledger",
     "Cacti",


### PR DESCRIPTION
Closes #4303

## Summary

Backfills three stub READMEs that previously contained only \`TO-DO\`/\`TODO\` placeholders, and corrects a misleading \`description\` field.

- \`packages/cactus-plugin-keychain-azure-kv/README.md\` — was 2 lines (\`# TO-DO\`)
- \`packages/cactus-plugin-keychain-google-sm/README.md\` — was 2 lines (\`# TO-DO\`)
- \`packages/cactus-common/README.md\` — was 9 lines of \`TODO\` placeholders
- \`packages/cactus-plugin-keychain-google-sm/package.json\` — \`description\` referenced *Azure key vault* instead of *Google Cloud Secret Manager*

Each new README documents Summary, Installation, Usage, Options, Web service endpoints (where applicable), Running tests, and References. The contents are derived from the existing source (\`public-api.ts\`, plugin classes, web-service folders) so they match the actual surface today.

\`cactus-common\` is depended on by virtually every other package, so the lack of any documented surface was the most impactful gap of the three.

## Why this matters

Aligns with the Cacti Cleanup Initiative goals around documentation and contributor onboarding.

## Validation

- Linked source paths and methods all exist on \`main\` (e.g. \`Strings.dropNonPrintable\`, \`PluginKeychainAzureKv\`, \`AzureCredentialType\`, \`PluginKeychainGoogleSm\`, \`createRuntimeErrorWithCause\`/\`newRex\`).
- No code changes outside docs and the one corrected \`description\` field; no test impact.

## Out of scope

- Other test-only packages with short READMEs (\`cactus-test-*\`).
- A repo-wide README lint / CI gate — possible follow-up once a canonical structure is settled.

## Pull Request Requirements
- [x] Rebased onto \`upstream/main\` and squashed into a single commit.
- [x] Signed off (\`git commit -s\`).
- [x] Conventional commit format. Title ≤ 80 chars; body lines ≤ 102 chars.