### PR TITLE
fix(satp): ensure request.common is defined in stage3 server service

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/server/stage3-server-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/server/stage3-server-service.ts
@@ -454,6 +454,10 @@ export class Stage3ServerService extends SATPService {
 
         const sessionData = session.getServerSessionData();
 
+        if (request.common == undefined) {
+          throw new Error(`${fnTag} request.common is undefined`);
+        }
+
         commonBodyVerifier(
           fnTag,
           request.common,
@@ -510,6 +514,10 @@ export class Stage3ServerService extends SATPService {
         session.verify(fnTag, SessionType.SERVER);
 
         const sessionData = session.getServerSessionData();
+
+        if (request.common == undefined) {
+          throw new Error(`${fnTag} request.common is undefined`);
+        }
 
         commonBodyVerifier(
           fnTag,
@@ -584,6 +592,10 @@ export class Stage3ServerService extends SATPService {
         session.verify(fnTag, SessionType.SERVER);
 
         const sessionData = session.getServerSessionData();
+
+        if (request.common == undefined) {
+          throw new Error(`${fnTag} request.common is undefined`);
+        }
 
         commonBodyVerifier(
           fnTag,


### PR DESCRIPTION
This PR addresses issue #4269 by implementing required validation checks for the common field in several request types within the Stage 3 Server Service.

Root Cause Analysis
The original bug report indicated an inverted logic check; however, the current version of the code lacked any explicit undefined check before passing request.common to the commonBodyVerifier. This could lead to runtime errors or silent verification failures if a request is received with a missing common block.

Changes Made
Modified packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/server/stage3-server-service.ts to include explicit undefined checks and throw descriptive errors in the following methods:

checkCommitPreparationRequest: Added check to ensure request.common is defined before calling the verifier.

checkCommitFinalAssertionRequest: Added check to ensure request.common is defined before calling the verifier.

checkTransferCompleteRequest: Added check to ensure request.common is defined before calling the verifier.

Impact
Stability: Prevents the gateway from processing malformed requests that lack essential common metadata.

Error Reporting: Provides clear, logged error messages when a request fails validation, making debugging easier for SATP flows.

Consistency: Aligns the Stage 3 server logic with the project's expected validation standards.