### PR TITLE
fix(cmd-api-server): make gRPC bind host configurable

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
@@ -811,8 +811,7 @@ export class ApiServer {
     const pluginRegistry = await this.getOrInitPluginRegistry();
 
     return new Promise((resolve, reject) => {
-      // const grpcHost = "0.0.0.0"; // FIXME - make this configurable (config-service.ts)
-      const grpcHost = "127.0.0.1"; // FIXME - make this configurable (config-service.ts)
+      const grpcHost = this.options.config.grpcHost;
       const grpcHostAndPort = `${grpcHost}:${this.options.config.grpcPort}`;
 
       const grpcTlsCredentials = this.options.config.grpcMtlsEnabled

--- a/packages/cactus-cmd-api-server/src/main/typescript/config/config-service.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/config/config-service.ts
@@ -55,6 +55,7 @@ export interface ICactusApiServerOptions {
   apiTlsCertPem: string;
   apiTlsKeyPem: string;
   apiTlsClientCaPem: string;
+  grpcHost: string;
   grpcPort: number;
   grpcMtlsEnabled: boolean;
   plugins: PluginImport[];
@@ -400,6 +401,13 @@ export class ConfigService {
         arg: "api-tls-key-pem",
         default: null as string | null,
       },
+      grpcHost: {
+        doc: "The host to bind the gRPC server to. Secure default is: 127.0.0.1. Use 0.0.0.0 to bind for any host.",
+        format: "ipaddress",
+        env: "GRPC_HOST",
+        arg: "grpc-host",
+        default: "127.0.0.1",
+      },
       grpcPort: {
         doc: "The gRPC port to serve web services on.",
         format: "port",
@@ -500,6 +508,7 @@ export class ConfigService {
     const apiPort = (schema.apiPort as SchemaObj).default;
     const apiProtocol = apiTlsEnabled ? "https:" : "http";
     const apiBaseUrl = `${apiProtocol}//${apiHost}:${apiPort}`;
+    const grpcHost = (schema.grpcHost as SchemaObj).default;
     const grpcPort = (schema.grpcPort as SchemaObj).default;
     const grpcMtlsEnabled = (schema.grpcMtlsEnabled as SchemaObj).default;
     const enableShutdownHook = (schema.enableShutdownHook as SchemaObj).default;
@@ -607,6 +616,7 @@ export class ConfigService {
       apiTlsCertPem: pkiServer.certificatePem,
       apiTlsKeyPem: pkiServer.privateKeyPem,
       apiTlsClientCaPem: "-", // API mTLS is off so this will not crash the server
+      grpcHost,
       grpcPort,
       grpcMtlsEnabled,
       cockpitEnabled: (schema.cockpitEnabled as SchemaObj).default,


### PR DESCRIPTION
**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit.
- [x] Have git sign-off at the end of the commit message.
- [x] Follow the Conventional Commits specification.

**Character Limit**
- [x] Pull Request Title and Commit Subject ≤ 80 characters.
- [x] Commit Message per line ≤ 102 characters.

---

Relates to #4037

## What this does

The gRPC server bind address in `ApiServer.startGrpcServer()` was hardcoded to `127.0.0.1` with a FIXME to make it configurable. That blocks deployments that need another bind address (for example `0.0.0.0` behind reverse proxies or in containers). **CRPC** already exposes `crpcHost`; **gRPC** only had `grpcPort` and TLS flags.

## Changes

- **`config-service.ts`** — Add `grpcHost` to `ICactusApiServerOptions` and the convict schema: default `127.0.0.1`, env `GRPC_HOST`, CLI `--grpc-host`, format `ipaddress` (same pattern as `crpcHost`). Wire it into `newExampleConfig`.
- **`api-server.ts`** — Use `this.options.config.grpcHost` instead of the literal; remove the FIXME and commented alternate.

## Behavioral impact

- Default remains `127.0.0.1` — backward compatible.
- Operators can set `--grpc-host` or `GRPC_HOST` when they need a different bind.

## Test plan

 `yarn lerna run lint --scope @hyperledger/cactus-cmd-api-server`
`yarn lerna run test --scope @hyperledger/cactus-cmd-api-server` (or CI)

