### PR TITLE
Fix: Standardize HTTP Error Handling & Docs

### DIFF
--- a/docs/docs/guides/error-handling.md
+++ b/docs/docs/guides/error-handling.md
@@ -1,0 +1,65 @@
+# Error Handling Guidelines for Contributors
+
+This document outlines the guidelines for handling errors in REST endpoints within the project. Proper error handling is crucial for providing clear feedback to API consumers and for maintaining the stability and debuggability of the system.
+
+## Philosophy
+
+*   **Client Errors (4xx):** These indicate that the client has sent a bad request. The client should modify their request and try again. Examples include invalid input, missing parameters, or unauthorized access.
+*   **Server Errors (5xx):** These indicate that something went wrong on the server's side while processing a valid request. The client should typically retry the request later, or report the issue to the developers.
+
+## Using `http-errors` Library
+
+The project utilizes the `http-errors` library (and `http-errors-enhanced-cjs` for status code identifiers) to standardize HTTP error responses. This library allows you to create `HttpError` instances that carry both a status code and a message, which are then correctly processed by the `handleRestEndpointException` utility.
+
+### When to use `createHttpError` (for 4xx Client Errors)
+
+Always use `throw createHttpError(statusCode, message)` when an error originates from invalid client input or a client-side condition that prevents successful processing. This ensures that the client receives an appropriate 4xx status code and a descriptive message.
+
+**Examples of common 4xx errors and when to use them:**
+
+*   **`400 Bad Request`**: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+    *   *Example:* Invalid format for a request body parameter (e.g., a non-numeric string where a number is expected).
+    *   *Code Example:*
+        ```typescript
+        import createHttpError from "http-errors";
+
+        // ... inside an endpoint handler
+        const amountNum = parseInt(reqBody.amount);
+        if (isNaN(amountNum)) {
+          throw createHttpError(400, "Invalid amount provided. Must be a number.");
+        }
+        ```
+*   **`401 Unauthorized`**: The client must authenticate itself to get the requested response. (Note: 401 means "unauthenticated".)
+    *   *Example:* A request without a valid authentication token.
+*   **`403 Forbidden`**: The client does not have access rights to the content, i.e., it is unauthorized, so the server is refusing to give the requested response. Unlike 401, a client's authentication will make no difference.
+    *   *Example:* An authenticated user trying to access a resource they do not have permissions for.
+*   **`404 Not Found`**: The server cannot find the requested resource.
+    *   *Example:* Requesting data for an entity ID that does not exist in the system.
+*   **`409 Conflict`**: Indicates a request conflict with the current state of the target resource.
+    *   *Example:* Attempting to create a resource that already exists with a unique identifier.
+*   **`422 Unprocessable Entity`**: The request was well-formed but was unable to be followed due to semantic errors.
+    *   *Example:* Validation errors where the data structure is correct but the values are logically invalid (e.g., a date in the past for a future appointment).
+
+### When to allow default 500 (Internal Server Error)
+
+If an exception occurs that is *not* an `HttpError` instance, the `handleRestEndpointException` utility will automatically catch it and return a `500 Internal Server Error`. This behavior is desired for:
+
+*   **Unhandled System Errors:** Unexpected issues within the server logic, database errors, integration failures with external services, or other unforeseen problems that are not directly caused by client input.
+*   **Programmatic Bugs:** Errors that indicate a fault in the server's code itself.
+
+**Important:** Do **not** manually throw `createHttpError(500, ...)` unless you are intentionally creating a generic internal server error for a specific, known scenario (which is rare). Let unhandled exceptions fall through to `handleRestEndpointException` to be converted to `500`s.
+
+### Logging within `handleRestEndpointException`
+
+The `handleRestEndpointException` function handles logging differently based on the error type:
+
+*   **5xx Errors (Internal Server Errors):** These are logged at the `error` level to ensure immediate visibility for developers, as they indicate critical issues that need to be addressed.
+*   **4xx Errors (Client Errors):** These are logged at the `debug` level. While they represent client mistakes, logging them as errors would clutter logs with non-critical issues. `debug` level provides visibility for troubleshooting client-side integration problems without triggering alerts for server-side stability.
+
+### Best Practices
+
+*   **Validate Early:** Perform input validation as early as possible in your endpoint handlers.
+*   **Specific Errors:** Strive to return the most specific 4xx status code possible. Avoid always defaulting to `400 Bad Request` if a more precise code like `404 Not Found` or `401 Unauthorized` is applicable.
+*   **Meaningful Messages:** Provide clear, concise, and actionable error messages in your `createHttpError` calls. These messages are returned to the client.
+*   **Avoid Leaking Information:** For `500 Internal Server Errors`, ensure that sensitive internal details (stack traces, database queries, API keys) are not exposed to the client. The `handleRestEndpointException` utility already sanitizes exceptions by default.
+*   **Test Error Paths:** Write tests that explicitly verify both 4xx and 5xx error scenarios to ensure your error handling works as expected.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -194,6 +194,7 @@ nav:
     - Getting Started: guides/getting-started.md
     - Operations: guides/operations.md
     - Developers: guides/developers.md
+    - Error Handling: guides/error-handling.md
     - Upgrading: guides/upgrading.md
   - References:
     - Technical Specifications: references/specs.md

--- a/examples/cactus-example-cbdc-bridging-backend/src/main/typescript/web-services/approve-endpoint.ts
+++ b/examples/cactus-example-cbdc-bridging-backend/src/main/typescript/web-services/approve-endpoint.ts
@@ -20,6 +20,7 @@ import {
   ApproveRequest,
   TransactRequestSourceChainAssetTypeEnum,
 } from "../generated/openapi/typescript-axios/api";
+import createHttpError from "http-errors"; // Import createHttpError
 
 export class ApproveEndpointV1 implements IWebServiceEndpoint {
   public static readonly CLASS_NAME = "ApproveEndpointV1";
@@ -83,6 +84,13 @@ export class ApproveEndpointV1 implements IWebServiceEndpoint {
     this.log.debug(reqTag);
     const reqBody: ApproveRequest = req.body;
     this.log.debug("reqBody: ", reqBody);
+
+    // Validate reqBody.amount
+    const amountNum = parseInt(reqBody.amount);
+    if (isNaN(amountNum)) {
+      throw createHttpError(400, "Invalid amount provided for approval. Must be a number.");
+    }
+
     try {
       let result;
       if (
@@ -91,7 +99,7 @@ export class ApproveEndpointV1 implements IWebServiceEndpoint {
       ) {
         result = await this.options.infrastructure
           .getBesuEnvironment()
-          .approveNTokensBesu(reqBody.user, parseInt(reqBody.amount));
+          .approveNTokensBesu(reqBody.user, amountNum); // Use validated amountNum
       } else {
         result = await this.options.infrastructure
           .getFabricEnvironment()

--- a/examples/cactus-example-cbdc-bridging-backend/src/main/typescript/web-services/get-amount-approved-endpoint.ts
+++ b/examples/cactus-example-cbdc-bridging-backend/src/main/typescript/web-services/get-amount-approved-endpoint.ts
@@ -17,6 +17,7 @@ import {
   registerWebServiceEndpoint,
 } from "@hyperledger-cacti/cactus-core";
 import { TransactRequestSourceChainAssetTypeEnum } from "../generated/openapi/typescript-axios/api";
+import createHttpError from "http-errors"; // Import createHttpError
 
 export class GetAmountApprovedEndpointV1 implements IWebServiceEndpoint {
   public static readonly CLASS_NAME = "GetAmountApprovedEndpointV1";
@@ -78,16 +79,22 @@ export class GetAmountApprovedEndpointV1 implements IWebServiceEndpoint {
     const fnTag = `${this.className}#handleRequest()`;
     const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
     this.log.debug(reqTag);
+
+    const user = req.query.user as string;
+    if (!user) {
+      throw createHttpError(400, "User parameter is required.");
+    }
+
     try {
       let result;
       if (req.query.chain === TransactRequestSourceChainAssetTypeEnum.Besu) {
         result = await this.options.infrastructure
           .getBesuEnvironment()
-          .getAmountApprovedBesu(req.query.user as string);
+          .getAmountApprovedBesu(user);
       } else {
         result = await this.options.infrastructure
           .getFabricEnvironment()
-          .getAmountApprovedFabric(req.query.user as string);
+          .getAmountApprovedFabric(user);
       }
       res.status(200).json(result);
     } catch (ex) {

--- a/examples/cactus-example-cbdc-bridging-backend/src/main/typescript/web-services/get-balance-endpoint.ts
+++ b/examples/cactus-example-cbdc-bridging-backend/src/main/typescript/web-services/get-balance-endpoint.ts
@@ -17,6 +17,7 @@ import {
   registerWebServiceEndpoint,
 } from "@hyperledger-cacti/cactus-core";
 import { TransactRequestSourceChainAssetTypeEnum } from "../generated/openapi/typescript-axios/api";
+import createHttpError from "http-errors"; // Import createHttpError
 
 export class GetBalanceEndpointV1 implements IWebServiceEndpoint {
   public static readonly CLASS_NAME = "GetBalanceEndpointV1";
@@ -78,6 +79,12 @@ export class GetBalanceEndpointV1 implements IWebServiceEndpoint {
     const fnTag = `${this.className}#handleRequest()`;
     const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
     this.log.debug(reqTag);
+
+    const user = req.query.user as string;
+    if (!user) {
+      throw createHttpError(400, "User parameter is required.");
+    }
+
     try {
       let result;
       if (
@@ -86,11 +93,11 @@ export class GetBalanceEndpointV1 implements IWebServiceEndpoint {
       ) {
         result = await this.options.infrastructure
           .getBesuEnvironment()
-          .getBesuBalance(req.query.user as string);
+          .getBesuBalance(user);
       } else {
         result = await this.options.infrastructure
           .getFabricEnvironment()
-          .getFabricBalance(req.query.user as string);
+          .getFabricBalance(user);
       }
       res.status(200).json({
         amount: result,

--- a/examples/cactus-example-cbdc-bridging-backend/src/main/typescript/web-services/mint-endpoint.ts
+++ b/examples/cactus-example-cbdc-bridging-backend/src/main/typescript/web-services/mint-endpoint.ts
@@ -20,6 +20,7 @@ import {
   MintRequest,
   TransactRequestSourceChainAssetTypeEnum,
 } from "../generated/openapi/typescript-axios/api";
+import createHttpError from "http-errors"; // Import createHttpError
 
 export class MintEndpointV1 implements IWebServiceEndpoint {
   public static readonly CLASS_NAME = "MintEndpointV1";
@@ -83,6 +84,13 @@ export class MintEndpointV1 implements IWebServiceEndpoint {
     this.log.debug(reqTag);
     const reqBody: MintRequest = req.body;
     this.log.debug("reqBody: ", reqBody);
+
+    // Validate reqBody.amount
+    const amountNum = parseInt(reqBody.amount);
+    if (isNaN(amountNum)) {
+      throw createHttpError(400, "Invalid amount provided for minting. Must be a number.");
+    }
+
     try {
       let result;
       if (
@@ -91,7 +99,7 @@ export class MintEndpointV1 implements IWebServiceEndpoint {
       ) {
         result = await this.options.infrastructure
           .getBesuEnvironment()
-          .mintTokensBesu(reqBody.user, parseInt(reqBody.amount));
+          .mintTokensBesu(reqBody.user, amountNum); // Use validated amountNum
       } else {
         result = await this.options.infrastructure
           .getFabricEnvironment()

--- a/examples/cactus-example-cbdc-bridging-backend/src/main/typescript/web-services/transact-endpoint.ts
+++ b/examples/cactus-example-cbdc-bridging-backend/src/main/typescript/web-services/transact-endpoint.ts
@@ -17,6 +17,7 @@ import {
   registerWebServiceEndpoint,
 } from "@hyperledger-cacti/cactus-core";
 import { TransactRequest } from "../generated/openapi/typescript-axios/api";
+import createHttpError from "http-errors"; // Import createHttpError
 
 export class TransactEndpointV1 implements IWebServiceEndpoint {
   public static readonly CLASS_NAME = "TransactEndpointV1";
@@ -77,13 +78,30 @@ export class TransactEndpointV1 implements IWebServiceEndpoint {
     this.log.debug(reqTag);
     const reqBody: TransactRequest = req.body;
     this.log.debug("reqBody: ", reqBody);
+
+    // Validate reqBody.sender
+    if (!reqBody.sender) {
+      throw createHttpError(400, "Sender parameter is required.");
+    }
+
+    // Validate reqBody.receiver
+    if (!reqBody.receiver) {
+      throw createHttpError(400, "Receiver parameter is required.");
+    }
+
+    // Validate reqBody.amount
+    const amountNum = parseInt(reqBody.amount);
+    if (isNaN(amountNum)) {
+      throw createHttpError(400, "Invalid amount provided for transaction. Must be a number.");
+    }
+
     try {
       const result = await this.options.infrastructure.bridgeTokens(
         reqBody.sender,
         reqBody.receiver,
         reqBody.sourceChain.assetType!,
         reqBody.receiverChain.assetType!,
-        parseInt(reqBody.amount),
+        amountNum, // Use validated amountNum
       );
       res.status(200).json(result);
     } catch (ex) {

--- a/examples/cactus-example-cbdc-bridging-backend/src/main/typescript/web-services/transfer-endpoint.ts
+++ b/examples/cactus-example-cbdc-bridging-backend/src/main/typescript/web-services/transfer-endpoint.ts
@@ -20,6 +20,7 @@ import {
   TransactRequestSourceChainAssetTypeEnum,
   TransferRequest,
 } from "../generated/openapi/typescript-axios/api";
+import createHttpError from "http-errors"; // Import createHttpError
 
 export class TransferEndpointV1 implements IWebServiceEndpoint {
   public static readonly CLASS_NAME = "TransferEndpointV1";
@@ -83,6 +84,23 @@ export class TransferEndpointV1 implements IWebServiceEndpoint {
     this.log.debug(reqTag);
     const reqBody: TransferRequest = req.body;
     this.log.debug("reqBody: ", reqBody);
+
+    // Validate reqBody.from
+    if (!reqBody.from) {
+      throw createHttpError(400, "Sender (from) parameter is required.");
+    }
+
+    // Validate reqBody.to
+    if (!reqBody.to) {
+      throw createHttpError(400, "Receiver (to) parameter is required.");
+    }
+
+    // Validate reqBody.amount
+    const amountNum = parseInt(reqBody.amount);
+    if (isNaN(amountNum)) {
+      throw createHttpError(400, "Invalid amount provided for transfer. Must be a number.");
+    }
+
     try {
       let result;
       if (
@@ -96,7 +114,7 @@ export class TransferEndpointV1 implements IWebServiceEndpoint {
           .transferTokensBesu(
             reqBody.from,
             reqBody.to,
-            parseInt(reqBody.amount),
+            amountNum, // Use validated amountNum
           );
       } else if (
         reqBody.sourceChain.assetType ===
@@ -108,7 +126,7 @@ export class TransferEndpointV1 implements IWebServiceEndpoint {
           .getFabricEnvironment()
           .transferTokensFabric(reqBody.from, reqBody.to, reqBody.amount);
       } else {
-        throw new Error("Invalid chain combination");
+        throw createHttpError(400, "Invalid chain combination for transfer.");
       }
       res.status(200).json(result);
     } catch (ex) {

--- a/packages/cactus-core/src/main/typescript/web-services/handle-rest-endpoint-exception.ts
+++ b/packages/cactus-core/src/main/typescript/web-services/handle-rest-endpoint-exception.ts
@@ -54,9 +54,9 @@ export async function handleRestEndpointException(
     // For 5xx errors we treat it as a production bug that needs to be fixed on
     // our side and for everything else we treat it a user error and debug log it.
     if (ctx.error.statusCode >= INTERNAL_SERVER_ERROR) {
-      ctx.log.debug(ctx.errorMsg, errorAsSanitizedJson);
-    } else {
       ctx.log.error(ctx.errorMsg, errorAsSanitizedJson);
+    } else {
+      ctx.log.debug(ctx.errorMsg, errorAsSanitizedJson);
     }
 
     // If the `expose` property is set to true it implies that we can safely


### PR DESCRIPTION
### Problem Addressed
Fixes: #1378 

This PR addresses the inconsistent use of HTTP status codes (4xx for client errors vs. 5xx for server errors) across the codebase, and the lack of clear documentation for contributors on proper error handling practices. Initially, unhandled exceptions were incorrectly defaulting to `500 Internal Server Error`, even for client-originated issues, leading to misleading error responses.

### Changes Made

This PR introduces the following improvements:

1.  **Corrected Logging Levels in `handleRestEndpointException`**:
    *   The logging logic in `packages/cactus-core/src/main/typescript/web-services/handle-rest-endpoint-exception.ts` has been adjusted.
    *   `5xx` errors (critical server issues) are now logged at the `error` level.
    *   Non-`5xx` errors (client errors) are now logged at the `debug` level. This ensures more accurate log severity and prevents logs from being cluttered with expected client-side errors.

2.  **Refactored User Error Exceptions in Endpoints**:
    *   Systematic review and refactoring were performed on several API endpoints within `examples/cactus-example-cbdc-bridging-backend/src/main/typescript/web-services/`.
    *   Explicit input validation checks were added for parameters such as `amount`, `sender`, `receiver`, and `user`.
    *   Generic exceptions thrown due to invalid client input were replaced with `createHttpError` instances (from the `http-errors` library), guaranteeing that these client-side errors now correctly trigger `4xx` HTTP status codes (e.g., `400 Bad Request`).

3.  **Documented Error Handling Guidelines for Contributors**:
    *   A new comprehensive documentation file, `docs/docs/guides/error-handling.md`, has been created.
    *   This document provides clear guidelines for developers on:
        *   The philosophical distinction between 4xx and 5xx errors.
        *   How to effectively use the `http-errors` library.
        *   When to apply specific `4xx` HTTP status codes (e.g., `400`, `401`, `403`, `404`, `409`, `422`).
        *   When to allow exceptions to default to a `500 Internal Server Error` for unhandled system failures.
        *   Details on the updated logging behavior within `handleRestEndpointException`.
        *   General best practices for robust error handling.
    *   This new documentation file has been integrated into the project's documentation structure by updating `docs/mkdocs.yml` under the `Guides` section.

### Outcome

This PR establishes a more robust and consistent approach to HTTP error handling, clearly distinguishing user-originated errors from internal server errors. This improves the API experience for consumers by providing accurate feedback and equips developers with clear, actionable guidelines for maintaining high standards in future contributions.

**Pull Request Requirements**
- [X] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficiently and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when, and why.
- [X] Have git sign-off at the end of the commit message (`Signed-off-by: Name <email>`) to certify the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). Use the `-s` flag with `git commit`. See [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information. **AI agents must not add Signed-off-by tags** — only the human submitter may certify the DCO (see [AI Guidelines §7](./AI_GUIDELINES.md)).
- [x] Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) specification for commit linting.
- [ ] If AI tools were used, include an `Assisted-by` tag in the commit message per the [AI Guidelines §2.2](./AI_GUIDELINES.md#22-disclosure) (e.g., `Assisted-by: GitHub-Copilot:claude-opus-4`). All AI-generated code must be human-reviewed before submission
**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 80 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 102 characters (including spaces and special characters).
 