### PR TITLE
fix(examples): prevent shutdown hangs caused by unresolved hooks

### DIFF
--- a/examples/cactus-example-carbon-accounting-backend/src/main/typescript/carbon-accounting-app.ts
+++ b/examples/cactus-example-carbon-accounting-backend/src/main/typescript/carbon-accounting-app.ts
@@ -50,6 +50,47 @@ export interface ICarbonAccountingAppOptions {
 }
 
 export type ShutdownHook = () => Promise<void>;
+const SHUTDOWN_HOOK_TIMEOUT_MS = Number(process.env.SHUTDOWN_HOOK_TIMEOUT_MS) || 5_000;
+
+async function runShutdownHookWithTimeout(
+  log: Logger,
+  hook: ShutdownHook,
+  hookIndex: number,
+  fnTag: string,
+): Promise<void> {
+  let timedOut = false;
+  const hookPromise = Promise.resolve().then(() => hook());
+
+  hookPromise.catch((err: unknown) => {
+    if (timedOut) {
+      log.error(`${fnTag}: exit hook #%d rejected after timing out:`, hookIndex, err);
+    }
+  });
+
+  let timeoutId: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<string>((resolve) => {
+    timeoutId = setTimeout(() => {
+      timedOut = true;
+      resolve("timed-out");
+    }, SHUTDOWN_HOOK_TIMEOUT_MS);
+  });
+
+  try {
+    const result = await Promise.race([hookPromise.then(() => "completed"), timeoutPromise]);
+    if (result === "timed-out") {
+      log.warn(
+        `${fnTag}: exit hook #%d timed out after %d ms; continuing shutdown`,
+        hookIndex,
+        SHUTDOWN_HOOK_TIMEOUT_MS,
+      );
+      return;
+    }
+  } catch (err) {
+    log.error(`${fnTag}: exit hook #%d failed; continuing shutdown:`, hookIndex, err);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+}
 export class CarbonAccountingApp {
   private readonly log: Logger;
   private readonly shutdownHooks: ShutdownHook[];
@@ -197,8 +238,11 @@ export class CarbonAccountingApp {
   }
 
   public async stop(): Promise<void> {
+    const fnTag = "CarbonAccountingApp#stop()";
+    let i = 0;
     for (const hook of this.shutdownHooks) {
-      await hook(); // FIXME add timeout here so that shutdown does not hang
+      i++;
+      await runShutdownHookWithTimeout(this.log, hook, i, fnTag);
     }
   }
 

--- a/examples/cactus-example-carbon-accounting-backend/src/test/typescript/unit/shutdown-hook-timeout.test.ts
+++ b/examples/cactus-example-carbon-accounting-backend/src/test/typescript/unit/shutdown-hook-timeout.test.ts
@@ -1,0 +1,91 @@
+import "jest-extended";
+
+import { CarbonAccountingApp } from "../../../main/typescript/carbon-accounting-app";
+
+describe("CarbonAccountingApp shutdown hooks with timeout", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  test("hung hook does not block shutdown and next hooks run", async () => {
+    const app = new CarbonAccountingApp({ disableSignalHandlers: true, logLevel: "ERROR" });
+
+    const log = (app as any).log;
+    const warnSpy = jest.spyOn(log, "warn").mockImplementation(() => undefined);
+
+    let secondRun = false;
+
+    app.onShutdown(() => new Promise(() => {})); // never-resolving
+    app.onShutdown(async () => {
+      secondRun = true;
+    });
+
+    const stopPromise = app.stop();
+
+    // advance past the timeout used by the implementation (5s)
+    await jest.advanceTimersByTimeAsync(6_000);
+    await stopPromise;
+
+    expect(secondRun).toBeTrue();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  test("normal hook resolves and subsequent hooks run", async () => {
+    const app = new CarbonAccountingApp({ disableSignalHandlers: true, logLevel: "ERROR" });
+    let a = false;
+    let b = false;
+
+    app.onShutdown(async () => {
+      a = true;
+    });
+    app.onShutdown(async () => {
+      b = true;
+    });
+
+    await app.stop();
+
+    expect(a).toBeTrue();
+    expect(b).toBeTrue();
+  });
+
+  test("rejected hook logs error and subsequent hooks run", async () => {
+    const app = new CarbonAccountingApp({ disableSignalHandlers: true, logLevel: "ERROR" });
+    const log = (app as any).log;
+    const errorSpy = jest.spyOn(log, "error").mockImplementation(() => undefined);
+
+    let ran = false;
+    app.onShutdown(async () => {
+      throw new Error("boom");
+    });
+    app.onShutdown(async () => {
+      ran = true;
+    });
+
+    await app.stop();
+    expect(ran).toBeTrue();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  test("hook that resolves after timeout is treated as timed-out", async () => {
+    const app = new CarbonAccountingApp({ disableSignalHandlers: true, logLevel: "ERROR" });
+    const log = (app as any).log;
+    const warnSpy = jest.spyOn(log, "warn").mockImplementation(() => undefined);
+
+    let lateResolved = false;
+    app.onShutdown(() =>
+      new Promise<void>((resolve) => setTimeout(() => {
+        lateResolved = true;
+        resolve();
+      }, 10_000)),
+    );
+    app.onShutdown(async () => {
+      /* noop */
+    });
+
+    const stopPromise = app.stop();
+    await jest.advanceTimersByTimeAsync(6_000);
+    await stopPromise;
+
+    expect(lateResolved).toBeFalse();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
+++ b/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
@@ -84,6 +84,53 @@ export interface ISupplyChainAppOptions {
 }
 
 export type ShutdownHook = () => Promise<void>;
+// Small, local helper to run a shutdown hook with a timeout so a
+// single hung hook cannot block the entire application shutdown.
+const SHUTDOWN_HOOK_TIMEOUT_MS = Number(process.env.SHUTDOWN_HOOK_TIMEOUT_MS) || 5_000;
+
+async function runShutdownHookWithTimeout(
+  log: Logger,
+  hook: ShutdownHook,
+  hookIndex: number,
+  fnTag: string,
+): Promise<void> {
+  let timedOut = false;
+  const hookPromise = Promise.resolve().then(() => hook());
+
+  hookPromise.catch((err: unknown) => {
+    // If the hook rejects after timing out, make sure we log it but
+    // avoid an unhandled rejection.
+    if (timedOut) {
+      log.error(`${fnTag}: exit hook #%d rejected after timing out:`, hookIndex, err);
+    }
+  });
+
+  let timeoutId: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<string>((resolve) => {
+    timeoutId = setTimeout(() => {
+      timedOut = true;
+      resolve("timed-out");
+    }, SHUTDOWN_HOOK_TIMEOUT_MS);
+  });
+
+  try {
+    const result = await Promise.race([hookPromise.then(() => "completed"), timeoutPromise]);
+    if (result === "timed-out") {
+      log.warn(
+        `${fnTag}: exit hook #%d timed out after %d ms; continuing shutdown`,
+        hookIndex,
+        SHUTDOWN_HOOK_TIMEOUT_MS,
+      );
+      return;
+    }
+    // completed normally
+  } catch (err) {
+    log.error(`${fnTag}: exit hook #%d failed; continuing shutdown:`, hookIndex, err);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+}
+
 //TODO: Generate fabric connector and set in the pluginRegistry
 export class SupplyChainApp {
   private readonly log: Logger;
@@ -459,11 +506,12 @@ export class SupplyChainApp {
   }
 
   public async stop(): Promise<void> {
+    const fnTag = "SupplyChainApp#stop()";
     let i = 0;
     for (const hook of this.shutdownHooks) {
       i++;
       this.log.info("Executing exit hook #%d...", i);
-      await hook(); // FIXME add timeout here so that shutdown does not hang
+      await runShutdownHookWithTimeout(this.log, hook, i, fnTag);
       this.log.info("Executed exit hook #%d OK", i);
     }
   }

--- a/examples/cactus-example-supply-chain-backend/src/test/typescript/unit/shutdown-hook-timeout.test.ts
+++ b/examples/cactus-example-supply-chain-backend/src/test/typescript/unit/shutdown-hook-timeout.test.ts
@@ -1,0 +1,91 @@
+import "jest-extended";
+
+import { SupplyChainApp } from "../../../main/typescript/supply-chain-app";
+
+describe("SupplyChainApp shutdown hooks with timeout", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  test("hung hook does not block shutdown and next hooks run", async () => {
+    const app = new SupplyChainApp({ disableSignalHandlers: true, logLevel: "ERROR" });
+
+    const log = (app as any).log;
+    const warnSpy = jest.spyOn(log, "warn").mockImplementation(() => undefined);
+
+    let secondRun = false;
+
+    app.onShutdown(() => new Promise(() => {})); // never-resolving
+    app.onShutdown(async () => {
+      secondRun = true;
+    });
+
+    const stopPromise = app.stop();
+
+    // advance past the timeout used by the implementation (5s)
+    await jest.advanceTimersByTimeAsync(6_000);
+    await stopPromise;
+
+    expect(secondRun).toBeTrue();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  test("normal hook resolves and subsequent hooks run", async () => {
+    const app = new SupplyChainApp({ disableSignalHandlers: true, logLevel: "ERROR" });
+    let a = false;
+    let b = false;
+
+    app.onShutdown(async () => {
+      a = true;
+    });
+    app.onShutdown(async () => {
+      b = true;
+    });
+
+    await app.stop();
+
+    expect(a).toBeTrue();
+    expect(b).toBeTrue();
+  });
+
+  test("rejected hook logs error and subsequent hooks run", async () => {
+    const app = new SupplyChainApp({ disableSignalHandlers: true, logLevel: "ERROR" });
+    const log = (app as any).log;
+    const errorSpy = jest.spyOn(log, "error").mockImplementation(() => undefined);
+
+    let ran = false;
+    app.onShutdown(async () => {
+      throw new Error("boom");
+    });
+    app.onShutdown(async () => {
+      ran = true;
+    });
+
+    await app.stop();
+    expect(ran).toBeTrue();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  test("hook that resolves after timeout is treated as timed-out", async () => {
+    const app = new SupplyChainApp({ disableSignalHandlers: true, logLevel: "ERROR" });
+    const log = (app as any).log;
+    const warnSpy = jest.spyOn(log, "warn").mockImplementation(() => undefined);
+
+    let lateResolved = false;
+    app.onShutdown(() =>
+      new Promise<void>((resolve) => setTimeout(() => {
+        lateResolved = true;
+        resolve();
+      }, 10_000)),
+    );
+    app.onShutdown(async () => {
+      /* noop */
+    });
+
+    const stopPromise = app.stop();
+    await jest.advanceTimersByTimeAsync(6_000);
+    await stopPromise;
+
+    expect(lateResolved).toBeFalse();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #4333

This PR prevents the example backends from hanging indefinitely during shutdown when a registered shutdown hook never resolves.

The change adds timeout protection around shutdown hook execution in:

* `cactus-example-supply-chain-backend`
* `cactus-example-carbon-accounting-backend`

Shutdown now continues gracefully even if a hook:

* never resolves
* rejects
* resolves after the timeout threshold

## Changes

* Added `runShutdownHookWithTimeout()` helper
* Added configurable shutdown timeout support
* Added timeout/error logging for problematic hooks
* Ensured remaining hooks continue executing after timeout/failure
* Added regression tests covering:

  * hanging hooks
  * rejected hooks
  * normal hooks
  * late-resolving hooks

## Testing Performed

* TypeScript checks passed for modified files
* Added deterministic Jest regression tests using fake timers
* Verified timeout handling and continuation behavior locally with targeted validation

## Notes

This change is intentionally scoped only to the example backends to minimize risk and avoid API changes.
