### PR TITLE
chore(examples): correct typo in supply-chain app crash message

### DIFF
--- a/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app-cli.ts
+++ b/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app-cli.ts
@@ -18,7 +18,7 @@ export async function launchApp(
   try {
     await supplyChainApp.start();
   } catch (ex) {
-    console.error(`SupplyChainApp crashed. Existing...`, ex);
+    console.error(`SupplyChainApp crashed. Exiting...`, ex);
     await supplyChainApp.stop();
     process.exit(-1);
   }


### PR DESCRIPTION
## Summary

Fixes a typo in the supply chain example backend crash message.

The application previously logged:

`SupplyChainApp crashed. Existing...`

This has been corrected to:

`SupplyChainApp crashed. Exiting...`

to accurately reflect the application shutdown behavior after a fatal error.

## Related Issue

Fixes #4338

## Testing Performed

* Verified the updated string in the source file
* Ran targeted TypeScript compilation validation for the affected package
* Confirmed only the intended line changed