### PR TITLE
fix(satp-hermes): correct add-counterparty-gateway operationId

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/api1/admin/add-counterparty-gateway-endpoint.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/api1/admin/add-counterparty-gateway-endpoint.ts
@@ -57,9 +57,11 @@ export class AddCounterpartyGatewayEndpointV1 implements IWebServiceEndpoint {
   }
 
   public getOperationId(): string {
-    return OAS.paths[
-      "/api/v1/@hyperledger-cacti/cactus-plugin-satp-hermes/get-sessions-ids"
-    ].get.operationId;
+    const apiPath =
+      OAS.paths[
+        "/api/v1/@hyperledger-cacti/cactus-plugin-satp-hermes/add-counterparty-gateway"
+      ];
+    return apiPath.post.operationId;
   }
 
   getAuthorizationOptionsProvider(): IAsyncProvider<IEndpointAuthzOptions> {


### PR DESCRIPTION
## Description

Corrects the operation ID lookup for the `add-counterparty-gateway` endpoint in `add-counterparty-gateway-endpoint.ts`. 

Previously, `getOperationId()` was incorrectly returning the operation ID of the `get-sessions-ids` GET endpoint (`GetSessionIds`). This has been corrected to retrieve the proper POST operation ID (`AddCounterparty`) on the `add-counterparty-gateway` path from the bundled OAS spec.


## PR author checklist

- [x] I read and followed the [Pull Request Guidelines](../PULL.md), including linking a 'Triage_Ready' issue (§9).
- [x] If AI tools were used, the commit includes an 'Assisted-by' tag per [AI Guidelines §2.2](../AI_GUIDELINES.md#22-disclosure). All AI-generated code has been human-reviewed before submission.
