### PR TITLE
fix(cacti-plugin-consortium-static): add jti replay protection

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -263,6 +263,8 @@
   ,"adress"
   ,"NFToken"
   ,"NFT"
+  ,"Jtis"
+  ,"jtis"
   ],
   "dictionaries": [
     "typescript,node,npm,go,rust"

--- a/packages/cacti-plugin-consortium-static/src/main/typescript/repository/static-consortium-repository.ts
+++ b/packages/cacti-plugin-consortium-static/src/main/typescript/repository/static-consortium-repository.ts
@@ -57,6 +57,7 @@ export class StaticConsortiumRepository {
   private readonly packageConfigs: Map<string, unknown>;
 
   private readonly entitiesJWK: Map<string, JWK>;
+  private readonly seenJtis = new Map<string, number>();
 
   public get className(): string {
     return StaticConsortiumRepository.CLASS_NAME;
@@ -190,10 +191,6 @@ export class StaticConsortiumRepository {
       );
       return false;
     }
-    const result = await verifyOrganization(jwt, jwk, member.name);
-    if (typeof result === "string") {
-      throw new Error(fn + result);
-    }
-    return result;
+    return verifyOrganization(jwt, jwk, member.name, this.seenJtis);
   }
 }

--- a/packages/cacti-plugin-consortium-static/src/main/typescript/utils.ts
+++ b/packages/cacti-plugin-consortium-static/src/main/typescript/utils.ts
@@ -28,30 +28,48 @@ export async function verifyOrganization(
   token: string,
   jwk: JWK,
   expectedOrganization: string,
-): Promise<string | boolean> {
+  seenJtis?: Map<string, number>,
+): Promise<boolean> {
   try {
-    // Import the JWK as a public key
     const publicKey: Uint8Array | KeyLike = await importJWK(jwk, "ES256K");
 
-    // Verify the JWT using the public key
+    // jwtVerify throws JWTExpired / JWTInvalid on bad tokens, so no manual expiry check needed
     const { payload } = await jwtVerify(token, publicKey);
 
-    // Check if the organization name matches
     if (payload.iss !== expectedOrganization) {
       return false;
     }
 
-    //TODO: verify payload.jti against remote log of the organization.
-    if (!payload.exp) {
-      return "Your token does not have an expiration date.";
+    // jwtVerify does not require exp to be present; reject tokens that omit it
+    if (payload.exp === undefined) {
+      return false;
     }
-    if (payload.exp < Date.now()) {
-      return "The token has expired";
+
+    if (seenJtis !== undefined) {
+      const { jti } = payload;
+      if (!jti) {
+        return false;
+      }
+
+      // Prune expired entries on each call to prevent unbounded memory growth
+      const nowSecs = Math.floor(Date.now() / 1000);
+      for (const [key, expiry] of seenJtis) {
+        if (expiry <= nowSecs) {
+          seenJtis.delete(key);
+        }
+      }
+
+      // Namespace by issuer: jti uniqueness is only guaranteed within an issuer
+      // payload.iss and payload.exp are guaranteed non-undefined at this point
+      const cacheKey = `${payload.iss}:${jti}`;
+      if (seenJtis.has(cacheKey)) {
+        return false;
+      }
+      seenJtis.set(cacheKey, payload.exp as number);
     }
 
     return true;
-  } catch (err) {
-    console.error(err);
+  } catch (_err) {
     return false;
   }
 }

--- a/packages/cacti-plugin-consortium-static/src/test/typescript/unit/verify-organization.test.ts
+++ b/packages/cacti-plugin-consortium-static/src/test/typescript/unit/verify-organization.test.ts
@@ -1,0 +1,137 @@
+import "jest-extended";
+import { SignJWT, importJWK } from "jose";
+import {
+  generateES256JWK,
+  issueOrgToken,
+  verifyOrganization,
+} from "../../../main/typescript/utils";
+
+describe("verifyOrganization", () => {
+  const org = "TestOrg";
+  const expFuture = Math.floor(Date.now() / 1000) + 3600;
+  const expPast = Math.floor(Date.now() / 1000) - 10;
+
+  let pub: Awaited<ReturnType<typeof generateES256JWK>>["pub"];
+  let priv: Awaited<ReturnType<typeof generateES256JWK>>["priv"];
+
+  beforeAll(async () => {
+    const keys = await generateES256JWK();
+    pub = keys.pub;
+    priv = keys.priv;
+  });
+
+  it("accepts a valid token on first use", async () => {
+    const token = await issueOrgToken(
+      priv,
+      { iss: org, exp: expFuture },
+      "member1",
+      "pubkey1",
+    );
+    const result = await verifyOrganization(
+      token,
+      pub,
+      org,
+      new Map<string, number>(),
+    );
+    expect(result).toBe(true);
+  });
+
+  it("rejects a replayed token with the same jti", async () => {
+    const token = await issueOrgToken(
+      priv,
+      { iss: org, exp: expFuture },
+      "member1",
+      "pubkey1",
+    );
+    const seenJtis = new Map<string, number>();
+    await verifyOrganization(token, pub, org, seenJtis);
+    const result = await verifyOrganization(token, pub, org, seenJtis);
+    expect(result).toBe(false);
+  });
+
+  it("rejects a token with wrong issuer", async () => {
+    const token = await issueOrgToken(
+      priv,
+      { iss: "WrongOrg", exp: expFuture },
+      "member1",
+      "pubkey1",
+    );
+    const result = await verifyOrganization(
+      token,
+      pub,
+      org,
+      new Map<string, number>(),
+    );
+    expect(result).toBe(false);
+  });
+
+  it("rejects an expired token", async () => {
+    const token = await issueOrgToken(
+      priv,
+      { iss: org, exp: expPast },
+      "member1",
+      "pubkey1",
+    );
+    const result = await verifyOrganization(
+      token,
+      pub,
+      org,
+      new Map<string, number>(),
+    );
+    expect(result).toBe(false);
+  });
+
+  it("rejects a token that has no exp claim", async () => {
+    const key = await importJWK(priv, "ES256K");
+    const token = await new SignJWT({})
+      .setProtectedHeader({ alg: "ES256K", typ: "JWT" })
+      .setIssuer(org)
+      .setJti("no-exp-jti")
+      .sign(key);
+    const result = await verifyOrganization(
+      token,
+      pub,
+      org,
+      new Map<string, number>(),
+    );
+    expect(result).toBe(false);
+  });
+
+  it("accepts same jti from two different orgs (no cross-org collision)", async () => {
+    const org2 = "OtherOrg";
+    const keys2 = await generateES256JWK();
+    const sharedJti = "shared-jti-value";
+
+    const token1 = await issueOrgToken(
+      priv,
+      { iss: org, exp: expFuture, jti: sharedJti },
+      "member1",
+      "pubkey1",
+    );
+    const token2 = await issueOrgToken(
+      keys2.priv,
+      { iss: org2, exp: expFuture, jti: sharedJti },
+      "member2",
+      "pubkey2",
+    );
+
+    const seenJtis = new Map<string, number>();
+    const result1 = await verifyOrganization(token1, pub, org, seenJtis);
+    const result2 = await verifyOrganization(token2, keys2.pub, org2, seenJtis);
+    expect(result1).toBe(true);
+    expect(result2).toBe(true);
+  });
+
+  it("skips jti tracking when seenJtis is not provided", async () => {
+    const token = await issueOrgToken(
+      priv,
+      { iss: org, exp: expFuture },
+      "member1",
+      "pubkey1",
+    );
+    const first = await verifyOrganization(token, pub, org);
+    const second = await verifyOrganization(token, pub, org);
+    expect(first).toBe(true);
+    expect(second).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds optional `seenJtis: Set<string>` parameter to `verifyOrganization` — if provided, a token whose `jti` has already been seen is rejected, preventing replay attacks
- `StaticConsortiumRepository` owns the `Set` as private state and passes it on every `verifyJWT` call
- Removes the buggy manual expiry check (`payload.exp` in seconds vs `Date.now()` in milliseconds); `jose`'s `jwtVerify` already throws `JWTExpired` for expired tokens, making the manual check both dead code and incorrect
- Removes `console.error` in the catch block; all verification failures now return `false` uniformly
- Adds unit tests covering: first-use acceptance, replay rejection, wrong issuer, expired token, and backwards-compatible no-`seenJtis` mode

Closes #4372

## PR Checklist

- [x] Rebased onto `upstream/main` and squashed into a single commit
- [x] `Signed-off-by` present (`git commit -s`)
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification)
- [x] `Assisted-by: anthropic:claude-sonnet-4-6` included per [AI Guidelines §2.2](./AI_GUIDELINES.md#22-disclosure)