### PR TITLE
fix(satp-hermes): run DB migrations on startup for all repositories

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/database/repository/interfaces/repository.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/database/repository/interfaces/repository.ts
@@ -57,6 +57,8 @@ export interface IRepository<T, K> {
   readById(id: K): Promise<T>;
   /** Create new entity in storage */
   create(entity: T): any;
+  /** Run pending database migrations */
+  migrate(): Promise<void>;
   /** Clean up repository resources and connections */
   destroy(): any;
   /** Reset repository to initial state */

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/database/repository/ipfs-remote-log-repository.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/database/repository/ipfs-remote-log-repository.ts
@@ -158,6 +158,17 @@ export class IPFSRemoteLogRepository implements IRemoteLogRepository {
   async reset() {}
 
   /**
+   * Migration (no-op for IPFS).
+   *
+   * IPFS is schema-less, so no migrations are required.
+   * This method exists to satisfy the interface contract.
+   *
+   * @returns Promise resolving immediately
+   * @since 0.0.3-beta
+   */
+  async migrate(): Promise<void> {}
+
+  /**
    * Destroy operation (no-op for IPFS).
    *
    * IPFS connections are stateless, so no cleanup is required.

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/database/repository/knex-audit-repository.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/database/repository/knex-audit-repository.ts
@@ -187,6 +187,16 @@ export class KnexAuditEntryRepository implements IAuditEntryRepository {
   }
 
   /**
+   * Run pending database migrations to bring the schema up to date.
+   *
+   * @returns Promise resolving when all pending migrations have been applied
+   * @since 0.0.3-beta
+   */
+  async migrate(): Promise<void> {
+    await this.database.migrate.latest();
+  }
+
+  /**
    * Reset the database to initial state by rolling back and reapplying migrations.
    *
    * This operation is destructive and will delete all existing data.

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/database/repository/knex-local-log-repository.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/database/repository/knex-local-log-repository.ts
@@ -268,6 +268,16 @@ export class KnexLocalLogRepository implements ILocalLogRepository {
   }
 
   /**
+   * Run pending database migrations to bring the schema up to date.
+   *
+   * @returns Promise resolving when all pending migrations have been applied
+   * @since 0.0.3-beta
+   */
+  async migrate(): Promise<void> {
+    await this.database.migrate.latest();
+  }
+
+  /**
    * Reset the database to initial state by rolling back and reapplying migrations.
    *
    * This operation is destructive and will delete all existing data.

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/database/repository/knex-oracle-log-repository.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/database/repository/knex-oracle-log-repository.ts
@@ -75,6 +75,16 @@ export class KnexOracleLogRepository implements IOracleLogRepository {
     throw lastError;
   }
 
+  /**
+   * Run pending database migrations to bring the schema up to date.
+   *
+   * @returns Promise resolving when all pending migrations have been applied
+   * @since 0.0.3-beta
+   */
+  async migrate(): Promise<void> {
+    await this.database.migrate.latest();
+  }
+
   async reset() {
     await this.database.migrate.rollback();
     await this.database.migrate.latest();

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/database/repository/knex-remote-log-repository.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/database/repository/knex-remote-log-repository.ts
@@ -126,6 +126,16 @@ export class KnexRemoteLogRepository implements IRemoteLogRepository {
   }
 
   /**
+   * Run pending database migrations to bring the schema up to date.
+   *
+   * @returns Promise resolving when all pending migrations have been applied
+   * @since 0.0.3-beta
+   */
+  async migrate(): Promise<void> {
+    await this.database.migrate.latest();
+  }
+
+  /**
    * Reset the database to initial state by rolling back and reapplying migrations.
    *
    * This operation is destructive and will delete all existing remote log data.

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/plugin-satp-hermes-gateway-cli.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/plugin-satp-hermes-gateway-cli.ts
@@ -359,6 +359,21 @@ export async function launchGateway(
       validateKnexRepositoryConfig({ configValue: config.remoteRepository }),
   );
 
+  const auditRepository = await runValidation(
+    "Audit Repository Config",
+    logger,
+    () => validateKnexRepositoryConfig({ configValue: config.auditRepository }),
+  );
+
+  const oracleLogRepository = await runValidation(
+    "Oracle Log Repository Config",
+    logger,
+    () =>
+      validateKnexRepositoryConfig({
+        configValue: config.oracleLogRepository,
+      }),
+  );
+
   const enableCrashRecovery = await runValidation(
     "SATP Enable Crash Recovery",
     logger,
@@ -407,6 +422,8 @@ export async function launchGateway(
     enableCrashRecovery,
     localRepository,
     remoteRepository,
+    auditRepository,
+    oracleLogRepository,
     extensions,
     adapterConfig,
     pluginRegistry: new PluginRegistry({ plugins: [] }),

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/plugin-satp-hermes-gateway.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/plugin-satp-hermes-gateway.ts
@@ -96,7 +96,7 @@ import { getEnumKeyByValue, getEnumValueByKey } from "./services/utils";
 import { ISignerKeyPair } from "@hyperledger-cacti/cactus-common";
 import { IPrivacyPolicyValue } from "@hyperledger-cacti/cactus-plugin-bungee-hermes/dist/lib/main/typescript/view-creation/privacy-policies";
 import { IMergePolicyValue } from "@hyperledger-cacti/cactus-plugin-bungee-hermes/dist/lib/main/typescript/view-merging/merge-policies";
-import knex, { Knex } from "knex";
+import { Knex } from "knex";
 import { PluginRegistry } from "@hyperledger-cacti/cactus-core";
 import { NetworkId } from "./public-api";
 import {
@@ -105,7 +105,6 @@ import {
   ConfigService,
 } from "@hyperledger-cacti/cactus-cmd-api-server";
 import { AddressInfo } from "node:net";
-import { createMigrationSource } from "./database/knex-migration-source";
 import { ExtensionsManager } from "./extensions/extensions-manager";
 import { MonitorService } from "./services/monitoring/monitor";
 import { Context, context, Span, SpanStatusCode } from "@opentelemetry/api";
@@ -529,7 +528,7 @@ export class SATPGateway implements IPluginWebService, ICactusPlugin {
   private signer: JsObjectSigner;
   private _pubKey: string;
 
-  private isShutdown: boolean = false;
+  private ownApiServerPluginRegistry?: PluginRegistry;
 
   public claimFormat?: ClaimFormat;
   public localRepository?: ILocalLogRepository;
@@ -673,6 +672,27 @@ export class SATPGateway implements IPluginWebService, ICactusPlugin {
         createOracleLogKnexConfig(this.instanceId),
       );
     }
+
+    this.onShutdown({
+      name: "destroy-db-repositories",
+      hook: async () => {
+        const repositories = {
+          localRepository: this.localRepository,
+          remoteRepository: this.remoteRepository,
+          auditRepository: this.auditRepository,
+          oracleLogRepository: this.oracleLogRepository,
+        };
+        for (const [name, repo] of Object.entries(repositories)) {
+          if (repo != null) {
+            await repo.destroy();
+          } else {
+            this.logger.warn(
+              `Skipping repository destroy on shutdown: ${name} is not defined`,
+            );
+          }
+        }
+      },
+    });
 
     if (this.config.keyPair === undefined) {
       throw new Error("Key pair is undefined");
@@ -1168,6 +1188,7 @@ export class SATPGateway implements IPluginWebService, ICactusPlugin {
         const pluginRegistry = new PluginRegistry({
           plugins: [this, ...extensions],
         });
+        this.ownApiServerPluginRegistry = pluginRegistry;
 
         if (!this.config.gid) {
           throw new Error("GatewayIdentity is not defined");
@@ -1248,33 +1269,17 @@ export class SATPGateway implements IPluginWebService, ICactusPlugin {
 
     await context.with(ctx, async () => {
       try {
-        if (!this.config.localRepository) {
-          this.logger.info(`${fnTag}: Local repository is not defined`);
-          this.logger.info(`${fnTag}: Using default local repository`);
-          this.config.localRepository = knexLocalInstance.default;
-        }
-        this.logger.info(`${fnTag}: Creating migration source`);
-        const migrationSource = await createMigrationSource();
-        this.logger.info(
-          `${fnTag}: Created migration source: ${JSON.stringify(migrationSource)}`,
-        );
-        let database: Knex | undefined;
-        try {
-          database = knex({
-            ...this.config.localRepository,
-            migrations: {
-              // This removes the problem with the migration source being in the file system
-              migrationSource: migrationSource,
-            },
-          });
+        const repositories = [
+          this.localRepository,
+          this.remoteRepository,
+          this.auditRepository,
+          this.oracleLogRepository,
+        ];
 
-          await database.migrate.latest();
-          await this.oracleLogRepository.database.migrate.latest();
-          await (
-            this.auditRepository as AuditEntryRepository
-          ).database.migrate.latest();
-        } finally {
-          await database?.destroy();
+        for (const repo of repositories) {
+          if (repo != null) {
+            await repo.migrate();
+          }
         }
       } catch (err) {
         span.setStatus({ code: SpanStatusCode.ERROR, message: String(err) });
@@ -1487,11 +1492,6 @@ export class SATPGateway implements IPluginWebService, ICactusPlugin {
         this.logger.debug(`Entering ${fnTag}`);
 
         this.logger.debug("Shutting down Gateway Application");
-        if (this.isShutdown) {
-          this.OApiServer = undefined; // without this, this will be a recursive loop, OAPI server will call shutdown on the gateway
-        }
-
-        this.isShutdown = true;
 
         try {
           this.logger.debug("Shutting down BLO");
@@ -1504,19 +1504,14 @@ export class SATPGateway implements IPluginWebService, ICactusPlugin {
 
         if (this.OApiServer) {
           this.logger.debug("Shutting down OpenAPI server");
-          await this.OApiServer?.shutdown();
+          this.deregisterSelfFromOwnApiServer();
+          await this.OApiServer.shutdown();
           this.logger.debug("OpenAPI server shut down");
-          await this.destroyRepositories();
-          return;
         }
 
         this.logger.debug("Shutting down Gateway Coordinator");
         await this.shutdownGOLServer();
-        this.logger.debug("Running shutdown hooks");
-        for (const hook of this.shutdownHooks) {
-          this.logger.debug(`Running shutdown hook: ${hook.name}`);
-          await hook.hook();
-        }
+        await this.runShutdownHooks();
 
         this.logger.debug("Oracle Manager shut down");
         await this.SATPCCManager?.getOracleManager().shutdown();
@@ -1527,8 +1522,6 @@ export class SATPGateway implements IPluginWebService, ICactusPlugin {
 
         this.logger.info(`Closed ${connectionsClosed} connections`);
         this.logger.info("Gateway Coordinator shut down");
-
-        await this.destroyRepositories();
 
         if (this.monitorService) {
           this.logger.debug("Shutting down monitor service");
@@ -1546,30 +1539,22 @@ export class SATPGateway implements IPluginWebService, ICactusPlugin {
     });
   }
 
-  private async destroyRepositories(): Promise<void> {
-    const fnTag = `${this.className}#destroyRepositories()`;
-    if (this.localRepository) {
-      this.logger.debug("Destroying local repository");
-      try {
-        await this.localRepository.destroy();
-      } catch (err) {
-        this.logger.error(
-          `${fnTag}: Error destroying local repository: ${err}`,
-        );
-      }
-      this.localRepository = undefined;
+  private async runShutdownHooks(): Promise<void> {
+    this.logger.debug("Running shutdown hooks");
+    for (const hook of this.shutdownHooks) {
+      this.logger.debug(`Running shutdown hook: ${hook.name}`);
+      await hook.hook();
     }
-    if (this.remoteRepository) {
-      this.logger.debug("Destroying remote repository");
-      try {
-        await this.remoteRepository.destroy();
-      } catch (err) {
-        this.logger.error(
-          `${fnTag}: Error destroying remote repository: ${err}`,
-        );
-      }
-      this.remoteRepository = undefined;
-    }
+  }
+
+  /**
+   * Prevents ApiServer#shutdown() from recursing back into this.shutdown():
+   * the gateway registers itself as a plugin of its own ApiServer (see
+   * getOrCreateHttpServer()) to install its endpoints, which would otherwise
+   * get its shutdown() called again by the ApiServer's plugin-shutdown loop.
+   */
+  private deregisterSelfFromOwnApiServer(): void {
+    this.ownApiServerPluginRegistry?.deleteByPackageName(this.getPackageName());
   }
 
   private async shutdownGOLServer(): Promise<void> {
@@ -1610,14 +1595,11 @@ export class SATPGateway implements IPluginWebService, ICactusPlugin {
         this.logger.debug(`Entering ${fnTag}`);
         this.logger.debug("Killing Gateway Application");
 
-        this.isShutdown = true;
-
         if (this.OApiServer) {
           this.logger.debug("Shutting down OpenAPI server");
-          await this.OApiServer?.shutdown();
+          this.deregisterSelfFromOwnApiServer();
+          await this.OApiServer.shutdown();
           this.logger.debug("OpenAPI server shut down");
-          await this.destroyRepositories();
-          return;
         }
 
         if (this.monitorService) {
@@ -1627,11 +1609,8 @@ export class SATPGateway implements IPluginWebService, ICactusPlugin {
         }
 
         this.logger.debug("Shutting down Gateway Coordinator");
-        this.logger.debug("Running shutdown hooks");
-        for (const hook of this.shutdownHooks) {
-          this.logger.debug(`Running shutdown hook: ${hook.name}`);
-          await hook.hook();
-        }
+        await this.shutdownGOLServer();
+        await this.runShutdownHooks();
 
         this.logger.debug("Oracle Manager shut down");
         await this.SATPCCManager?.getOracleManager().shutdown();
@@ -1643,7 +1622,6 @@ export class SATPGateway implements IPluginWebService, ICactusPlugin {
         this.logger.info(`Closed ${connectionsClosed} connections`);
         this.logger.info("Gateway Coordinator shut down");
 
-        await this.destroyRepositories();
         return;
       } catch (err) {
         span.setStatus({ code: SpanStatusCode.ERROR, message: String(err) });

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/gateway/gateway-init-startup.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/gateway/gateway-init-startup.test.ts
@@ -1,4 +1,7 @@
 import "jest-extended";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import {
   Containers,
   pruneDockerContainersIfGithubAction,
@@ -9,6 +12,7 @@ import {
 } from "@hyperledger-cacti/cactus-common";
 import { ApiServer } from "@hyperledger-cacti/cactus-cmd-api-server";
 import { ApiClient } from "@hyperledger-cacti/cactus-api-client";
+import knex from "knex";
 
 import {
   SATPGateway,
@@ -351,7 +355,141 @@ describe("SATPGateway startup", () => {
       // todo error in the test, something was not properly shutdown
       await gateway.shutdown();
     }
+
+    const gateway2 = await factory.create({
+      instanceId: "gateway-orchestrator-instance-id-2",
+      pluginRegistry: new PluginRegistry(),
+      gid: {
+        id: "mockID2",
+        name: "CustomGateway2",
+        version: [
+          {
+            Core: SATP_CORE_VERSION,
+            Architecture: SATP_ARCHITECTURE_VERSION,
+            Crash: SATP_CRASH_VERSION,
+          },
+        ],
+        proofID: "mockProofID11",
+        gatewayServerPort: serverPort,
+        gatewayClientPort: clientPort,
+        address: "http://localhost",
+      },
+      monitorService: monitorService,
+    });
+    await expect(gateway2.startup()).resolves.toBeUndefined();
+    await gateway2.shutdown();
   });
+
+  test("createDBRepository migrates all four databases", async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "satp-db-test-"));
+    const dbPaths = {
+      local: join(tmpDir, "local.sqlite3"),
+      remote: join(tmpDir, "remote.sqlite3"),
+      audit: join(tmpDir, "audit.sqlite3"),
+      oracle: join(tmpDir, "oracle.sqlite3"),
+    };
+
+    const sqliteConfig = (filename: string) => ({
+      client: "sqlite3",
+      connection: { filename },
+      useNullAsDefault: true,
+    });
+
+    const options: SATPGatewayConfig = {
+      instanceId: "gateway-db-migration-test",
+      pluginRegistry: new PluginRegistry(),
+      logLevel: logLevel,
+      gid: {
+        id: "mockID",
+        name: "DBMigrationGateway",
+        version: [
+          {
+            Core: SATP_CORE_VERSION,
+            Architecture: SATP_ARCHITECTURE_VERSION,
+            Crash: SATP_CRASH_VERSION,
+          },
+        ],
+        gatewayServerPort: 13020,
+        gatewayClientPort: 13021,
+        address: "http://localhost",
+      },
+      localRepository: sqliteConfig(dbPaths.local),
+      remoteRepository: sqliteConfig(dbPaths.remote),
+      auditRepository: sqliteConfig(dbPaths.audit),
+      oracleLogRepository: sqliteConfig(dbPaths.oracle),
+      monitorService: monitorService,
+    };
+
+    const gateway = await factory.create(options);
+    await gateway.startup();
+    await gateway.shutdown();
+
+    const expectedTables: Record<string, string> = {
+      [dbPaths.local]: "logs",
+      [dbPaths.remote]: "remote-logs",
+      [dbPaths.audit]: "audit_entries",
+      [dbPaths.oracle]: "oracle_logs",
+    };
+
+    for (const [filename, expectedTable] of Object.entries(expectedTables)) {
+      const db = knex({
+        client: "sqlite3",
+        connection: { filename },
+        useNullAsDefault: true,
+      });
+      try {
+        const hasTable = await db.schema.hasTable(expectedTable);
+        expect(hasTable).toBeTrue();
+      } finally {
+        await db.destroy();
+      }
+    }
+
+    rmSync(tmpDir, { recursive: true });
+  });
+
+  test("shutdown destroys all repositories even without startup", async () => {
+    const sqliteConfig = (filename: string) => ({
+      client: "sqlite3",
+      connection: { filename },
+      useNullAsDefault: true,
+    });
+
+    const options: SATPGatewayConfig = {
+      instanceId: "gateway-db-shutdown-test",
+      pluginRegistry: new PluginRegistry(),
+      logLevel: logLevel,
+      gid: {
+        id: "mockID",
+        name: "DBShutdownGateway",
+        version: [
+          {
+            Core: SATP_CORE_VERSION,
+            Architecture: SATP_ARCHITECTURE_VERSION,
+            Crash: SATP_CRASH_VERSION,
+          },
+        ],
+        gatewayServerPort: 13030,
+        gatewayClientPort: 13031,
+        address: "http://localhost",
+      },
+      localRepository: sqliteConfig(":memory:"),
+      remoteRepository: sqliteConfig(":memory:"),
+      auditRepository: sqliteConfig(":memory:"),
+      oracleLogRepository: sqliteConfig(":memory:"),
+      monitorService: monitorService,
+    };
+
+    const gateway = await factory.create(options);
+
+    await gateway.shutdown();
+
+    await expect(gateway.localRepository!.migrate()).rejects.toThrow();
+    await expect(gateway.remoteRepository!.migrate()).rejects.toThrow();
+    await expect(gateway.auditRepository.migrate()).rejects.toThrow();
+    await expect(gateway.oracleLogRepository.migrate()).rejects.toThrow();
+  });
+
   test("Gateway launches without database config", async () => {
     const [serverPort, clientPort] = await getFreePorts(2);
     const options: SATPGatewayConfig = {


### PR DESCRIPTION
The CLI only forwarded localRepository and remoteRepository to SATPGatewayConfig, leaving auditRepository and oracleLogRepository to fall back to a random UUID-named SQLite file. Those databases were never migrated, causing the gateway to crash on the first write to the audit or oracle log tables.

- Validate and pass auditRepository and oracleLogRepository from the config JSON in the CLI, consistent with how local/remote repos are already handled
- Extend createDBRepository() to run migrate.latest() across all four configured repositories instead of localRepository only
- Add integration test asserting that startup() creates the expected tables (logs, remote-logs, audit_entries, oracle_logs) in all four databases
