### PR TITLE
fix(cmd-api-server): deprecate cockpitWwwRoot default path

### DIFF
--- a/examples/cactus-example-carbon-accounting-backend/example-config.json
+++ b/examples/cactus-example-carbon-accounting-backend/example-config.json
@@ -16,7 +16,7 @@
     "apiTlsClientCaPem": "-",
     "cockpitHost": "127.0.0.1",
     "cockpitPort": 3000,
-    "cockpitWwwRoot": "packages/cactus-cmd-api-server/node_modules/@hyperledger-cacti/cactus-cockpit/www/",
+    "cockpitWwwRoot": "",
     "cockpitCorsDomainCsv": "",
     "cockpitMtlsEnabled": false,
     "cockpitTlsEnabled": true,

--- a/packages/cactus-cmd-api-server/src/main/typescript/config/config-service.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/config/config-service.ts
@@ -260,12 +260,11 @@ export class ConfigService {
         default: 3000,
       },
       cockpitWwwRoot: {
-        doc: "The file-system path pointing to the static files of web application served as the cockpit by the API server.",
+        doc: "The file-system path pointing to the static files of web application served as the cockpit by the API server. NOTE: The @hyperledger/cactus-cockpit package has been removed from this repository. This configuration option is deprecated and its default value is now an empty string. If you still use a custom cockpit UI, provide a valid path via this setting or the COCKPIT_WWW_ROOT environment variable.",
         format: "*",
         env: "COCKPIT_WWW_ROOT",
         arg: "cockpit-www-root",
-        default:
-          "packages/cactus-cmd-api-server/node_modules/@hyperledger-cacti/cactus-cockpit/www/",
+        default: "",
       },
       cockpitCorsDomainCsv: {
         doc:


### PR DESCRIPTION
fix(cmd-api-server): deprecate cockpitWwwRoot default path

Update cockpitWwwRoot default value to an empty string since the @hyperledger/cactus-cockpit package
has been removed. This prevents the config from pointing to a non-existent installation path.
This PR supersedes and replaces #4146.

Fixes #4108

Co-authored-by: sputnik-mac <sputnik.mac.001@gmail.com>
Signed-off-by: Parth Singh <posiedon.1721@gmail.com>
