### PR TITLE
ci: set YARN_NM_MODE to classic

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -75,7 +75,10 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "echo \"source /usr/share/bash-completion/completions/git\" >> ~/.bashrc"
+	"postCreateCommand": "echo \"source /usr/share/bash-completion/completions/git\" >> ~/.bashrc",
+	"remoteEnv": {
+    	"YARN_NM_MODE": "classic"
+	}
 
 	// Configure tool-specific properties.
 	// "customizations": {},


### PR DESCRIPTION
### Summary
This PR fixes a developer environment issue where the devcontainer fails to properly resolve dependencies upon a fresh rebuild. 

By explicitly enforcing `"YARN_NM_MODE": "classic"` in the `remoteEnv` configuration of `.devcontainer.json`, both `yarn install` and `yarn run configure` now execute successfully without node module resolution errors.

### Context & The Error
When attempting to rebuild the dev container from scratch, contributors (or anyone clearing their cache) can encounter module resolution failures during the dependency setup phase. 

This occurs because newer Yarn environments within the container can default to stricter resolution strategies (like Plug'n'Play / PnP). Because this monorepo relies on the traditional `node_modules` hoisting strategy, this mismatch causes the build scripts to fail. Setting the mode explicitly to `classic` forces Yarn to use standard resolution, immediately stabilizing the setup process for everyone.

### Detailed Error Report & Investigation
I flagged this issue during my daily progress tracking and was the mentors asked to open a PR regardind the fix. For full terminal logs and the step-by-step debugging process, please see my report here: 
👉 **[Link to my HackMD Report](https://hackmd.io/@ParthSinghPS/B1KGQP6bfg#Day4-18june)**

### Testing Performed
- [x] Rebuilt the dev container from scratch (`Rebuild without cache`).
- [x] Verified `yarn install` completes successfully.
- [x] Verified `yarn run configure` executes with no errors.