### PR TITLE
feat(connector-fabric): add CertDatastore.has() and .delete() methods

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/identity/internal/cert-datastore.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/identity/internal/cert-datastore.ts
@@ -32,6 +32,13 @@ export class CertDatastore {
     await keychain.set(keychainRef, JSON.stringify(iData));
   }
 
-  // TODO has
-  // TODO delete
+  async has(keychainId: string, keychainRef: string): Promise<boolean> {
+    const keychain = this.pluginRegistry.findOneByKeychainId(keychainId);
+    return await keychain.has(keychainRef);
+  }
+
+  async delete(keychainId: string, keychainRef: string): Promise<void> {
+    const keychain = this.pluginRegistry.findOneByKeychainId(keychainId);
+    await keychain.delete(keychainRef);
+  }
 }

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/unit/cert-datastore.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/unit/cert-datastore.test.ts
@@ -1,0 +1,66 @@
+import "jest-extended";
+import {
+  CertDatastore,
+  IIdentityData,
+} from "../../../main/typescript/identity/internal/cert-datastore";
+import { PluginRegistry } from "@hyperledger-cacti/cactus-core";
+import { PluginKeychainMemory } from "@hyperledger-cacti/cactus-plugin-keychain-memory";
+import { FabricSigningCredentialType } from "../../../main/typescript/generated/openapi/typescript-axios/api";
+import { v4 as uuidv4 } from "uuid";
+
+describe("CertDatastore unit tests", () => {
+  let keychainPlugin: PluginKeychainMemory;
+  let pluginRegistry: PluginRegistry;
+  let datastore: CertDatastore;
+  const keychainId = uuidv4();
+
+  const testIdentityData: IIdentityData = {
+    type: FabricSigningCredentialType.X509,
+    credentials: {
+      certificate: "fake-cert",
+      privateKey: "fake-key",
+    },
+    mspId: "Org1MSP",
+  };
+
+  beforeEach(() => {
+    keychainPlugin = new PluginKeychainMemory({
+      instanceId: uuidv4(),
+      keychainId: keychainId,
+      logLevel: "WARN",
+    });
+
+    pluginRegistry = new PluginRegistry({ plugins: [keychainPlugin] });
+    datastore = new CertDatastore(pluginRegistry);
+  });
+
+  test("get() retrieves and parses identity data", async () => {
+    await keychainPlugin.set("keychain-ref", JSON.stringify(testIdentityData));
+    const result = await datastore.get(keychainId, "keychain-ref");
+    expect(result).toEqual(testIdentityData);
+  });
+
+  test("put() serializes and saves identity data", async () => {
+    await datastore.put(keychainId, "keychain-ref", testIdentityData);
+    const stored = await keychainPlugin.get("keychain-ref");
+    expect(stored).toBe(JSON.stringify(testIdentityData));
+  });
+
+  test("has() checks existence of a key in keychain", async () => {
+    await keychainPlugin.set("keychain-ref", JSON.stringify(testIdentityData));
+    const exists = await datastore.has(keychainId, "keychain-ref");
+    expect(exists).toBe(true);
+  });
+
+  test("has() returns false for non-existent key", async () => {
+    const exists = await datastore.has(keychainId, "non-existent-key");
+    expect(exists).toBe(false);
+  });
+
+  test("delete() removes a key from keychain", async () => {
+    await keychainPlugin.set("keychain-ref", JSON.stringify(testIdentityData));
+    expect(await keychainPlugin.has("keychain-ref")).toBe(true);
+    await datastore.delete(keychainId, "keychain-ref");
+    expect(await keychainPlugin.has("keychain-ref")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Implemented `CertDatastore.has()` and `CertDatastore.delete()` methods in the Fabric connector datastore.
- Resolves unimplemented TODO stubs in `CertDatastore` to allow checking and deleting certificates in keychains.

## Changes
| File | Fix |
|------|-----|
| `packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/identity/internal/cert-datastore.ts` | Implemented `has()` and `delete()` stubs by looking up the keychain via `PluginRegistry` and delegating the operations. |
| `packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/unit/cert-datastore.test.ts` | Created new unit tests verifying the correctness of `get()`, `put()`, `has()`, and `delete()` methods. |

---

## Pull Request Requirements
- [x] Rebased onto upstream/main and squashed into single commit
- [x] Signed-off-by present (DCO, human only)
- [x] Conventional Commits format
- [x] Assisted-by tag (if AI was used)


