### PR TITLE
docs: update formatting and link references in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We are conducting an initiative called "Cacti cleanup". The initiative focuses o
 5. Enhance onboarding: Making it easier for new contributors to get started
 6. Optimize the CI/CD pipelines by reducing runtime and costs
 
-Please refer to [the overview of this initiative (+ the SATP-Hermes initiative)](https://www.youtube.com/watch?v=pN1m0vgV7bY), and the [public Github project board](https://github.com/orgs/hyperledger-cacti/projects/2). Please contribute and vote on the different aspects of the initiative [on the Discord threads](https://discord.com/channels/905194001349627914/908379338716631050/1428405972992266343).
+Please refer to [the overview of this initiative (+ the SATP-Hermes initiative)](https://www.youtube.com/watch?v=pN1m0vgV7bY), and the [public GitHub project board](https://github.com/orgs/hyperledger-cacti/projects/2). Please contribute and vote on the different aspects of the initiative [on the Discord threads](https://discord.com/channels/905194001349627914/908379338716631050/1428405972992266343).
 
 ## Scope of Project
 
@@ -37,7 +37,7 @@ As a fusion of two earlier systems (Cactus and Weaver) that have similar philoso
 
 The current Cacti code base contains the legacy Cactus and Weaver source code in aggregated form with their original folder structures intact. But the packages built from the two sections of code are unified and released under a common `cacti` namespace, and the CI/CD pipelines for testing and releases are also integrated under a common set of GitHub Actions. A _deeper_ merge and integration of source code is part of our roadmap, and will be carried out over a longer time period, but the current setup of code and release packages makes it easy for new users to navigate Cacti and for legacy users to carry out seamless upgrades.
 
-(Reference for legacy users: Cactus source code lies here (i.e., the root folder), excluding the `weaver` folder. Weaver source code lies within the [weaver](./weaver/) folder.
+For legacy users: Cactus source code is in the repository root (excluding the `weaver` folder), and Weaver source code is in the `weaver` directory.
 
 ## Documentation
 
@@ -62,7 +62,7 @@ deny list" to "white list and black list".
 writing inclusive documentation might not look like a huge improvement, it's a
 first step in the right direction.
 - We suggest to refer to
-[Microsoft bias free writing guidelines](https://docs.microsoft.com/en-us/style-guide/bias-free-communication)
+[Microsoft bias free writing guidelines](https://learn.microsoft.com/en-us/style-guide/bias-free-communication)
 and
 [Google inclusive doc writing guide](https://developers.google.com/style/inclusive-documentation)
 as starting points.


### PR DESCRIPTION
This PR supersedes and replaces #4248 to resolve commit squashing
requirements and address maintainer feedback.

As discussed in the original PR's review by @AndreAugusto11, the
'Getting Started for Contributors' section has been removed to avoid
duplicating information already present in BUILD.md and CONTRIBUTING.md.

The remaining cleanups from the original author have been retained:
- Fixed GitHub capitalization in the project board link.
- Simplified the legacy source code reference sentence for better
  readability.
- Updated the outdated Microsoft bias-free writing guidelines link.