### PR TITLE
ci(satp-hermes): stop publishing to npmjs; GPR-only + idempotent

### DIFF
--- a/.github/workflows/satp-hermes-publish-npmjs-gateway-sdk.yaml
+++ b/.github/workflows/satp-hermes-publish-npmjs-gateway-sdk.yaml
@@ -4,13 +4,15 @@ name: SATP Hermes Gateway SDK - NPM Publish
 # NPM + GHCR DOCKER PUBLISHING WORKFLOW
 # =============================================================================
 #
-# This workflow publishes the SATP Hermes Gateway SDK to npmjs.org and GitHub
-# Package Registry (GPR) with support for both development and production releases.
+# This workflow publishes the SATP Hermes Gateway SDK to the GitHub Package
+# Registry (GPR) for both development and production builds. npmjs.org
+# publishing is owned by the repo-wide publish-npm.yaml (the single npm OIDC
+# trusted publisher), so it is intentionally not done here.
 #
 # PACKAGE CONFIGURATION:
 #   Organization: @hyperledger-cacti
 #   Package: @hyperledger-cacti/cactus-plugin-satp-hermes
-#   Registry: https://registry.npmjs.org/
+#   Registry: https://npm.pkg.github.com/ (GitHub Packages)
 #
 # VERSION STRATEGY:
 #   Version Source: package.json version (0.0.3-beta)
@@ -47,9 +49,10 @@ name: SATP Hermes Gateway SDK - NPM Publish
 #     - Examples (dist/lib/examples/)
 #     - Build configs, dev scripts
 #
-# REQUIRED SECRETS:
-#   NPM_TOKEN: NPM authentication token with publish permissions for @hyperledger-cacti
-#   GITHUB_TOKEN: Auto-provided by GitHub Actions for GPR publishing
+# AUTH:
+#   GPR:       GITHUB_TOKEN, auto-provided by GitHub Actions.
+#   npmjs.org: not published here — handled by publish-npm.yaml via npm OIDC
+#              trusted publishing (no NPM_TOKEN anywhere).
 #
 # USAGE:
 #   Development Release (Automatic):
@@ -126,7 +129,6 @@ on:
 permissions:
   contents: read
   packages: write
-  id-token: write
 
 env:
   NPM_PACKAGE_NAME: '@hyperledger-cacti/cactus-plugin-satp-hermes'
@@ -270,62 +272,14 @@ jobs:
           retention-days: 1
 
   # =============================================================================
-  # STAGE: PUBLISH NPM PACKAGES
+  # STAGE: PUBLISH NPM PACKAGE
   # =============================================================================
-  # The following two jobs run in parallel on push events to release branches
-  # for faster deployment.
-
-  # Stage: Publish NPM package to npmjs.org
-  publish-satp-hermes-npm-package-npmjs:
-    needs: [build-satp-hermes-npm-package, set-npm-tags]
-    if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/satp-dev' || github.ref == 'refs/heads/satp-stg' || startsWith(github.ref, 'refs/tags/'))) || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    # Production publishes run under the `prod` environment so maintainers can
-    # gate them with required reviewers / scoped secrets; dev builds use none.
-    environment: ${{ needs.set-npm-tags.outputs.is_release == 'true' && 'prod' || '' }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
-        with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org/'
-          scope: '@hyperledger-cacti'
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
-        with:
-          name: satp-hermes-build-artifacts
-          path: packages/cactus-plugin-satp-hermes/
-
-      - name: Set package version
-        env:
-          NEW_VERSION: ${{ needs.set-npm-tags.outputs.tag_version }}
-        run: |
-          node -e "
-            const fs = require('fs');
-            const pkgPath = 'packages/cactus-plugin-satp-hermes/package.json';
-            const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-            pkg.version = process.env.NEW_VERSION;
-            fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\\n');
-            console.log('Set version to:', pkg.version);
-          "
-
-      - name: Verify package contents
-        run: |
-          cd packages/cactus-plugin-satp-hermes
-          echo "Package contents to be published:"
-          npm pack --dry-run
-
-      - name: Publish to npmjs.org
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: ${{ needs.set-npm-tags.outputs.is_release == 'true' }}
-        run: |
-          cd packages/cactus-plugin-satp-hermes
-          npm whoami
-          npm publish --tag "${{ needs.set-npm-tags.outputs.dist_tag }}" --access public
+  # npmjs.org publishing for this package is owned by the repo-wide
+  # publish-npm.yaml, which is the single npm OIDC trusted publisher and
+  # publishes every non-private package (this one included) on `v*` release
+  # tags. npm allows only one trusted publisher per package and matches it
+  # against the top-level workflow, so this pipeline does NOT publish to
+  # npmjs.org; it only publishes dev/release builds to GitHub Packages.
 
   # Stage: Publish NPM package to GitHub Package Registry
   publish-satp-hermes-npm-package-ghcr:
@@ -367,7 +321,17 @@ jobs:
       - name: Publish to GitHub Package Registry
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PKG_NAME: ${{ needs.set-npm-tags.outputs.npm_package_name }}
+          PKG_VERSION: ${{ needs.set-npm-tags.outputs.tag_version }}
+          DIST_TAG: ${{ needs.set-npm-tags.outputs.dist_tag }}
+          REGISTRY: https://npm.pkg.github.com/
         run: |
           cd packages/cactus-plugin-satp-hermes
-          npm whoami --registry=https://npm.pkg.github.com/
-          npm publish --tag "${{ needs.set-npm-tags.outputs.dist_tag }}" --access public --registry=https://npm.pkg.github.com/
+          # Idempotency guard: skip when this exact version already exists
+          # (a re-run of the same commit republishes an identical dev version).
+          if npm view "${PKG_NAME}@${PKG_VERSION}" version --registry="${REGISTRY}" >/dev/null 2>&1; then
+            echo "::notice::${PKG_NAME}@${PKG_VERSION} already on GitHub Packages; skipping publish."
+            exit 0
+          fi
+          npm whoami --registry="${REGISTRY}"
+          npm publish --tag "${DIST_TAG}" --access public --registry="${REGISTRY}"

--- a/.github/workflows/satp-hermes-release-pipeline.yaml
+++ b/.github/workflows/satp-hermes-release-pipeline.yaml
@@ -29,10 +29,11 @@ on:
   workflow_dispatch:
 
 # Least privilege for the pipeline; child workflows request their own.
+# npmjs publishing (and its OIDC id-token) is owned by publish-npm.yaml, not
+# this pipeline, so no id-token permission is needed here.
 permissions:
   contents: write # create the GitHub release
   packages: write # GHCR + GitHub Package Registry
-  id-token: write # npm publish provenance
 
 concurrency:
   group: satp-hermes-release-${{ github.ref }}
@@ -112,7 +113,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write
     uses: ./.github/workflows/satp-hermes-publish-npmjs-gateway-sdk.yaml
     secrets: inherit
 


### PR DESCRIPTION
The satp npm workflow published to npmjs.org with a legacy NPM_TOKEN that now 401s. npm moved to OIDC trusted publishing, but a package may have only one trusted publisher and npm matches it against the top-level workflow, not a reusable child. The repo-wide publish-npm.yaml already is that single trusted publisher and publishes every non-private package (satp included) on v* tags.

So this pipeline can neither reuse nor duplicate that publisher for npmjs. Remove the npmjs publish job entirely: npmjs is owned by publish-npm.yaml on releases, and this workflow now publishes dev/release builds only to the GitHub Package Registry (GITHUB_TOKEN). No npm tokens anywhere.

Also add an idempotency guard to the GitHub Packages publish: dev versions are keyed on the short SHA, so re-running the pipeline on an unchanged commit republishes an identical version and the registry 409s. Skip when the exact version already exists.

Drop the now-unused id-token: write from this workflow and the caller pipeline.

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficiently and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when, and why.
- [x] Have git sign-off at the end of the commit message (`Signed-off-by: Name <email>`) to certify the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). Use the `-s` flag with `git commit`. See [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information. **AI agents must not add Signed-off-by tags** — only the human submitter may certify the DCO (see [AI Guidelines §7](./AI_GUIDELINES.md)).
- [x] Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) specification for commit linting.
- [x] If AI tools were used, include an `Assisted-by` tag in the commit message per the [AI Guidelines §2.2](./AI_GUIDELINES.md#22-disclosure) (e.g., `Assisted-by: GitHub-Copilot:claude-opus-4`). All AI-generated code must be human-reviewed before submission.
- [x] Read and followed the [Pull Request Guidelines](../PULL.md).
> **Note:** PRs that do not satisfy the requirements above will fail the
> DCO checker and/or the commit lint CI checks and cannot be merged.

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.
