### PR TITLE
chore: apply local lint only to changed file

### DIFF
--- a/.husky/pre-push.d/10-lint.sh
+++ b/.husky/pre-push.d/10-lint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Full project lint (prettier + eslint + cspell). Mirrors CI 'yarn lint'.
+# Lint only files changed in local (unpushed) commits. Mirrors CI 'yarn lint'.
 # Skip with: SKIP_LINT=1 git push ...
 
 set -e
@@ -9,4 +9,23 @@ if [ "${SKIP_LINT:-0}" = "1" ]; then
 	exit 0
 fi
 
-yarn lint
+# Only lint files currently staged in the index
+CHANGED=$(git diff --cached --name-only --diff-filter=d \
+	| grep -E '\.(ts|js)$|/openapi\.json$' || true)
+
+if [ -z "$CHANGED" ]; then
+	echo "  No lintable files changed, skipping lint."
+	exit 0
+fi
+
+COUNT=$(printf '%s\n' "$CHANGED" | grep -c '.')
+echo "  Linting $COUNT changed file(s)..."
+
+printf '%s\n' "$CHANGED" | xargs yarn lint:files
+printf '%s\n' "$CHANGED" | xargs yarn format:files
+
+# CSpell — only src files matching original "*/*/src/**/*.{js,ts}" scope
+SPELL=$(printf '%s\n' "$CHANGED" | grep -E '^[^/]+/[^/]+/src/.*\.(ts|js)$' || true)
+if [ -n "$SPELL" ]; then
+	printf '%s\n' "$SPELL" | xargs yarn cspell lint --no-progress
+fi

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "purge-build-cache": "del-cli .build-cache/*",
     "clean": "yarn purge-build-cache && del-cli \"./{packages,examples,extensions}/cactus-*/{dist,.nyc_output,src/main/kotlin/generated/openapi/kotlin-client/*,src/main/proto/generated/*,src/main/typescript/generated/openapi/typescript-axios/*,src/main-server/kotlin/gen/kotlin-spring/src/**/{model,api}/*}\" \"!**/.openapi-generator-ignore\"",
     "lint": "run-s format:eslint format:prettier spellcheck",
+    "lint:files": "eslint --quiet --fix",
+    "format:files": "prettier --write --config .prettierrc.js",
     "lint:actions": "sh ./tools/lint-actions.sh",
     "check:circular-deps": "lerna exec --no-bail -- madge --circular --extensions ts ./src/main/typescript/",
     "format:eslint": "eslint '**/*.{js,ts}' --quiet --fix",


### PR DESCRIPTION
Only runs linter on changed files, locally (CI still runs all)

**A Must Read for Beginners**
Please read [the contribution guides](..CONTRIBUTING.md) prior to your first contribution.
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.

**Pull Request Requirements**
- [x] Read and followed the [Pull Request Guidelines](../PULL.md).
- [x] If AI tools were used, include an `Assisted-by` tag in the commit message per the [AI Guidelines §2.2](./AI_GUIDELINES.md#22-disclosure) (e.g., `Assisted-by: GitHub-Copilot:claude-opus-4`). All AI-generated code must be human-reviewed before submission.
