### PR TITLE
ci: fix go version in copm test action to 1.26.4

### DIFF
--- a/.github/actions/copm_test/action.yaml
+++ b/.github/actions/copm_test/action.yaml
@@ -38,7 +38,7 @@ runs:
       working-directory: weaver/core/relay
     - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 #v6.5.0
       with:
-        go-version: '1.20.14'
+        go-version: '1.26.4'
     - name: Use Protoc 3.15
       shell: bash
       run: |


### PR DESCRIPTION
Supersedes #4096.

The original was closed because it contained a merge commit
and the npm->yarn changes have already been merged to main.
This PR extracts only the remaining change: updating the Go version
in .github/actions/copm_test/action.yaml from 1.20.14 to 1.26.4,
as requested by @sandeepnRES.