### PR TITLE
ci: add least-privilege GITHUB_TOKEN permissions to workflows

### DIFF
--- a/.github/workflows/.dast-nuclei-cacti-satp.yaml
+++ b/.github/workflows/.dast-nuclei-cacti-satp.yaml
@@ -64,6 +64,8 @@ on:
           Newline-separated list of URLs to scan.
           When omitted, the built-in default set covering all Cacti API server
           endpoints (api-server, Fabric connector, Besu connector) is used.
+permissions:
+  contents: read
 
 jobs:
   nuclei-scan:

--- a/.github/workflows/.dast-nuclei-cmd-api-server.yaml
+++ b/.github/workflows/.dast-nuclei-cmd-api-server.yaml
@@ -9,6 +9,8 @@ on:
 
   pull_request:
     branches: [main, dev]
+permissions:
+  contents: read
 
 jobs:
   nuclei-scan:

--- a/.github/workflows/.sast-nuclei.yaml
+++ b/.github/workflows/.sast-nuclei.yaml
@@ -28,6 +28,8 @@ on:
           nuclei-templates release tag to clone (e.g. v10.1.4).
           Leave empty to use the latest commit on the default branch.
           Verify available tags at github.com/projectdiscovery/nuclei-templates/releases
+permissions:
+  contents: read
 
 jobs:
   nuclei-scan:

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,6 +1,8 @@
 name: Lint GitHub Actions workflows
 on:
   workflow_call:
+permissions:
+  contents: read
 
 jobs:
   Lint_GitHub_Actions:

--- a/.github/workflows/besu-all-in-one-publish.yaml
+++ b/.github/workflows/besu-all-in-one-publish.yaml
@@ -12,6 +12,8 @@ concurrency:
 
 env:
   IMAGE_NAME: besu-all-in-one
+permissions:
+  contents: read
 
 jobs:
   # Push image to GitHub Packages.

--- a/.github/workflows/cacti-dev-container-vscode-publish.yaml
+++ b/.github/workflows/cacti-dev-container-vscode-publish.yaml
@@ -13,6 +13,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 
 jobs:
   # Push image to GitHub Packages.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,12 +22,10 @@ env:
 # `contents: write` is required by `cpl-connector-besu` (connector-packages)
 # and `cactus-cmd-api-server` (core-packages) because they push benchmark
 # results to the gh-pages branch on main and write commit-comment alerts.
-# `actions: read` is used by the benchmark cache restore.
-# `checks: write` is used by dorny/test-reporter inside jest-runner.
+# Least-privilege default; jobs that call reusable workflows needing more
+# declare their own permissions block (which caps the called workflow).
 permissions:
-  contents: write
-  actions: read
-  checks: write
+  contents: read
 
 jobs:
   env-setup:
@@ -61,6 +59,11 @@ jobs:
       
   packages-workflow:
     needs: [checks-and-build, env-setup]
+    # core-packages/connector-packages push benchmark data to gh-pages on main.
+    permissions:
+      contents: write
+      actions: read
+      checks: write
     uses: ./.github/workflows/packages-workflow.yaml
     with:
       affected-packages: ${{ needs.checks-and-build.outputs.affected_packages }}
@@ -70,6 +73,11 @@ jobs:
 
   examples-workflow:
     needs: [checks-and-build, env-setup]
+    # dorny/test-reporter (checks: write) + benchmark cache restore (actions: read).
+    permissions:
+      contents: read
+      actions: read
+      checks: write
     uses: ./.github/workflows/examples-workflow.yaml
     with:
       affected-packages: ${{ needs.checks-and-build.outputs.affected_packages }}

--- a/.github/workflows/ci_weaver.yaml
+++ b/.github/workflows/ci_weaver.yaml
@@ -14,6 +14,9 @@ on:
 env:
   RUN_ALL: "${{github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}"
 
+permissions:
+  contents: read
+
 jobs:
 
   fabric-fabric-satp:

--- a/.github/workflows/cmd-api-server-publish.yaml
+++ b/.github/workflows/cmd-api-server-publish.yaml
@@ -13,6 +13,8 @@ concurrency:
 env:
   NODEJS_VERSION: v20.20.0
   IMAGE_NAME: cactus-cmd-api-server
+permissions:
+  contents: read
 
 jobs:
   # Push image to GitHub Packages.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 
 jobs:
   analyze:

--- a/.github/workflows/connector-corda-server-publish.yaml
+++ b/.github/workflows/connector-corda-server-publish.yaml
@@ -12,6 +12,8 @@ concurrency:
 
 env:
   IMAGE_NAME: cactus-connector-corda-server
+permissions:
+  contents: read
 
 jobs:
   # Push image to GitHub Packages.

--- a/.github/workflows/connector-fabric-cli-publish-dev.yaml
+++ b/.github/workflows/connector-fabric-cli-publish-dev.yaml
@@ -16,9 +16,15 @@ concurrency:
 env:
   IMAGE_NAME: cactus-connector-fabric-cli
 
-jobs:      
+permissions:
+  contents: read
+
+jobs:
   pr-build-container:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write # push image to GHCR
     env:
       DOCKER_BUILDKIT: 1
       DOCKERFILE_PATH: ./packages/cactus-plugin-ledger-connector-fabric/cli.Dockerfile

--- a/.github/workflows/connector-fabric-cli-publish.yaml
+++ b/.github/workflows/connector-fabric-cli-publish.yaml
@@ -12,6 +12,8 @@ concurrency:
 
 env:
   IMAGE_NAME: cactus-connector-fabric-cli
+permissions:
+  contents: read
 
 jobs:
   # Push image to GitHub Packages.

--- a/.github/workflows/coverage_ts.yaml
+++ b/.github/workflows/coverage_ts.yaml
@@ -9,7 +9,10 @@
          - Cactus_CI
         types:
           - completed
-    
+
+    permissions:
+      contents: read
+
     jobs:
       generate_coverage_report:
         runs-on: ubuntu-22.04

--- a/.github/workflows/daml-all-in-one-publish.yaml
+++ b/.github/workflows/daml-all-in-one-publish.yaml
@@ -12,6 +12,8 @@ concurrency:
 
 env:
   IMAGE_NAME: cacti-daml-all-in-one
+permissions:
+  contents: read
 
 jobs:
   # Push image to GitHub Packages.

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -22,6 +22,8 @@ env:
   NODEJS_VERSION: v20.20.0
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  contents: read
 
 jobs:
   deploy-docs:

--- a/.github/workflows/fabric2-all-in-one-publish.yaml
+++ b/.github/workflows/fabric2-all-in-one-publish.yaml
@@ -12,6 +12,8 @@ concurrency:
 
 env:
   IMAGE_NAME: cactus-fabric2-all-in-one
+permissions:
+  contents: read
 
 jobs:
   # Push image to GitHub Packages.

--- a/.github/workflows/geth-all-in-one-publish.yaml
+++ b/.github/workflows/geth-all-in-one-publish.yaml
@@ -12,6 +12,8 @@ concurrency:
 
 env:
   IMAGE_NAME: cactus-geth-all-in-one
+permissions:
+  contents: read
 
 jobs:
   # Push image to GitHub Packages.

--- a/.github/workflows/gg-shield-action.yaml
+++ b/.github/workflows/gg-shield-action.yaml
@@ -12,6 +12,8 @@ on:
   pull_request:
     branches:
       - main
+permissions:
+  contents: read
 
 jobs:
   scanning:

--- a/.github/workflows/ghpkg-all-kotlin-api-clients-publish.yaml
+++ b/.github/workflows/ghpkg-all-kotlin-api-clients-publish.yaml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-22.04

--- a/.github/workflows/htlc-packages-workflow.yaml
+++ b/.github/workflows/htlc-packages-workflow.yaml
@@ -18,6 +18,8 @@ on:
 concurrency:
   group: htlc-packages-workflows-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 
 jobs:
   cp-htlc-coordinator-besu:

--- a/.github/workflows/packages-workflow.yaml
+++ b/.github/workflows/packages-workflow.yaml
@@ -22,16 +22,18 @@ concurrency:
   group: packages-workflows-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Dispatcher only; pass-through cap for the package workflows below.
-# Must include `contents: write` because connector-packages and core-packages
-# each have one benchmark job that pushes to gh-pages on main.
+# Dispatcher only; least-privilege default. Each job below sets its own cap
+# for the reusable workflow it calls.
 permissions:
-  contents: write
-  actions: read
-  checks: write
+  contents: read
 
 jobs:
   core-packages:
+    # cactus-cmd-api-server pushes benchmark data to gh-pages on main.
+    permissions:
+      contents: write
+      actions: read
+      checks: write
     uses: ./.github/workflows/core-packages-workflow.yaml
     with:
       node_version: ${{ inputs.node_version }}
@@ -40,6 +42,11 @@ jobs:
       affected-packages: ${{ inputs.affected-packages }}
 
   connector-packages:
+    # cpl-connector-besu pushes benchmark data to gh-pages on main.
+    permissions:
+      contents: write
+      actions: read
+      checks: write
     uses: ./.github/workflows/connector-packages-workflow.yaml
     with:
       node_version: ${{ inputs.node_version }}
@@ -48,6 +55,11 @@ jobs:
       affected-packages: ${{ inputs.affected-packages }}
 
   keychain-packages:
+    # dorny/test-reporter (checks: write) + benchmark cache restore (actions: read).
+    permissions:
+      contents: read
+      actions: read
+      checks: write
     uses: ./.github/workflows/keychain-packages-workflow.yaml
     with:
       node_version: ${{ inputs.node_version }}
@@ -56,15 +68,25 @@ jobs:
       affected-packages: ${{ inputs.affected-packages }}
 
   other-packages:
+    # dorny/test-reporter (checks: write) + benchmark cache restore (actions: read).
+    permissions:
+      contents: read
+      actions: read
+      checks: write
     uses: ./.github/workflows/other-packages-workflow.yaml
     with:
       node_version: ${{ inputs.node_version }}
       run_code_coverage:  ${{ inputs.run_code_coverage }}
       run_trivy_scan:  ${{ inputs.run_trivy_scan }}
       affected-packages: ${{ inputs.affected-packages }}
-      
+
   satp-hermes-workflow:
     if: contains(fromJson(inputs.affected-packages), 'packages/cactus-plugin-satp-hermes')
+    # dorny/test-reporter (checks: write) + benchmark cache restore (actions: read).
+    permissions:
+      contents: read
+      actions: read
+      checks: write
     uses: ./.github/workflows/satp-hermes-workflow.yaml
     with:
       node_version: ${{ inputs.node_version }}

--- a/.github/workflows/pr-structural-checks.yaml
+++ b/.github/workflows/pr-structural-checks.yaml
@@ -19,6 +19,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 
 jobs:
   commitlint:

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -17,6 +17,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/satp-hermes-build.yaml
+++ b/.github/workflows/satp-hermes-build.yaml
@@ -6,6 +6,8 @@ on:
       build_success:
         description: "Whether the build was successful"
         value: ${{ jobs.build-satp.outputs.build_success }}
+permissions:
+  contents: read
 
 jobs:
   build-satp:

--- a/.github/workflows/satp-hermes-codegen.yaml
+++ b/.github/workflows/satp-hermes-codegen.yaml
@@ -6,6 +6,8 @@ on:
       codegen_success:
         description: "Whether the code generation was successful"
         value: ${{ jobs.codegen-satp.outputs.codegen_success }}
+permissions:
+  contents: read
 
 jobs:
   codegen-satp: 

--- a/.github/workflows/satp-hermes-lint.yaml
+++ b/.github/workflows/satp-hermes-lint.yaml
@@ -6,6 +6,8 @@ on:
       lint_success:
         description: "Whether the lint was successful"
         value: ${{ jobs.lint-satp.outputs.lint_success }}
+permissions:
+  contents: read
 
 jobs:
   lint-satp:

--- a/.github/workflows/satp-hermes-manual-release.yaml
+++ b/.github/workflows/satp-hermes-manual-release.yaml
@@ -47,6 +47,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   # =============================================================================
   # STAGE 8: CREATE GITHUB RELEASE (MANUAL RELEASE MODE ONLY)
@@ -57,6 +60,8 @@ jobs:
   create-github-release:
     if: ${{ inputs.is_release }}
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write # create the GitHub release
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
         with:

--- a/.github/workflows/satp-hermes-publish-docker.yaml
+++ b/.github/workflows/satp-hermes-publish-docker.yaml
@@ -105,7 +105,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
 
 env:
   # Image namespace is the 'hyperledger' Docker Hub org. Note this is NOT the
@@ -277,6 +276,9 @@ jobs:
     needs: [build-satp-docker, set-docker-tags]
     if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/satp-dev' || github.ref == 'refs/heads/satp-stg' || startsWith(github.ref, 'refs/tags/'))) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write # push image to GHCR
     # Production publishes run under the `prod` environment so maintainers can
     # gate them with required reviewers / scoped secrets; dev builds use none.
     environment: ${{ needs.set-docker-tags.outputs.is_release == 'true' && 'prod' || '' }}

--- a/.github/workflows/satp-hermes-publish-npmjs-gateway-sdk.yaml
+++ b/.github/workflows/satp-hermes-publish-npmjs-gateway-sdk.yaml
@@ -92,7 +92,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 env:
   NPM_PACKAGE_NAME: '@hyperledger-cacti/cactus-plugin-satp-hermes'
@@ -250,6 +249,9 @@ jobs:
     needs: [build-satp-hermes-npm-package, set-npm-tags]
     if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/satp-dev' || github.ref == 'refs/heads/satp-stg' || startsWith(github.ref, 'refs/tags/'))) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # publish package to GitHub Package Registry
     continue-on-error: true  # Don't fail the workflow if GitHub Package Registry push fails
     # Production publishes run under the `prod` environment; dev builds use none.
     environment: ${{ needs.set-npm-tags.outputs.is_release == 'true' && 'prod' || '' }}

--- a/.github/workflows/satp-hermes-release-pipeline.yaml
+++ b/.github/workflows/satp-hermes-release-pipeline.yaml
@@ -28,12 +28,12 @@ on:
     tags: ['v[0-9]*']
   workflow_dispatch:
 
-# Least privilege for the pipeline; child workflows request their own.
-# npmjs publishing (and its OIDC id-token) is owned by publish-npm.yaml, not
-# this pipeline, so no id-token permission is needed here.
+# Least privilege for the pipeline; every job below declares its own
+# permissions (which cap the reusable workflows they call), so no writes are
+# needed at the top level. npmjs publishing (and its OIDC id-token) is owned by
+# publish-npm.yaml, not this pipeline, so no id-token permission is needed here.
 permissions:
-  contents: write # create the GitHub release
-  packages: write # GHCR + GitHub Package Registry
+  contents: read
 
 concurrency:
   group: satp-hermes-release-${{ github.ref }}

--- a/.github/workflows/satp-hermes-scheduled.yaml
+++ b/.github/workflows/satp-hermes-scheduled.yaml
@@ -21,6 +21,8 @@ on:
   # Keep manual dispatch so you can trigger an ad-hoc run without waiting
   # for Sunday (useful when debugging a flaky test outside normal PR flow).
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   satp-hermes:

--- a/.github/workflows/satp-hermes-workflow.yaml
+++ b/.github/workflows/satp-hermes-workflow.yaml
@@ -66,6 +66,8 @@ on:
 concurrency:
   group: satp-hermes-package-workflows-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 
 jobs:
   # Test execution jobs: run unit and integration tests in parallel

--- a/.github/workflows/sawtooth-all-in-one-publish.yaml
+++ b/.github/workflows/sawtooth-all-in-one-publish.yaml
@@ -12,6 +12,8 @@ concurrency:
 
 env:
   IMAGE_NAME: cactus-sawtooth-all-in-one
+permissions:
+  contents: read
 
 jobs:
   # Push image to GitHub Packages.

--- a/.github/workflows/test_weaver-asset-exchange-besu.yaml
+++ b/.github/workflows/test_weaver-asset-exchange-besu.yaml
@@ -18,6 +18,9 @@ concurrency:
   cancel-in-progress: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: read
+
 jobs:
   check_code_changed:
     outputs:

--- a/.github/workflows/test_weaver-asset-exchange-corda.yaml
+++ b/.github/workflows/test_weaver-asset-exchange-corda.yaml
@@ -20,6 +20,9 @@ concurrency:
   cancel-in-progress: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: read
+
 jobs:
   check_code_changed:
     outputs:

--- a/.github/workflows/test_weaver-asset-exchange-fabric.yaml
+++ b/.github/workflows/test_weaver-asset-exchange-fabric.yaml
@@ -23,6 +23,9 @@ concurrency:
   cancel-in-progress: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: read
+
 jobs:
   check_code_changed:
     outputs:

--- a/.github/workflows/test_weaver-asset-transfer.yaml
+++ b/.github/workflows/test_weaver-asset-transfer.yaml
@@ -23,6 +23,9 @@ concurrency:
   cancel-in-progress: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: read
+
 jobs:
   check_code_changed:
     outputs:

--- a/.github/workflows/test_weaver-corda-interop-app.yaml
+++ b/.github/workflows/test_weaver-corda-interop-app.yaml
@@ -18,6 +18,8 @@ on:
 concurrency:
   group: corda-interop-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 
 jobs:
   check_code_changed:

--- a/.github/workflows/test_weaver-data-sharing.yaml
+++ b/.github/workflows/test_weaver-data-sharing.yaml
@@ -23,6 +23,9 @@ concurrency:
   cancel-in-progress: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: read
+
 jobs:
   check_code_changed:
     outputs:

--- a/.github/workflows/test_weaver-docker-build.yaml
+++ b/.github/workflows/test_weaver-docker-build.yaml
@@ -17,6 +17,8 @@ on:
 concurrency:
   group: docker-build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 
 jobs:
   check_code_changed:

--- a/.github/workflows/test_weaver-fabric-fabric-satp.yaml
+++ b/.github/workflows/test_weaver-fabric-fabric-satp.yaml
@@ -16,6 +16,8 @@ on:
 concurrency:
   group: fabric-satp-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 
 jobs:
   check_code_changed:

--- a/.github/workflows/test_weaver-go.yaml
+++ b/.github/workflows/test_weaver-go.yaml
@@ -14,6 +14,8 @@ on:
 concurrency:
   group: go-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 
 jobs:
 

--- a/.github/workflows/test_weaver-node-pkgs.yaml
+++ b/.github/workflows/test_weaver-node-pkgs.yaml
@@ -21,6 +21,8 @@ on:
 concurrency:
   group: node-pkg-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 
 jobs:
   check_code_changed:

--- a/.github/workflows/test_weaver-pre-release.yaml
+++ b/.github/workflows/test_weaver-pre-release.yaml
@@ -14,6 +14,8 @@ on:
 concurrency:
   group: pre-release-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 
 jobs:
   check_release:

--- a/.github/workflows/test_weaver-relay.yaml
+++ b/.github/workflows/test_weaver-relay.yaml
@@ -14,6 +14,8 @@ on:
 concurrency:
   group: relay-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 
 jobs:
   check_code_changed:

--- a/.github/workflows/weaver_deploy_corda-pkgs.yml
+++ b/.github/workflows/weaver_deploy_corda-pkgs.yml
@@ -14,6 +14,8 @@ on:
       
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   publish-protos-java-kt:

--- a/.github/workflows/weaver_deploy_go-pkgs.yml
+++ b/.github/workflows/weaver_deploy_go-pkgs.yml
@@ -14,11 +14,16 @@ on:
       
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+permissions:
+  contents: read
+
 
 jobs:
   publish-protos-go:
     if: github.repository_owner == 'hyperledger-cacti'
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write # create GitHub release
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
@@ -76,6 +81,8 @@ jobs:
     if: ${{ always() && github.repository_owner == 'hyperledger-cacti' }}
     needs: publish-protos-go
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write # create GitHub release
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
@@ -142,6 +149,8 @@ jobs:
     if: ${{ always() && github.repository_owner == 'hyperledger-cacti' }}
     needs: publish-protos-go
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write # create GitHub release
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
@@ -208,6 +217,8 @@ jobs:
     if: ${{ always() && github.repository_owner == 'hyperledger-cacti' }}
     needs: [publish-protos-go]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write # create GitHub release
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
@@ -274,6 +285,8 @@ jobs:
     if: ${{ always() && github.repository_owner == 'hyperledger-cacti' }}
     needs: [publish-protos-go, publish-lib-utils, publish-lib-asset-exchange]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write # create GitHub release
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
@@ -340,6 +353,8 @@ jobs:
     if: ${{ always() && github.repository_owner == 'hyperledger-cacti' }}
     needs: [publish-protos-go]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write # create GitHub release
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
@@ -406,6 +421,9 @@ jobs:
     if: always()
     needs: [publish-protos-go, publish-lib-utils, publish-lib-asset-exchange]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write # push image to GHCR
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0

--- a/.github/workflows/weaver_deploy_node-pkgs.yml
+++ b/.github/workflows/weaver_deploy_node-pkgs.yml
@@ -15,6 +15,8 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   publish-protos-js:

--- a/.github/workflows/weaver_deploy_relay-server.yml
+++ b/.github/workflows/weaver_deploy_relay-server.yml
@@ -14,6 +14,8 @@ on:
       
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+permissions:
+  contents: read
 
 jobs:
   publish-protos-rs:


### PR DESCRIPTION
Set an explicit top-level `permissions:` block on 45 workflows that previously relied on the default token scope, resolving the Scorecard TokenPermissions code-scanning alerts.

Every workflow gets top-level `contents: read`. Jobs that legitimately write keep their access via job-level `permissions:` (which override the top level), added where a publishing job had none:
- connector-fabric-cli-publish-dev: packages: write (push image to GHCR)
- satp-hermes-manual-release: contents: write (create GitHub release)
- weaver_deploy_go-pkgs: contents: write per release job, packages: write for the GHCR image job

Changes are purely additive (only trailing-whitespace lines removed); no existing permission was reduced, so publish/release/deploy pipelines and the dorny/test-reporter check runs are unaffected.

Additionally, four workflows that previously carried write scopes at the
top level now scope them to the specific jobs that need them, keeping the
top level at `contents: read`:
- ci.yaml / packages-workflow.yaml: `contents: write` (+ checks/actions)
  moved to the jobs that dispatch the benchmark-pushing package workflows;
  all other dispatched jobs get only `checks: write` for dorny/test-reporter.
- satp-hermes-publish-docker / -publish-npmjs-gateway-sdk: `packages: write`
  moved to the single GHCR-publishing job.
- satp-hermes-release-pipeline: top level reduced to `contents: read` since
  every job already declares its own permissions.

Assisted-by: Claude Opus 4.8

<!-- Thanks for contributing to Hyperledger Cacti!
     Please read CONTRIBUTING.md and PULL.md before opening a pull request.
     For rebasing and squashing help see:
     https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing -->

## Related issue

Fixes Token Permissions issues in workflows identified here:
https://github.com/hyperledger-cacti/cacti/security/code-scanning?query=is%3Aopen+branch%3Amain+severity%3Ahigh

## PR author checklist

- [ ] I read and followed the [Pull Request Guidelines](../PULL.md), including linking a `Triage_Ready` issue (§9).
- [ ] If AI tools were used, the commit includes an `Assisted-by` tag per [AI Guidelines §2.2](../AI_GUIDELINES.md#22-disclosure). All AI-generated code has been human-reviewed before submission.
