### PR TITLE
fix(api-server): await all gRPC plugin registrations before bindAsync

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
@@ -810,31 +810,31 @@ export class ApiServer {
     const { logLevel } = this.options.config;
     const pluginRegistry = await this.getOrInitPluginRegistry();
 
-    return new Promise((resolve, reject) => {
-      const grpcHost = this.options.config.grpcHost;
-      const grpcHostAndPort = `${grpcHost}:${this.options.config.grpcPort}`;
+    const grpcHost = this.options.config.grpcHost;
+    const grpcHostAndPort = `${grpcHost}:${this.options.config.grpcPort}`;
 
-      const grpcTlsCredentials = this.options.config.grpcMtlsEnabled
-        ? GrpcServerCredentials.createSsl(
-            Buffer.from(this.options.config.apiTlsCertPem),
-            [
-              {
-                cert_chain: Buffer.from(this.options.config.apiTlsCertPem),
-                private_key: Buffer.from(this.options.config.apiTlsKeyPem),
-              },
-            ],
-            true,
-          )
-        : GrpcServerCredentials.createInsecure();
+    const grpcTlsCredentials = this.options.config.grpcMtlsEnabled
+      ? GrpcServerCredentials.createSsl(
+          Buffer.from(this.options.config.apiTlsCertPem),
+          [
+            {
+              cert_chain: Buffer.from(this.options.config.apiTlsCertPem),
+              private_key: Buffer.from(this.options.config.apiTlsKeyPem),
+            },
+          ],
+          true,
+        )
+      : GrpcServerCredentials.createInsecure();
 
-      this.grpcServer.addService(
-        default_service.org.hyperledger.cactus.cmd_api_server
-          .DefaultServiceClient.service,
-        new GrpcServerApiServer(),
-      );
+    this.grpcServer.addService(
+      default_service.org.hyperledger.cactus.cmd_api_server.DefaultServiceClient
+        .service,
+      new GrpcServerApiServer(),
+    );
 
-      log.debug("Installing gRPC services of IPluginGrpcService instances...");
-      pluginRegistry.getPlugins().forEach(async (x: ICactusPlugin) => {
+    log.debug("Installing gRPC services of IPluginGrpcService instances...");
+    await Promise.all(
+      pluginRegistry.getPlugins().map(async (x: ICactusPlugin) => {
         if (!isIPluginGrpcService(x)) {
           this.log.debug("%s skipping %s instance", fnTag, x.getPackageName());
           return;
@@ -855,9 +855,11 @@ export class ApiServer {
         });
 
         log.info("%s Added gRPC service of: %s OK", fnTag, x.getPackageName());
-      });
-      log.debug("%s Installed all IPluginGrpcService instances OK", fnTag);
+      }),
+    );
+    log.debug("%s Installed all IPluginGrpcService instances OK", fnTag);
 
+    return new Promise((resolve, reject) => {
       this.grpcServer.bindAsync(
         grpcHostAndPort,
         grpcTlsCredentials,

--- a/packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-server-startup-order.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-server-startup-order.test.ts
@@ -1,0 +1,80 @@
+import {
+  ApiServer,
+  ConfigService,
+  AuthorizationProtocol,
+} from "../../../main/typescript/public-api";
+import { PluginRegistry } from "@hyperledger-cacti/cactus-core";
+import {
+  ICactusPlugin,
+  IPluginGrpcService,
+  IGrpcSvcDefAndImplPair,
+} from "@hyperledger-cacti/cactus-core-api";
+
+describe("API server: awaits IPluginGrpcService registrations before bindAsync", () => {
+  let isPluginRegistered = false;
+  let apiServer: ApiServer;
+
+  afterAll(async () => {
+    if (apiServer) {
+      await apiServer.shutdown();
+    }
+  });
+
+  test("Plugin GRPC service registration completes before ApiServer start resolves", async () => {
+    class MockGrpcPlugin implements ICactusPlugin, IPluginGrpcService {
+      public getPackageName(): string {
+        return "mock-grpc-plugin";
+      }
+      public getInstanceId(): string {
+        return "mock-grpc-plugin-instance-1";
+      }
+      public async onPluginInit(): Promise<unknown> {
+        return;
+      }
+      public async createGrpcSvcDefAndImplPairs(): Promise<
+        IGrpcSvcDefAndImplPair[]
+      > {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            isPluginRegistered = true;
+            resolve([]);
+          }, 1000); // Artificial 1-second delay to trigger the race condition
+        });
+      }
+    }
+
+    const mockPlugin = new MockGrpcPlugin();
+    const pluginRegistry = new PluginRegistry({ plugins: [mockPlugin] });
+
+    const configService = new ConfigService();
+    const apiSrvOpts = await configService.newExampleConfig();
+    apiSrvOpts.authorizationProtocol = AuthorizationProtocol.NONE;
+    apiSrvOpts.configFile = "";
+    apiSrvOpts.logLevel = "TRACE";
+    apiSrvOpts.apiCorsDomainCsv = "*";
+    apiSrvOpts.apiPort = 0;
+    apiSrvOpts.grpcPort = 0;
+    apiSrvOpts.crpcPort = 0;
+    apiSrvOpts.cockpitPort = 0;
+    apiSrvOpts.grpcMtlsEnabled = false;
+    apiSrvOpts.apiTlsEnabled = false;
+    apiSrvOpts.plugins = []; // Handled by the injected pluginRegistry
+
+    const config = await configService.newExampleConfigConvict(apiSrvOpts);
+
+    apiServer = new ApiServer({
+      config: config.getProperties(),
+      pluginRegistry,
+    });
+
+    // Start the server and wait for it to resolve
+    const startResponse = await apiServer.start();
+
+    expect(startResponse).toBeTruthy();
+
+    // If the race condition exists, start() will resolve immediately
+    // and isPluginRegistered will still be false.
+    // With the fix (Promise.all), start() blocks until the 1-second timeout finishes.
+    expect(isPluginRegistered).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description
This PR implements the gRPC server startup race condition fix originally proposed in #4163 by @mn-ram.
It ensures all `IPluginGrpcService` registrations complete before `bindAsync()` is invoked. By replacing `forEach(async ...)` with `await Promise.all(...)`, it prevents `12 UNIMPLEMENTED` errors on gRPC connector endpoints and avoids unhandled promise rejections on plugin init failures.
Adds a unit test with an artificial delay as requested.
> **Note:** As discussed in the original PR, the changes to the `KnexOracleLogRepository` `ENVIRONMENT` fallback are intentionally excluded from this PR to keep it narrowly focused on the gRPC server fix.

Assisted-by: google-gemini 3.1pro
Supersedes #4163
## Related issue
Fixes #4162

## PR author checklist

- [x] I read and followed the [Pull Request Guidelines](../PULL.md), including linking a `Triage_Ready` issue (§9).
- [x] If AI tools were used, the commit includes an `Assisted-by` tag per [AI Guidelines §2.2](../AI_GUIDELINES.md#22-disclosure). All AI-generated code has been human-reviewed before submission.
