### PR TITLE
fix(besu): close WebSocket provider and complete txSubject on shutdown

### DIFF
--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/plugin-ledger-connector-besu.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/plugin-ledger-connector-besu.ts
@@ -230,7 +230,26 @@ export class PluginLedgerConnectorBesu
   }
 
   public async shutdown(): Promise<void> {
-    this.log.info(`Shutting down ${this.className}...`);
+    const fnTag = `${this.className}#shutdown()`;
+    this.log.info(`${fnTag} Shutting down...`);
+    if (
+      this.web3Provider &&
+      typeof this.web3Provider.disconnect === "function"
+    ) {
+      try {
+        this.web3Provider.disconnect(1000, "Shutdown");
+      } catch (ex) {
+        this.log.error(`${fnTag} Failed to disconnect web3Provider:`, ex);
+      }
+    }
+    if (this.txSubject) {
+      try {
+        this.txSubject.complete();
+      } catch (ex) {
+        this.log.error(`${fnTag} Failed to complete txSubject:`, ex);
+      }
+    }
+    this.contracts = {};
   }
 
   async registerWebServices(

--- a/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/unit/shutdown.test.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/unit/shutdown.test.ts
@@ -1,0 +1,63 @@
+import { PluginLedgerConnectorBesu } from "../../../main/typescript/public-api";
+import { PluginRegistry } from "@hyperledger-cacti/cactus-core";
+import { v4 as uuidv4 } from "uuid";
+import Web3 from "web3";
+
+jest.mock("web3");
+
+describe("PluginLedgerConnectorBesu shutdown unit tests", () => {
+  const rpcApiHttpHost = "http://127.0.0.1:8000";
+  const rpcApiWsHost = "ws://127.0.0.1:9000";
+  const instanceId = uuidv4();
+  const pluginRegistry = new PluginRegistry({ plugins: [] });
+  let connector: PluginLedgerConnectorBesu;
+  let mockWebsocketProvider: any;
+
+  beforeEach(() => {
+    mockWebsocketProvider = {
+      disconnect: jest.fn(),
+    };
+    (Web3.providers.WebsocketProvider as jest.Mock).mockReturnValue(
+      mockWebsocketProvider,
+    );
+    connector = new PluginLedgerConnectorBesu({
+      rpcApiHttpHost,
+      rpcApiWsHost,
+      instanceId,
+      pluginRegistry,
+      logLevel: "INFO",
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("shutdown() completes txSubject and disconnects web3Provider", async () => {
+    const txSubjectObservable = connector.getTxSubjectObservable();
+    const completeSpy = jest.fn();
+
+    txSubjectObservable.subscribe({
+      complete: completeSpy,
+    });
+    await connector.shutdown();
+    expect(mockWebsocketProvider.disconnect).toHaveBeenCalledTimes(1);
+    expect(completeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("shutdown() is robust against disconnect failures", async () => {
+    mockWebsocketProvider.disconnect.mockImplementation(() => {
+      throw new Error("Disconnect failed");
+    });
+    const txSubjectObservable = connector.getTxSubjectObservable();
+    const completeSpy = jest.fn();
+
+    txSubjectObservable.subscribe({
+      complete: completeSpy,
+    });
+    // Should not throw
+    await expect(connector.shutdown()).resolves.not.toThrow();
+    expect(mockWebsocketProvider.disconnect).toHaveBeenCalledTimes(1);
+    expect(completeSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to Hyperledger Cacti!
     Please read CONTRIBUTING.md and PULL.md before opening a pull request.
     For rebasing and squashing help see:
     https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing -->

## Description

This addresses a resource and memory leak found within the `PluginLedgerConnectorBesu` class during the shutdown sequence. 

Previously, invoking the `shutdown()` method left active connections dangling and RxJS subjects open. This fix ensures proper cleanup by:
- Safely disconnecting the `web3Provider` if an active connection exists.
- Completing the `txSubject` to close any lingering active subscriptions.
- Clearing the internal `contracts` execution map to release memory. 

These changes ensure the plugin can gracefully shut down without leaving zombie processes or holding onto unnecessary memory. Also includes robust error handling and regression tests as requested by maintainers.

Supersedes #4238

Assisted-by: google-gemini 3.1pro

## Related issue

Fixes #4226

## PR author checklist

- [x] I read and followed the [Pull Request Guidelines](../PULL.md), including linking a `Triage_Ready` issue (§9).
- [x] If AI tools were used, the commit includes an `Assisted-by` tag per [AI Guidelines §2.2](../AI_GUIDELINES.md#22-disclosure). All AI-generated code has been human-reviewed before submission.